### PR TITLE
docs(shared-mounts): document GCS UBLA requirement

### DIFF
--- a/docs/2026-02-05-shared-mount-syncer.md
+++ b/docs/2026-02-05-shared-mount-syncer.md
@@ -219,6 +219,30 @@ The shared config PVC approach is sunsetted and is **not** planned for implement
 in the near future. Any existing PVC code should be treated as legacy and not enabled
 for new deployments. Use the object-storage syncer above.
 
+## GCS Uniform Bucket-Level Access (Important)
+
+When using GCS buckets with Uniform Bucket-Level Access (UBLA) enabled, rclone must
+be configured for bucket-policy mode. Otherwise uploads fail with:
+
+- `googleapi: Error 400: Cannot insert legacy ACL for an object when uniform bucket-level access is enabled`
+
+Required rclone config:
+
+```ini
+[gcs]
+type = google cloud storage
+provider = GCS
+env_auth = true
+bucket_policy_only = true
+```
+
+Equivalent environment override (if you do not want to embed it in `rclone.conf`):
+
+- `RCLONE_GCS_BUCKET_POLICY_ONLY=true`
+
+If this is missing, shared mount revision writes return 500 and cross-pod sync does not
+advance, even though the syncer loop is running.
+
 ## Validation
 
 - Start two pods for the same owner and confirm `/shared/live` matches.


### PR DESCRIPTION
## Summary
- document the required rclone setting for GCS buckets with Uniform Bucket-Level Access
- include the exact runtime error symptom when this setting is missing
- include both `rclone.conf` and env-var forms of the fix (`bucket_policy_only` / `RCLONE_GCS_BUCKET_POLICY_ONLY`)

## Why
Shared mount uploads fail with 500s when GCS UBLA is enabled and rclone attempts legacy object ACL writes. This note captures the operational fix directly in the shared-mounts doc.
