### PR TITLE
fix(ui): default shared mount sync mode to poll

### DIFF
--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -443,7 +443,8 @@ const defaultUserConfigYaml = `sharedMounts:
     mountPath: /home/dev/.config
     scope: owner
     mode: snapshot
-    syncMode: manual`;
+    syncMode: poll
+    pollSeconds: 30`;
 
 function normalizePresetEnv(env) {
   if (!env) return null;

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -55,7 +55,8 @@
     mountPath: /home/dev/.config
     scope: owner
     mode: snapshot
-    syncMode: manual
+    syncMode: poll
+    pollSeconds: 30
 ttl: 8h"
             ></textarea>
             <small class="hint">


### PR DESCRIPTION
## Summary
- change the default create-form user config template from syncMode manual to syncMode poll
- add pollSeconds 30 to the default template
- update the textarea placeholder example to match

## Why
New Spritzes created from UI were defaulting to manual sync and looked broken for live config sync.

## Validation
- built UI image locally via docker build -t spritz-ui-default-live-sync-test /tmp/spritz/ui
