### PR TITLE
chore(images): add nano and vim

### DIFF
--- a/images/examples/base/Dockerfile
+++ b/images/examples/base/Dockerfile
@@ -18,7 +18,9 @@ RUN apt-get update \
     ca-certificates \
     curl \
     git \
+    nano \
     openssh-client \
+    vim \
   && rm -rf /var/lib/apt/lists/*
 
 COPY scripts/install-zmx.sh /tmp/install-zmx.sh


### PR DESCRIPTION
Add nano and vim to the base Spritz image so devboxes have basic editors available.