### PR TITLE
fix(openclaw): run gateway foreground in autostart

### DIFF
--- a/images/examples/openclaw/entrypoint.sh
+++ b/images/examples/openclaw/entrypoint.sh
@@ -56,7 +56,7 @@ if [[ "${auto_start}" == "true" ]]; then
 fi
 
 if [[ "${should_auto_start}" == "true" ]]; then
-  set -- openclaw gateway --bind custom --port "${gateway_port}"
+  set -- openclaw gateway run --bind custom --port "${gateway_port}"
 fi
 
 exec /usr/local/bin/spritz-entrypoint "$@"


### PR DESCRIPTION
## Summary
- use `openclaw gateway run` for auto-start instead of service-style `openclaw gateway`
- keep the existing auto-start trigger behavior (empty command or `sleep infinity`)

## Validation
- `bash -n images/examples/openclaw/entrypoint.sh`