### PR TITLE
docs(auth): add portable authentication architecture

### DIFF
--- a/docs/2026-02-24-portable-authentication-and-account-architecture.md
+++ b/docs/2026-02-24-portable-authentication-and-account-architecture.md
@@ -1,13 +1,13 @@
 ---
 date: 2026-02-24
 author: Spritz Maintainers <user@example.com>
-title: Platform-Agnostic Authentication and Account Architecture
+title: Portable Authentication and Account Architecture
 tags: [spritz, auth, oidc, deployment, architecture]
 ---
 
 ## Overview
 
-This document defines the default, platform-agnostic authentication and account model for Spritz.
+This document defines the default, portable authentication and account model for Spritz.
 
 The objective is a deployment model that works across arbitrary environments without requiring a
 specific edge provider, SaaS login product, or organization-specific identity stack.


### PR DESCRIPTION
## TL;DR
Adds a comprehensive, portable authentication and account architecture spec for Spritz.

## Summary
- define default auth model for arbitrary deployments: in-cluster OIDC gateway + API header auth
- document UI/API auth contracts, identity/account semantics, and security requirements
- include migration guidance from legacy login flows and a deployment validation checklist

## Validation
- documentation-only change
- verified file naming/front matter consistency with existing docs style
