### PR TITLE
fix(operator): append trailing slash to ingress urls

### DIFF
--- a/operator/controllers/spritz_controller.go
+++ b/operator/controllers/spritz_controller.go
@@ -720,6 +720,9 @@ func spritzURL(spritz *spritzv1.Spritz) string {
 		if path == "" {
 			path = "/"
 		}
+		if path != "/" && !strings.HasSuffix(path, "/") {
+			path += "/"
+		}
 		return fmt.Sprintf("https://%s%s", spritz.Spec.Ingress.Host, path)
 	}
 

--- a/operator/controllers/spritz_url_test.go
+++ b/operator/controllers/spritz_url_test.go
@@ -1,0 +1,49 @@
+package controllers
+
+import (
+	"testing"
+
+	spritzv1 "spritz.sh/operator/api/v1"
+)
+
+func TestSpritzURLIngressAddsTrailingSlash(t *testing.T) {
+	spritz := &spritzv1.Spritz{}
+	spritz.Spec.Ingress = &spritzv1.SpritzIngress{
+		Host: "staging.console.textcortex.com",
+		Path: "/spritz/w/tidy-fjord",
+	}
+
+	got := spritzURL(spritz)
+	want := "https://staging.console.textcortex.com/spritz/w/tidy-fjord/"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestSpritzURLIngressRootStaysRoot(t *testing.T) {
+	spritz := &spritzv1.Spritz{}
+	spritz.Spec.Ingress = &spritzv1.SpritzIngress{
+		Host: "staging.console.textcortex.com",
+		Path: "/",
+	}
+
+	got := spritzURL(spritz)
+	want := "https://staging.console.textcortex.com/"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestSpritzURLIngressKeepsExistingTrailingSlash(t *testing.T) {
+	spritz := &spritzv1.Spritz{}
+	spritz.Spec.Ingress = &spritzv1.SpritzIngress{
+		Host: "staging.console.textcortex.com",
+		Path: "/spritz/w/tidy-fjord/",
+	}
+
+	got := spritzURL(spritz)
+	want := "https://staging.console.textcortex.com/spritz/w/tidy-fjord/"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}


### PR DESCRIPTION
## Summary
- append a trailing slash to ingress-based status URL values when path is not `/`
- keeps relative asset paths stable for web UIs served behind `/spritz/w/<name>`
- add controller unit tests for slash handling

## Validation
- `go test ./controllers/...` (from `operator/`)
