### PR TITLE
fix(shared-mounts): support snapshot+poll convergence

### DIFF
--- a/operator/sharedmounts/sharedmounts.go
+++ b/operator/sharedmounts/sharedmounts.go
@@ -166,9 +166,6 @@ func ValidateMounts(mounts []MountSpec) error {
 		if mount.SyncMode != SyncPoll && mount.SyncMode != SyncManual {
 			return fmt.Errorf("syncMode must be %s or %s: %s", SyncPoll, SyncManual, mount.SyncMode)
 		}
-		if mount.Mode == ModeSnapshot && mount.SyncMode == SyncPoll {
-			return fmt.Errorf("snapshot mounts do not support syncMode=poll")
-		}
 		if err := ValidateMountPath(mount.MountPath); err != nil {
 			return err
 		}

--- a/operator/sharedmounts/sharedmounts_test.go
+++ b/operator/sharedmounts/sharedmounts_test.go
@@ -27,6 +27,12 @@ func TestValidateMountsAcceptsValidSyncMode(t *testing.T) {
 			MountPath: "/poll",
 			SyncMode:  SyncPoll,
 		}),
+		NormalizeMount(MountSpec{
+			Name:      "snapshot-poll",
+			MountPath: "/snapshot-poll",
+			Mode:      ModeSnapshot,
+			SyncMode:  SyncPoll,
+		}),
 	}
 	if err := ValidateMounts(tests); err != nil {
 		t.Fatalf("expected valid syncMode, got error: %v", err)


### PR DESCRIPTION
## Summary
- allow  with  in shared-mount validation
- keep all other mount validation rules unchanged
- add test coverage for snapshot+poll acceptance

## Why
Two writable devboxes need both publish and poll loops to converge shared config changes.

## Validation
- go test ./... (from operator/)