### PR TITLE
fix(api): bootstrap shared mounts when latest.json is empty

### DIFF
--- a/api/shared_mounts_handlers.go
+++ b/api/shared_mounts_handlers.go
@@ -164,6 +164,11 @@ func (s *server) fetchSharedMountLatest(ctx context.Context, ownerID, mountName 
 	if err != nil {
 		return sharedmounts.LatestManifest{}, err
 	}
+	// Treat an empty/whitespace manifest as "not found" so new mounts can
+	// bootstrap without requiring an initial publish.
+	if len(bytes.TrimSpace(data)) == 0 {
+		return sharedmounts.LatestManifest{}, errSharedMountNotFound
+	}
 	var manifest sharedmounts.LatestManifest
 	if err := json.Unmarshal(data, &manifest); err != nil {
 		return sharedmounts.LatestManifest{}, err


### PR DESCRIPTION
## Summary
- Treat an empty/whitespace `latest.json` as “not found”
- Allows new shared mounts to start without requiring an initial publish

## Why
Currently a zero-byte `latest.json` causes `GET /internal/v1/shared-mounts/.../latest` to return 500 (`unexpected end of JSON input`), which blocks devbox provisioning.