### PR TITLE
fix(syncer): decode latest manifest from API envelope

### DIFF
--- a/api/cmd/shared-syncer/main_test.go
+++ b/api/cmd/shared-syncer/main_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -58,5 +59,45 @@ func TestWriteTarContentsRejectsEscapingSymlink(t *testing.T) {
 	_ = tw.Close()
 	if err == nil {
 		t.Fatal("expected error for escaping symlink")
+	}
+}
+
+func TestParseLatestManifestWrapped(t *testing.T) {
+	body := []byte(`{"status":"success","data":{"revision":"r1","checksum":"sha256:abc","updated_at":"2026-02-11T00:00:00Z"}}`)
+	manifest, err := parseLatestManifest(body)
+	if err != nil {
+		t.Fatalf("parseLatestManifest failed: %v", err)
+	}
+	if manifest.Revision != "r1" || manifest.Checksum != "sha256:abc" {
+		t.Fatalf("unexpected manifest: %+v", manifest)
+	}
+}
+
+func TestParseLatestManifestWithoutDataFails(t *testing.T) {
+	body := []byte(`{"revision":"r2","checksum":"sha256:def","updated_at":"2026-02-11T00:00:00Z"}`)
+	_, err := parseLatestManifest(body)
+	if err == nil {
+		t.Fatal("expected parseLatestManifest to fail without data envelope")
+	}
+}
+
+func TestLatestRejectsInvalidPayload(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": "success",
+			"data":   map[string]any{"updated_at": "2026-02-11T00:00:00Z"},
+		})
+	}))
+	defer srv.Close()
+
+	client := &sharedMountClient{
+		baseURL: srv.URL,
+		token:   "token",
+		client:  srv.Client(),
+	}
+
+	_, _, err := client.latest(context.Background(), "owner", "mount")
+	if err == nil {
+		t.Fatal("expected error for invalid latest payload")
 	}
 }


### PR DESCRIPTION
## Summary
- update shared-syncer latest manifest decoding to consume the current API response envelope (`{status,data}`)
- remove legacy top-level manifest parsing path
- add tests for wrapped payload handling and invalid payload rejection

## Root cause
The syncer expected top-level `revision/checksum`, but the API returns `{status,data}`. That produced empty revision values during init, causing revision fetch failures and pods stuck in init crashloop.
