### PR TITLE
fix(openclaw): bind gateway for cluster reachability

### DIFF
--- a/images/examples/openclaw/README.md
+++ b/images/examples/openclaw/README.md
@@ -37,7 +37,7 @@ The image uses a small OpenClaw wrapper entrypoint and then calls
 `examples/base/entrypoint.sh`.
 
 By default, when the container command is the image default (`sleep infinity`),
-it auto-starts the OpenClaw gateway on port `8080` so Spritz `Open` can render
+it auto-starts the OpenClaw gateway on port `8080` with a LAN bind so Spritz `Open` can render
 OpenClaw UI immediately.
 
 To disable auto-start and keep shell-only behavior, set:
@@ -48,6 +48,7 @@ Auto-start related runtime overrides:
 
 - `OPENCLAW_GATEWAY_PORT` (default: `8080`)
 - `OPENCLAW_GATEWAY_MODE` (default: `local`)
+- `OPENCLAW_GATEWAY_BIND` (default: `lan`; set `loopback` for local-only)
 - `OPENCLAW_GATEWAY_TOKEN` (optional; auto-generated if omitted)
 
 ## Generic Config Support

--- a/images/examples/openclaw/entrypoint.sh
+++ b/images/examples/openclaw/entrypoint.sh
@@ -5,6 +5,7 @@ config_dir="${OPENCLAW_CONFIG_DIR:-${HOME}/.openclaw}"
 config_path="${OPENCLAW_CONFIG_PATH:-${config_dir}/openclaw.json}"
 gateway_port="${OPENCLAW_GATEWAY_PORT:-8080}"
 gateway_mode="${OPENCLAW_GATEWAY_MODE:-local}"
+gateway_bind="${OPENCLAW_GATEWAY_BIND:-lan}"
 auto_start="${OPENCLAW_AUTO_START:-true}"
 
 mkdir -p "${config_dir}"
@@ -35,6 +36,7 @@ export OPENCLAW_CONFIG_PATH="${config_path}"
 # Keep gateway defaults deterministic for Spritz web routing.
 openclaw config set gateway.mode "${gateway_mode}" >/dev/null
 openclaw config set gateway.port "${gateway_port}" >/dev/null
+openclaw config set gateway.bind "${gateway_bind}" >/dev/null
 
 token="${OPENCLAW_GATEWAY_TOKEN:-}"
 if [[ -z "${token}" ]]; then
@@ -56,7 +58,7 @@ if [[ "${auto_start}" == "true" ]]; then
 fi
 
 if [[ "${should_auto_start}" == "true" ]]; then
-  set -- openclaw gateway run --bind custom --port "${gateway_port}"
+  set -- openclaw gateway run --bind "${gateway_bind}" --port "${gateway_port}"
 fi
 
 exec /usr/local/bin/spritz-entrypoint "$@"


### PR DESCRIPTION
## Summary
- set OpenClaw gateway bind mode during entrypoint setup
- default bind mode to `lan` so Spritz gateway traffic can reach the devbox process
- keep bind mode overridable via `OPENCLAW_GATEWAY_BIND`
- document the new runtime override in the OpenClaw example README

## Validation
- `bash -n images/examples/openclaw/entrypoint.sh`
