### PR TITLE
docs(spec): add user config subset spec

### DIFF
--- a/docs/2026-02-09-user-config-subset.md
+++ b/docs/2026-02-09-user-config-subset.md
@@ -1,0 +1,94 @@
+---
+date: 2026-02-09
+author: Onur <onur@textcortex.com>
+title: Spritz User Config Subset
+tags: [spritz, ui, api, spec]
+---
+
+## Overview
+
+End users need a safe way to customize spritzes without editing the full CR spec.
+This document defines a **user-editable config subset** (`userConfig`) that the
+API validates and merges into a server-owned template.
+
+## Goals
+
+- Let users adjust a small, safe set of settings.
+- Keep security-sensitive fields server-owned.
+- Make validation deterministic and server-side.
+- Support UI YAML editing without exposing full spec controls.
+
+## Non-goals
+
+- Full CR spec editing in the UI.
+- Allowing users to pick storage buckets or credentials.
+- Exposing cluster-level settings like namespaces or service accounts.
+
+## User Config Schema
+
+`userConfig` is an object with these allowed fields.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `imagePreset` | string | Must match a server-provided preset. |
+| `image` | string | Allowed only when policy permits custom images. |
+| `repo` | object | `url`, `branch`, `dir`, `revision`, `depth`, `submodules`. |
+| `ttl` | string | Duration like `8h` or `30m`. |
+| `env` | list | Key/value list, subject to allowlist. |
+| `resources` | object | CPU and memory with min/max caps. |
+| `sharedMounts` | list | Same shape as `spec.sharedMounts`. |
+
+## Policy and Validation
+
+The API enforces a **UserConfigPolicy** that defines what is allowed.
+The policy is server-owned and can vary by environment.
+
+Minimum policy controls:
+
+- Allowed mount roots, for example `/home/dev` and `/workspace`.
+- Allowed scopes, currently `owner` only.
+- Allowed env keys or allowed prefixes.
+- Max TTL and resource caps.
+- Allowed image presets and allowed registries.
+
+Validation is always server-side. UI validation is helpful but not trusted.
+
+## Merge Rules
+
+1. Start from a server-managed template.
+2. Apply `userConfig` fields in a fixed order.
+3. Validate the resulting spec.
+4. Write the final spec into the Spritz CR.
+
+If validation fails, the API returns a clear error and the spec is unchanged.
+
+## Storage and Audit
+
+The API stores `userConfig` on the Spritz resource for auditability.
+Recommended storage is `spec.userConfig` with a `spec.userConfigVersion` or
+`metadata.annotations["spritz.sh/user-config"]` containing a JSON payload.
+
+The server remains the only writer of sensitive spec fields.
+
+## API Surface
+
+Recommended endpoints:
+
+- `POST /spritzes` accepts `userConfig` on create.
+- `PATCH /spritzes/{name}/user-config` updates only the user subset.
+- `GET /spritzes/{name}` returns the stored `userConfig`.
+
+## UI Behavior
+
+The UI should expose a YAML editor for `userConfig` only.
+This keeps power-user flexibility while retaining guardrails.
+
+## Validation Notes for Shared Mounts
+
+- `mountPath` must be absolute.
+- `mountPath` must be under allowed roots.
+- `scope` must be `owner` until new scopes are implemented.
+
+## References
+
+- `docs/2026-02-05-shared-mount-syncer.md`


### PR DESCRIPTION
## TL;DR
Document the userConfig subset and server-side merge/validation model.

## Summary
- Define allowed userConfig fields and policy controls
- Describe merge rules and API endpoints

## Review focus
- Schema scope and policy recommendations

## Test plan
- [x] npx -y @simpledoc/simpledoc check