### PR TITLE
feat(openclaw): auto-start gateway for spritz open route

### DIFF
--- a/images/examples/openclaw/README.md
+++ b/images/examples/openclaw/README.md
@@ -36,7 +36,19 @@ docker build \
 The image uses a small OpenClaw wrapper entrypoint and then calls
 `examples/base/entrypoint.sh`.
 
-Default command is `sleep infinity` so Spritz terminal/SSH sessions can attach cleanly.
+By default, when the container command is the image default (`sleep infinity`),
+it auto-starts the OpenClaw gateway on port `8080` so Spritz `Open` can render
+OpenClaw UI immediately.
+
+To disable auto-start and keep shell-only behavior, set:
+
+- `OPENCLAW_AUTO_START=false`
+
+Auto-start related runtime overrides:
+
+- `OPENCLAW_GATEWAY_PORT` (default: `8080`)
+- `OPENCLAW_GATEWAY_MODE` (default: `local`)
+- `OPENCLAW_GATEWAY_TOKEN` (optional; auto-generated if omitted)
 
 ## Generic Config Support
 

--- a/images/examples/openclaw/entrypoint.sh
+++ b/images/examples/openclaw/entrypoint.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 config_dir="${OPENCLAW_CONFIG_DIR:-${HOME}/.openclaw}"
 config_path="${OPENCLAW_CONFIG_PATH:-${config_dir}/openclaw.json}"
+gateway_port="${OPENCLAW_GATEWAY_PORT:-8080}"
+gateway_mode="${OPENCLAW_GATEWAY_MODE:-local}"
+auto_start="${OPENCLAW_AUTO_START:-true}"
 
 mkdir -p "${config_dir}"
 
@@ -25,5 +28,35 @@ JSON
 fi
 
 chmod 600 "${config_path}" || true
+
+# Force OpenClaw to use the same file path we prepared above.
+export OPENCLAW_CONFIG_PATH="${config_path}"
+
+# Keep gateway defaults deterministic for Spritz web routing.
+openclaw config set gateway.mode "${gateway_mode}" >/dev/null
+openclaw config set gateway.port "${gateway_port}" >/dev/null
+
+token="${OPENCLAW_GATEWAY_TOKEN:-}"
+if [[ -z "${token}" ]]; then
+  token="$(openclaw config get gateway.auth.token 2>/dev/null || true)"
+fi
+if [[ -z "${token}" ]]; then
+  token="$(head -c 24 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+fi
+export OPENCLAW_GATEWAY_TOKEN="${token}"
+openclaw config set gateway.auth.token "${OPENCLAW_GATEWAY_TOKEN}" >/dev/null
+
+should_auto_start=false
+if [[ "${auto_start}" == "true" ]]; then
+  if [[ "$#" -eq 0 ]]; then
+    should_auto_start=true
+  elif [[ "$#" -eq 2 && "$1" == "sleep" && "$2" == "infinity" ]]; then
+    should_auto_start=true
+  fi
+fi
+
+if [[ "${should_auto_start}" == "true" ]]; then
+  set -- openclaw gateway --bind custom --port "${gateway_port}"
+fi
 
 exec /usr/local/bin/spritz-entrypoint "$@"


### PR DESCRIPTION
## Summary
- auto-start OpenClaw gateway when image runs with default command (`sleep infinity`)
- default gateway routing to port `8080` so Spritz `/spritz/w/{name}` renders UI without manual commands
- ensure gateway mode/token/port are initialized in entrypoint, with env overrides
- document auto-start behavior and runtime knobs in OpenClaw README

## Details
- `OPENCLAW_AUTO_START=true` by default (set false to disable)
- `OPENCLAW_GATEWAY_PORT` default `8080`
- `OPENCLAW_GATEWAY_MODE` default `local`
- `OPENCLAW_GATEWAY_TOKEN` auto-generated if missing

## Validation
- `bash -n images/examples/openclaw/entrypoint.sh`
- in-cluster probe confirmed `openclaw gateway` on 8080 serves OpenClaw UI HTML at `/`.