### PR TITLE
fix(openclaw): route ACP bridge through pod IP

### DIFF
--- a/images/examples/openclaw/README.md
+++ b/images/examples/openclaw/README.md
@@ -66,6 +66,8 @@ Auto-start related runtime overrides:
 - `OPENCLAW_ACP_BIND` (default: `0.0.0.0`)
 - `OPENCLAW_ACP_PORT` (default: `2529`)
 - `OPENCLAW_ACP_PATH` (default: `/`)
+- `SPRITZ_OPENCLAW_ACP_GATEWAY_HOST` (optional; defaults to the pod/container IPv4 so trusted-proxy gateway auth accepts the ACP bridge)
+- `SPRITZ_OPENCLAW_ACP_GATEWAY_URL` (optional; overrides the computed bridge target)
 
 ## Generic Config Support
 

--- a/images/examples/openclaw/entrypoint.sh
+++ b/images/examples/openclaw/entrypoint.sh
@@ -11,6 +11,31 @@ acp_enabled="${OPENCLAW_ACP_ENABLED:-true}"
 acp_bind="${OPENCLAW_ACP_BIND:-0.0.0.0}"
 acp_port="${OPENCLAW_ACP_PORT:-2529}"
 acp_path="${OPENCLAW_ACP_PATH:-/}"
+bridge_bin="${SPRITZ_OPENCLAW_BRIDGE_BIN:-/usr/local/bin/spritz-openclaw-acp-bridge}"
+spritz_entrypoint_bin="${SPRITZ_OPENCLAW_MAIN_ENTRYPOINT:-/usr/local/bin/spritz-entrypoint}"
+
+detect_bridge_gateway_host() {
+  if [[ -n "${SPRITZ_OPENCLAW_ACP_GATEWAY_HOST:-}" ]]; then
+    printf '%s\n' "${SPRITZ_OPENCLAW_ACP_GATEWAY_HOST}"
+    return
+  fi
+
+  local host_ips="" candidate=""
+  if host_ips="$(hostname -i 2>/dev/null)"; then
+    candidate="$(printf '%s\n' "${host_ips}" | tr ' ' '\n' | awk '/^[0-9]+\./ { print; exit }')"
+    if [[ -n "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return
+    fi
+    candidate="$(printf '%s\n' "${host_ips}" | tr ' ' '\n' | sed -n '/./{p;q;}')"
+    if [[ -n "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return
+    fi
+  fi
+
+  printf '127.0.0.1\n'
+}
 
 mkdir -p "${config_dir}"
 
@@ -71,18 +96,19 @@ fi
 
 lower_acp_enabled="$(printf '%s' "${acp_enabled}" | tr '[:upper:]' '[:lower:]')"
 if [[ "${lower_acp_enabled}" == "false" || "${lower_acp_enabled}" == "0" || "${lower_acp_enabled}" == "no" || "${lower_acp_enabled}" == "off" ]]; then
-  exec /usr/local/bin/spritz-entrypoint "$@"
+  exec "${spritz_entrypoint_bin}" "$@"
 fi
 
-export SPRITZ_OPENCLAW_ACP_GATEWAY_URL="${SPRITZ_OPENCLAW_ACP_GATEWAY_URL:-ws://127.0.0.1:${gateway_port}}"
+bridge_gateway_host="$(detect_bridge_gateway_host)"
+export SPRITZ_OPENCLAW_ACP_GATEWAY_URL="${SPRITZ_OPENCLAW_ACP_GATEWAY_URL:-ws://${bridge_gateway_host}:${gateway_port}}"
 export SPRITZ_OPENCLAW_ACP_GATEWAY_TOKEN_FILE="${SPRITZ_OPENCLAW_ACP_GATEWAY_TOKEN_FILE:-${gateway_token_file}}"
 export SPRITZ_OPENCLAW_ACP_LISTEN_ADDR="${SPRITZ_OPENCLAW_ACP_LISTEN_ADDR:-${acp_bind}:${acp_port}}"
 export SPRITZ_OPENCLAW_ACP_PATH="${SPRITZ_OPENCLAW_ACP_PATH:-${acp_path}}"
 
-/usr/local/bin/spritz-openclaw-acp-bridge &
+"${bridge_bin}" &
 bridge_pid=$!
 
-/usr/local/bin/spritz-entrypoint "$@" &
+"${spritz_entrypoint_bin}" "$@" &
 main_pid=$!
 
 cleanup() {

--- a/images/examples/openclaw/entrypoint_test.sh
+++ b/images/examples/openclaw/entrypoint_test.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+entrypoint="${repo_root}/images/examples/openclaw/entrypoint.sh"
+
+assert_eq() {
+  local actual="$1"
+  local expected="$2"
+  local message="$3"
+  if [[ "${actual}" != "${expected}" ]]; then
+    printf 'assertion failed: %s\nexpected: %s\nactual:   %s\n' "${message}" "${expected}" "${actual}" >&2
+    exit 1
+  fi
+}
+
+make_openclaw_stub() {
+  local path="$1"
+  cat > "${path}" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "config" && "${2:-}" == "get" && "${3:-}" == "gateway.auth.token" ]]; then
+  exit 0
+fi
+if [[ "${1:-}" == "config" && "${2:-}" == "set" ]]; then
+  exit 0
+fi
+printf 'unexpected openclaw invocation: %s\n' "$*" >&2
+exit 1
+EOF
+  chmod +x "${path}"
+}
+
+run_case() {
+  local test_dir="$1"
+  local hostname_output="$2"
+  local expected_url="$3"
+  local explicit_url="${4:-}"
+
+  mkdir -p "${test_dir}/bin" "${test_dir}/home"
+  make_openclaw_stub "${test_dir}/bin/openclaw"
+
+  cat > "${test_dir}/bin/hostname" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\${1:-}" == "-i" ]]; then
+  printf '%s\n' '${hostname_output}'
+  exit 0
+fi
+exec /usr/bin/hostname "\$@"
+EOF
+  chmod +x "${test_dir}/bin/hostname"
+
+  cat > "${test_dir}/bin/bridge" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "${SPRITZ_OPENCLAW_ACP_GATEWAY_URL}" > "${TEST_GATEWAY_URL_FILE}"
+exit 0
+EOF
+  chmod +x "${test_dir}/bin/bridge"
+
+  cat > "${test_dir}/bin/main-entrypoint" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+sleep 5 &
+wait $!
+EOF
+  chmod +x "${test_dir}/bin/main-entrypoint"
+
+  local output_file="${test_dir}/gateway-url.txt"
+  (
+    export PATH="${test_dir}/bin:${PATH}"
+    export HOME="${test_dir}/home"
+    export OPENCLAW_AUTO_START=false
+    export TEST_GATEWAY_URL_FILE="${output_file}"
+    export SPRITZ_OPENCLAW_BRIDGE_BIN="${test_dir}/bin/bridge"
+    export SPRITZ_OPENCLAW_MAIN_ENTRYPOINT="${test_dir}/bin/main-entrypoint"
+    if [[ -n "${explicit_url}" ]]; then
+      export SPRITZ_OPENCLAW_ACP_GATEWAY_URL="${explicit_url}"
+    else
+      unset SPRITZ_OPENCLAW_ACP_GATEWAY_URL || true
+    fi
+    bash "${entrypoint}" true
+  )
+
+  local actual
+  actual="$(cat "${output_file}")"
+  assert_eq "${actual}" "${expected_url}" "gateway URL should match"
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+run_case "${tmpdir}/pod-ip-default" "10.244.3.160 2001:db8:1:3::e3ab" "ws://10.244.3.160:8080"
+run_case "${tmpdir}/explicit-override" "10.244.3.160 2001:db8:1:3::e3ab" "ws://bridge.example.internal:9000" "ws://bridge.example.internal:9000"
+
+printf 'entrypoint ACP gateway URL tests passed\n'


### PR DESCRIPTION
## Summary
- route the ACP bridge to the pod/container IP by default instead of loopback
- keep explicit gateway URL overrides supported
- add a shell smoke test for the entrypoint ACP bridge target selection

## Testing
- bash -n images/examples/openclaw/entrypoint.sh
- bash images/examples/openclaw/entrypoint_test.sh
- docker build -t spritz-openclaw:acp-podip-local -f images/examples/openclaw/Dockerfile images