### PR TITLE
feat(ui): add docker-style spritz names

### DIFF
--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -19,7 +19,10 @@
         <form id="create-form">
           <label>
             Name
-            <input name="name" required />
+            <div class="name-field">
+              <input name="name" />
+              <button type="button" class="ghost" id="name-random">Random</button>
+            </div>
           </label>
           <label>
             Image

--- a/ui/public/styles.css
+++ b/ui/public/styles.css
@@ -92,6 +92,16 @@ input {
   font-size: 14px;
 }
 
+.name-field {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.name-field input {
+  flex: 1;
+}
+
 textarea {
   padding: 10px 12px;
   border-radius: 10px;
@@ -118,6 +128,12 @@ button {
   background: #2e3a46;
   color: white;
   cursor: pointer;
+}
+
+button.ghost {
+  background: white;
+  border: 1px solid #d7dbe0;
+  color: #2e3a46;
 }
 
 .list-header {


### PR DESCRIPTION
## Summary
- generate Docker-style random names (adj-noun) with collision suffixes
- default and randomize the name field in the UI
- add small UI styling for the randomize control

## Testing
- `npx -y @simpledoc/simpledoc check`