### PR TITLE
feat(shared-mounts): watcher publish + long-poll apply

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -43,6 +43,7 @@ type server struct {
 	defaultMetadata   map[string]string
 	sharedMounts      sharedMountsConfig
 	sharedMountsStore *sharedMountsStore
+	sharedMountsLive  *sharedMountsLatestNotifier
 	userConfigPolicy  userConfigPolicy
 }
 
@@ -98,6 +99,10 @@ func main() {
 	if sharedMounts.enabled {
 		sharedStore = newSharedMountsStore(sharedMounts)
 	}
+	var sharedMountsLive *sharedMountsLatestNotifier
+	if sharedMounts.enabled {
+		sharedMountsLive = newSharedMountsLatestNotifier()
+	}
 	sshMintLimiter := newSSHMintLimiter()
 	defaultAnnotations, err := parseKeyValueCSV(os.Getenv("SPRITZ_DEFAULT_ANNOTATIONS"))
 	if err != nil {
@@ -121,6 +126,7 @@ func main() {
 		defaultMetadata:   defaultAnnotations,
 		sharedMounts:      sharedMounts,
 		sharedMountsStore: sharedStore,
+		sharedMountsLive:  sharedMountsLive,
 		userConfigPolicy:  userConfigPolicy,
 	}
 

--- a/api/shared_mounts_latest_notifier.go
+++ b/api/shared_mounts_latest_notifier.go
@@ -1,0 +1,58 @@
+package main
+
+import "sync"
+
+// sharedMountsLatestNotifier provides a minimal in-process notification mechanism for
+// long-polling shared mount "latest" requests.
+//
+// This intentionally does not persist state; callers should always re-fetch the latest
+// manifest after being notified.
+type sharedMountsLatestNotifier struct {
+	mu      sync.Mutex
+	waiters map[string]map[chan struct{}]struct{}
+}
+
+func newSharedMountsLatestNotifier() *sharedMountsLatestNotifier {
+	return &sharedMountsLatestNotifier{waiters: map[string]map[chan struct{}]struct{}{}}
+}
+
+func (n *sharedMountsLatestNotifier) subscribe(key string) chan struct{} {
+	ch := make(chan struct{})
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	waiters := n.waiters[key]
+	if waiters == nil {
+		waiters = map[chan struct{}]struct{}{}
+		n.waiters[key] = waiters
+	}
+	waiters[ch] = struct{}{}
+	return ch
+}
+
+func (n *sharedMountsLatestNotifier) unsubscribe(key string, ch chan struct{}) {
+	if ch == nil {
+		return
+	}
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	waiters := n.waiters[key]
+	if waiters == nil {
+		return
+	}
+	delete(waiters, ch)
+	if len(waiters) == 0 {
+		delete(n.waiters, key)
+	}
+}
+
+func (n *sharedMountsLatestNotifier) notify(key string) {
+	n.mu.Lock()
+	waiters := n.waiters[key]
+	delete(n.waiters, key)
+	n.mu.Unlock()
+
+	for ch := range waiters {
+		// Closing unblocks all long-pollers for this key.
+		close(ch)
+	}
+}


### PR DESCRIPTION
## Summary
- shared-mounts-syncer now publishes snapshots on filesystem changes (debounced), with periodic safety tick
- shared mount apply path uses API long-poll (waitSeconds + ifNoneMatchRevision) for near-instant updates
- spritz-api notifies long-pollers when latest.json advances
- updated shared mount syncer docs

## Test
- go test ./... (in api/)
