### PR TITLE
chore(agents): enforce agnostic placeholders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENTS.md
+
+## Scope
+
+This repository is open-source and must remain provider- and organization-agnostic.
+
+## Agnostic Rules (Mandatory)
+
+- Never add TextCortex-specific values to code, tests, docs, examples, or comments.
+- Never include organization-specific domains, project IDs, cluster names, account IDs, emails, tokens, or credentials.
+- Never use TextCortex hostnames in test fixtures.
+
+Use neutral placeholders instead:
+
+- domains: `example.com`, `console.example.com`
+- emails: `user@example.com`
+- IDs: `example-project`, `example-cluster`, `example-account`
+
+If environment-specific wiring is required, keep it outside this repository.

--- a/operator/controllers/spritz_url_test.go
+++ b/operator/controllers/spritz_url_test.go
@@ -9,12 +9,12 @@ import (
 func TestSpritzURLIngressAddsTrailingSlash(t *testing.T) {
 	spritz := &spritzv1.Spritz{}
 	spritz.Spec.Ingress = &spritzv1.SpritzIngress{
-		Host: "staging.console.textcortex.com",
+		Host: "console.example.com",
 		Path: "/spritz/w/tidy-fjord",
 	}
 
 	got := spritzURL(spritz)
-	want := "https://staging.console.textcortex.com/spritz/w/tidy-fjord/"
+	want := "https://console.example.com/spritz/w/tidy-fjord/"
 	if got != want {
 		t.Fatalf("expected %q, got %q", want, got)
 	}
@@ -23,12 +23,12 @@ func TestSpritzURLIngressAddsTrailingSlash(t *testing.T) {
 func TestSpritzURLIngressRootStaysRoot(t *testing.T) {
 	spritz := &spritzv1.Spritz{}
 	spritz.Spec.Ingress = &spritzv1.SpritzIngress{
-		Host: "staging.console.textcortex.com",
+		Host: "console.example.com",
 		Path: "/",
 	}
 
 	got := spritzURL(spritz)
-	want := "https://staging.console.textcortex.com/"
+	want := "https://console.example.com/"
 	if got != want {
 		t.Fatalf("expected %q, got %q", want, got)
 	}
@@ -37,12 +37,12 @@ func TestSpritzURLIngressRootStaysRoot(t *testing.T) {
 func TestSpritzURLIngressKeepsExistingTrailingSlash(t *testing.T) {
 	spritz := &spritzv1.Spritz{}
 	spritz.Spec.Ingress = &spritzv1.SpritzIngress{
-		Host: "staging.console.textcortex.com",
+		Host: "console.example.com",
 		Path: "/spritz/w/tidy-fjord/",
 	}
 
 	got := spritzURL(spritz)
-	want := "https://staging.console.textcortex.com/spritz/w/tidy-fjord/"
+	want := "https://console.example.com/spritz/w/tidy-fjord/"
 	if got != want {
 		t.Fatalf("expected %q, got %q", want, got)
 	}


### PR DESCRIPTION
## Summary
- replace TextCortex hostname fixtures in Spritz URL tests with neutral placeholders
- add repository-level AGENTS rules to keep Spritz provider/org agnostic

## Validation
- go test ./controllers/... (from operator/)