### PR TITLE
fix(operator): default resource requests for devboxes

### DIFF
--- a/operator/controllers/default_resources.go
+++ b/operator/controllers/default_resources.go
@@ -1,0 +1,28 @@
+package controllers
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func isEmptyResourceRequirements(rr corev1.ResourceRequirements) bool {
+	return len(rr.Requests) == 0 && len(rr.Limits) == 0
+}
+
+func defaultSpritzContainerResources() corev1.ResourceRequirements {
+	return corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("250m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
+}
+
+func defaultSharedMountSyncerResources() corev1.ResourceRequirements {
+	return corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		},
+	}
+}

--- a/operator/controllers/shared_mounts.go
+++ b/operator/controllers/shared_mounts.go
@@ -145,6 +145,8 @@ func buildSharedMountRuntime(spritz *spritzv1.Spritz, settings sharedMountsSetti
 		{Name: "SPRITZ_OWNER_ID", Value: spritz.Spec.Owner.ID},
 	}
 
+	syncerResources := defaultSharedMountSyncerResources()
+
 	initContainer := corev1.Container{
 		Name:            "shared-mounts-init",
 		Image:           settings.syncerImage,
@@ -152,6 +154,7 @@ func buildSharedMountRuntime(spritz *spritzv1.Spritz, settings sharedMountsSetti
 		Command:         []string{"/usr/local/bin/spritz-shared-syncer"},
 		Args:            []string{"--mode=init"},
 		Env:             syncerEnv,
+		Resources:       syncerResources,
 		VolumeMounts:    sharedMountVolumeMounts(runtimeMounts),
 	}
 	sidecarContainer := corev1.Container{
@@ -161,6 +164,7 @@ func buildSharedMountRuntime(spritz *spritzv1.Spritz, settings sharedMountsSetti
 		Command:         []string{"/usr/local/bin/spritz-shared-syncer"},
 		Args:            []string{"--mode=sidecar"},
 		Env:             syncerEnv,
+		Resources:       syncerResources,
 		VolumeMounts:    sharedMountVolumeMounts(runtimeMounts),
 	}
 

--- a/operator/controllers/spritz_controller.go
+++ b/operator/controllers/spritz_controller.go
@@ -398,13 +398,17 @@ func (r *SpritzReconciler) reconcileDeployment(ctx context.Context, spritz *spri
 			env = append(env, sharedMountRuntime.env...)
 		}
 		volumeMounts = appendRepoDirMounts(volumeMounts, repoDirs, repoMountRoots)
+		spritzResources := spritz.Spec.Resources
+		if isEmptyResourceRequirements(spritzResources) {
+			spritzResources = defaultSpritzContainerResources()
+		}
 		podSpec := corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
 					Name:         spritzContainerName,
 					Image:        spritz.Spec.Image,
 					Env:          env,
-					Resources:    spritz.Spec.Resources,
+					Resources:    spritzResources,
 					Ports:        ports,
 					VolumeMounts: volumeMounts,
 				},


### PR DESCRIPTION
## Summary
- Add default CPU/memory requests to devbox pods so they are not BestEffort and CFKE autoscaling has sane signals.
- Applies to the main spritz container (when spec.resources is empty) and the shared-mounts syncer init/sidecar.

## Defaults
- spritz: requests cpu=250m, memory=512Mi
- shared-mounts-syncer(+init): requests cpu=100m, memory=256Mi

## Testing
- go test ./... (operator)