### PR TITLE
feat(helm): allow extra env/volume overrides for spritz-api

### DIFF
--- a/helm/spritz/templates/api-deployment.yaml
+++ b/helm/spritz/templates/api-deployment.yaml
@@ -1,3 +1,7 @@
+{{- $extraEnv := .Values.api.extraEnv | default (list) -}}
+{{- $extraVolumeMounts := .Values.api.extraVolumeMounts | default (list) -}}
+{{- $extraVolumes := .Values.api.extraVolumes | default (list) -}}
+{{- $haveRcloneMount := and .Values.api.sharedMounts .Values.api.sharedMounts.enabled .Values.api.sharedMounts.rclone.configSecret.name -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -288,11 +292,21 @@ spec:
                   key: {{ .Values.api.sharedMounts.internalTokenSecret.key | quote }}
             {{- end }}
             {{- end }}
+            {{- with $extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- if and .Values.api.sharedMounts .Values.api.sharedMounts.enabled .Values.api.sharedMounts.rclone.configSecret.name }}
+          {{- end }}
+          {{- if or $haveRcloneMount (gt (len $extraVolumeMounts) 0) }}
           volumeMounts:
+            {{- if $haveRcloneMount }}
             - name: spritz-shared-mounts-rclone
               mountPath: /etc/spritz/rclone
               readOnly: true
+            {{- end }}
+            {{- with $extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           ports:
             - name: http
@@ -301,11 +315,16 @@ spec:
             - name: ssh
               containerPort: {{ .Values.api.sshGateway.port }}
             {{- end }}
-      {{- if and .Values.api.sharedMounts .Values.api.sharedMounts.enabled .Values.api.sharedMounts.rclone.configSecret.name }}
+      {{- if or $haveRcloneMount (gt (len $extraVolumes) 0) }}
       volumes:
+        {{- if $haveRcloneMount }}
         - name: spritz-shared-mounts-rclone
           secret:
             secretName: {{ .Values.api.sharedMounts.rclone.configSecret.name | quote }}
+        {{- end }}
+        {{- with $extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
 ---
 apiVersion: v1

--- a/helm/spritz/values.yaml
+++ b/helm/spritz/values.yaml
@@ -154,6 +154,9 @@ api:
     capabilities:
       drop:
         - ALL
+  extraEnv: []
+  extraVolumeMounts: []
+  extraVolumes: []
   sharedMounts:
     enabled: false
     mounts: []


### PR DESCRIPTION
## Summary
- Add `api.extraEnv`, `api.extraVolumeMounts`, and `api.extraVolumes` to the Helm chart
- Lets deploy environments mount cloud-specific credentials/config without forking the chart

## Motivation
CFKE staging needs to mount Workload Identity ADC JSON and set `GOOGLE_APPLICATION_CREDENTIALS` for shared-mounts GCS access.