### PR TITLE
fix(openclaw): support ACP bridge with trusted-proxy auth

### DIFF
--- a/OPENCLAW.md
+++ b/OPENCLAW.md
@@ -37,7 +37,9 @@ The OpenClaw example entrypoint does the following:
 4. Ensures `OPENCLAW_GATEWAY_TOKEN` exists (uses provided token or generates one).
 5. Writes the gateway token to a local token file for bridge use.
 6. Starts an image-owned ACP compatibility bridge on `0.0.0.0:2529` unless `OPENCLAW_ACP_ENABLED=false`.
-7. Auto-starts OpenClaw when command is default (`sleep infinity`), unless `OPENCLAW_AUTO_START=false`.
+7. When gateway auth mode is `trusted-proxy`, automatically trusts loopback for the internal bridge
+   and injects the required trusted-proxy headers on the bridge's upstream gateway hop.
+8. Auto-starts OpenClaw when command is default (`sleep infinity`), unless `OPENCLAW_AUTO_START=false`.
 
 Key implication: direct `/w/{name}` access with `bind=lan` expects real gateway auth.
 
@@ -63,6 +65,8 @@ Today the example image satisfies that contract with a compatibility bridge:
 - WebSocket server inside the image listens on `2529`
 - each ACP connection spawns `openclaw acp`
 - `openclaw acp` talks to the local OpenClaw gateway over loopback WebSocket
+- if gateway auth mode is `trusted-proxy`, the bridge uses a loopback-only header injector so the
+  internal ACP hop satisfies the same trusted-proxy contract as the browser route
 
 This keeps the Spritz side backend-agnostic while OpenClaw remains free to add native socket ACP
 later.

--- a/README.md
+++ b/README.md
@@ -1,21 +1,84 @@
-# spritz
+# Spritz
 
-Spritz is a Kubernetes-native control plane for ephemeral workspaces.
+Spritz is a Kubernetes-native control plane for creating and accessing short-lived workspaces and agent runtimes.
 
-## What it does
+## Status
 
-- creates per-user or per-team workspace instances as `Spritz` resources
-- exposes web and terminal access through the Spritz API and UI
-- reserves ACP on port `2529` for agent-capable backends
-- automatically discovers ACP agents and exposes them in the built-in chat UI
+Spritz is in active development and should be treated as alpha software.
 
-## Default runtime model
+That means:
+
+- the core direction is set, but APIs, CRDs, and Helm values may still change
+- deployment defaults are being hardened now, not frozen yet
+- it is usable for development and system testing, but it is not positioned as a stable GA platform yet
+
+## What Spritz is
+
+Spritz is the control plane around a workspace, not the workspace runtime itself.
+
+Its job is to:
+
+- create workspace instances as `Spritz` resources in Kubernetes
+- expose a single UI and API for opening those workspaces
+- standardize the default workspace shape, including `/home/dev` as the home directory
+- discover ACP-capable backends on port `2529`
+- provide a built-in ACP chat surface so operators can talk to running agents through Spritz
+
+The runtime inside a workspace is pluggable. A workspace may run OpenClaw or any other backend, as long as it follows the Spritz runtime contract.
+
+## What exists today
+
+Current Spritz includes:
+
+- a Kubernetes operator that reconciles `Spritz` resources into running workspace instances
+- a Spritz API that brokers access to workspaces and proxies browser ACP traffic
+- a Spritz UI for listing workspaces, opening them, and testing ACP-capable agents
+- a Helm chart intended to bring up a working standalone install with one public host
+- ACP discovery and status reporting through `Spritz.status.acp`
+
+## Default model
+
+The default deployment model is intentionally simple:
 
 - one Helm install
-- one public host for UI and API
+- one public host
+- one UI and one API behind the same ingress surface
+- browser traffic to agents always flows through `spritz-api`
 - workspace home starts at `/home/dev`
-- ACP is available on internal workspace port `2529`
-- browser ACP traffic always flows through `spritz-api`
+- ACP is reserved on internal workspace port `2529`
+
+The default goal is: install Spritz with a Helm chart, create workspaces, and talk to ACP-capable agents without needing custom edge routing or product-specific infrastructure.
+
+## ACP in Spritz
+
+Spritz reserves ACP on:
+
+- port `2529`
+- WebSocket transport
+- path `/`
+
+If something inside the workspace listens there and responds to ACP `initialize`, Spritz treats that workspace as ACP-capable.
+
+The operator owns discovery and writes canonical ACP readiness into `Spritz.status.acp`. The browser never connects directly to workspace ACP ports; it always goes through `spritz-api`.
+
+## What is still moving
+
+The broad architecture is established, but some surfaces are still evolving while Spritz is in alpha:
+
+- Helm values and install defaults
+- auth gateway packaging and default auth flows
+- ACP UI behavior and conversation management
+- backend presets for different workspace runtimes
+- operational hardening for production-scale installs
+
+## Design constraints
+
+Spritz is intended to stay portable and standalone:
+
+- no hard dependency on TextCortex-specific infrastructure inside the Spritz codebase
+- no required edge-worker path routing in the default deployment path
+- no backend-specific ACP logic in the Spritz control plane
+- no assumption that OpenClaw is the only supported runtime
 
 ## Key docs
 

--- a/images/examples/openclaw/README.md
+++ b/images/examples/openclaw/README.md
@@ -47,7 +47,7 @@ The image also starts an internal ACP compatibility bridge by default:
 
 - listen address: `0.0.0.0:2529`
 - WebSocket path: `/`
-- backend: per-connection `openclaw acp` stdio bridge to the local gateway
+- backend: per-connection `openclaw acp` stdio bridge to the local gateway over loopback
 
 This keeps the Spritz ACP contract stable even though OpenClaw's native ACP support is currently
 stdio-only.
@@ -66,9 +66,22 @@ Auto-start related runtime overrides:
 - `OPENCLAW_ACP_BIND` (default: `0.0.0.0`)
 - `OPENCLAW_ACP_PORT` (default: `2529`)
 - `OPENCLAW_ACP_PATH` (default: `/`)
-- `SPRITZ_OPENCLAW_ACP_GATEWAY_HOST` (optional; defaults to the pod/container IPv4 so trusted-proxy gateway auth accepts the ACP bridge)
+- `SPRITZ_OPENCLAW_ACP_GATEWAY_HOST` (optional; defaults to `127.0.0.1`)
 - `SPRITZ_OPENCLAW_ACP_GATEWAY_URL` (optional; overrides the computed bridge target)
-- `SPRITZ_OPENCLAW_ACP_ALLOW_INSECURE_PRIVATE_WS` (default: `1`; only affects the internal `openclaw acp` bridge child so private pod-network `ws://` works)
+- `SPRITZ_OPENCLAW_ACP_GATEWAY_HEADERS_JSON` (optional; JSON object of headers injected into the bridge's upstream gateway connection)
+- `SPRITZ_OPENCLAW_ACP_TRUSTED_PROXY_USER` (optional; default internal trusted-proxy user identity)
+- `SPRITZ_OPENCLAW_ACP_TRUSTED_PROXY_EMAIL` (optional; default internal trusted-proxy email identity)
+- `SPRITZ_OPENCLAW_ACP_ALLOW_INSECURE_PRIVATE_WS` (default: `0`; only needed when overriding the bridge target away from loopback onto a trusted private-network `ws://` endpoint)
+
+When the OpenClaw gateway itself is configured with `gateway.auth.mode="trusted-proxy"`, the
+entrypoint automatically:
+
+- appends `127.0.0.1` and `::1` to `gateway.trustedProxies`
+- derives a header set for the internal ACP bridge
+- routes the bridge child through a loopback-only header-injecting WebSocket proxy
+
+This keeps `/w/{name}` tokenless for browser users while allowing the internal ACP bridge to
+authenticate cleanly without using pod-IP workarounds.
 
 ## Generic Config Support
 

--- a/images/examples/openclaw/acpbridge/main.go
+++ b/images/examples/openclaw/acpbridge/main.go
@@ -3,11 +3,13 @@ package main
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -25,11 +27,13 @@ const (
 )
 
 type bridgeConfig struct {
-	ListenAddr string
-	Path       string
-	Command    string
-	Args       []string
-	Env        []string
+	ListenAddr     string
+	Path           string
+	Command        string
+	Args           []string
+	Env            []string
+	GatewayURL     string
+	GatewayHeaders http.Header
 }
 
 type pumpResult struct {
@@ -108,13 +112,43 @@ func configFromEnv() (bridgeConfig, error) {
 		extraEnv = append(extraEnv, "OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1")
 	}
 
+	gatewayHeaders, err := parseGatewayHeaders(strings.TrimSpace(os.Getenv("SPRITZ_OPENCLAW_ACP_GATEWAY_HEADERS_JSON")))
+	if err != nil {
+		return bridgeConfig{}, err
+	}
+
 	return bridgeConfig{
-		ListenAddr: listenAddr,
-		Path:       path,
-		Command:    command,
-		Args:       args,
-		Env:        extraEnv,
+		ListenAddr:     listenAddr,
+		Path:           path,
+		Command:        command,
+		Args:           args,
+		Env:            extraEnv,
+		GatewayURL:     gatewayURL,
+		GatewayHeaders: gatewayHeaders,
 	}, nil
+}
+
+func parseGatewayHeaders(raw string) (http.Header, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	decoded := map[string]string{}
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		return nil, errors.New("SPRITZ_OPENCLAW_ACP_GATEWAY_HEADERS_JSON must be a JSON object of string header values")
+	}
+	headers := http.Header{}
+	for key, value := range decoded {
+		trimmedKey := strings.TrimSpace(key)
+		trimmedValue := strings.TrimSpace(value)
+		if trimmedKey == "" || trimmedValue == "" {
+			continue
+		}
+		headers.Set(trimmedKey, trimmedValue)
+	}
+	if len(headers) == 0 {
+		return nil, nil
+	}
+	return headers, nil
 }
 
 func parseBoolEnv(key string, fallback bool) bool {
@@ -133,6 +167,12 @@ func parseBoolEnv(key string, fallback bool) bool {
 }
 
 func runServer(ctx context.Context, cfg bridgeConfig, logger *log.Logger) error {
+	effectiveCfg, cleanup, err := prepareBridgeRuntime(ctx, cfg, logger)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
 	listener, err := net.Listen("tcp", cfg.ListenAddr)
 	if err != nil {
 		return err
@@ -141,7 +181,7 @@ func runServer(ctx context.Context, cfg bridgeConfig, logger *log.Logger) error 
 		_ = listener.Close()
 	}()
 
-	server := &http.Server{Handler: newHandler(cfg, logger)}
+	server := &http.Server{Handler: newHandler(effectiveCfg, logger)}
 	go func() {
 		<-ctx.Done()
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), defaultShutdownTimeout)
@@ -151,6 +191,132 @@ func runServer(ctx context.Context, cfg bridgeConfig, logger *log.Logger) error 
 
 	logger.Printf("listening on %s%s", cfg.ListenAddr, cfg.Path)
 	return server.Serve(listener)
+}
+
+func prepareBridgeRuntime(ctx context.Context, cfg bridgeConfig, logger *log.Logger) (bridgeConfig, func(), error) {
+	if len(cfg.GatewayHeaders) == 0 {
+		return cfg, func() {}, nil
+	}
+	proxyURL, shutdown, err := startGatewayProxy(ctx, cfg.GatewayURL, cfg.GatewayHeaders, logger)
+	if err != nil {
+		return bridgeConfig{}, nil, err
+	}
+	effectiveCfg := cfg
+	effectiveCfg.Args = replaceGatewayURLArg(cfg.Args, proxyURL)
+	return effectiveCfg, shutdown, nil
+}
+
+func replaceGatewayURLArg(args []string, newURL string) []string {
+	replaced := append([]string(nil), args...)
+	for index := 0; index < len(replaced)-1; index++ {
+		if replaced[index] == "--url" {
+			replaced[index+1] = newURL
+			break
+		}
+	}
+	return replaced
+}
+
+func startGatewayProxy(ctx context.Context, upstreamURL string, headers http.Header, logger *log.Logger) (string, func(), error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", nil, err
+	}
+
+	upstream, err := url.Parse(upstreamURL)
+	if err != nil {
+		_ = listener.Close()
+		return "", nil, err
+	}
+	proxyPath := upstream.EscapedPath()
+	if proxyPath == "" {
+		proxyPath = "/"
+	}
+	localURL := (&url.URL{
+		Scheme:   "ws",
+		Host:     listener.Addr().String(),
+		Path:     proxyPath,
+		RawQuery: upstream.RawQuery,
+	}).String()
+
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			clientConn, err := websocket.Upgrade(w, r, nil, 64*1024, 64*1024)
+			if err != nil {
+				logger.Printf("gateway proxy upgrade failed: %v", err)
+				return
+			}
+			defer func() {
+				_ = clientConn.Close()
+			}()
+
+			dialer := websocket.Dialer{}
+			upstreamConn, _, err := dialer.DialContext(r.Context(), upstreamURL, headers)
+			if err != nil {
+				logger.Printf("gateway proxy upstream dial failed: %v", err)
+				_ = clientConn.WriteControl(
+					websocket.CloseMessage,
+					websocket.FormatCloseMessage(websocket.CloseTryAgainLater, "gateway proxy connect failed"),
+					timeNowPlusSecond(),
+				)
+				return
+			}
+			defer func() {
+				_ = upstreamConn.Close()
+			}()
+
+			proxyErrCh := make(chan error, 2)
+			go func() {
+				proxyErrCh <- proxyWebSocketMessages(upstreamConn, clientConn)
+			}()
+			go func() {
+				proxyErrCh <- proxyWebSocketMessages(clientConn, upstreamConn)
+			}()
+			err = <-proxyErrCh
+			if err != nil && !isNormalWebSocketClosure(err) {
+				logger.Printf("gateway proxy connection failed: %v", err)
+			}
+		}),
+	}
+
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), defaultShutdownTimeout)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+
+	go func() {
+		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Printf("gateway proxy server failed: %v", err)
+		}
+	}()
+
+	return localURL, func() {
+		_ = server.Close()
+		_ = listener.Close()
+	}, nil
+}
+
+func proxyWebSocketMessages(dst *websocket.Conn, src *websocket.Conn) error {
+	for {
+		messageType, payload, err := src.ReadMessage()
+		if err != nil {
+			return err
+		}
+		if err := dst.WriteMessage(messageType, payload); err != nil {
+			return err
+		}
+	}
+}
+
+func isNormalWebSocketClosure(err error) bool {
+	return websocket.IsCloseError(
+		err,
+		websocket.CloseNormalClosure,
+		websocket.CloseGoingAway,
+		websocket.CloseNoStatusReceived,
+	) || errors.Is(err, io.EOF)
 }
 
 func newHandler(cfg bridgeConfig, logger *log.Logger) http.Handler {

--- a/images/examples/openclaw/acpbridge/main_test.go
+++ b/images/examples/openclaw/acpbridge/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"io"
 	"log"
@@ -52,6 +53,91 @@ func TestConfigFromEnvEnablesPrivateWSOverride(t *testing.T) {
 	}
 	if len(cfg.Env) != 1 || cfg.Env[0] != "OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1" {
 		t.Fatalf("Env = %#v, want OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1", cfg.Env)
+	}
+}
+
+func TestConfigFromEnvParsesGatewayHeadersJSON(t *testing.T) {
+	t.Setenv("SPRITZ_OPENCLAW_ACP_GATEWAY_URL", "ws://127.0.0.1:8080")
+	t.Setenv(
+		"SPRITZ_OPENCLAW_ACP_GATEWAY_HEADERS_JSON",
+		`{"x-forwarded-user":"spritz-acp-bridge","x-forwarded-email":"spritz-acp-bridge@example.invalid"}`,
+	)
+
+	cfg, err := configFromEnv()
+	if err != nil {
+		t.Fatalf("configFromEnv() error = %v", err)
+	}
+	if got := cfg.GatewayHeaders.Get("x-forwarded-user"); got != "spritz-acp-bridge" {
+		t.Fatalf("x-forwarded-user = %q, want %q", got, "spritz-acp-bridge")
+	}
+	if got := cfg.GatewayHeaders.Get("x-forwarded-email"); got != "spritz-acp-bridge@example.invalid" {
+		t.Fatalf("x-forwarded-email = %q, want %q", got, "spritz-acp-bridge@example.invalid")
+	}
+}
+
+func TestGatewayProxyInjectsHeadersAndProxiesFrames(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	upstreamSeen := make(chan http.Header, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamSeen <- r.Header.Clone()
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade upstream: %v", err)
+		}
+		defer func() {
+			_ = conn.Close()
+		}()
+		messageType, payload, err := conn.ReadMessage()
+		if err != nil {
+			t.Fatalf("read upstream: %v", err)
+		}
+		if err := conn.WriteMessage(messageType, payload); err != nil {
+			t.Fatalf("write upstream: %v", err)
+		}
+	}))
+	defer upstream.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	proxyURL, shutdown, err := startGatewayProxy(
+		ctx,
+		"ws"+strings.TrimPrefix(upstream.URL, "http"),
+		http.Header{
+			"X-Forwarded-User":  []string{"spritz-acp-bridge"},
+			"X-Forwarded-Email": []string{"spritz-acp-bridge@example.invalid"},
+		},
+		log.New(io.Discard, "", 0),
+	)
+	if err != nil {
+		t.Fatalf("startGatewayProxy() error = %v", err)
+	}
+	defer shutdown()
+
+	conn, _, err := websocket.DefaultDialer.Dial(proxyURL, nil)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"jsonrpc":"2.0"}`)); err != nil {
+		t.Fatalf("write proxy: %v", err)
+	}
+	_, payload, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read proxy: %v", err)
+	}
+	if string(payload) != `{"jsonrpc":"2.0"}` {
+		t.Fatalf("payload = %q, want echo", string(payload))
+	}
+
+	headers := <-upstreamSeen
+	if got := headers.Get("X-Forwarded-User"); got != "spritz-acp-bridge" {
+		t.Fatalf("X-Forwarded-User = %q, want %q", got, "spritz-acp-bridge")
+	}
+	if got := headers.Get("X-Forwarded-Email"); got != "spritz-acp-bridge@example.invalid" {
+		t.Fatalf("X-Forwarded-Email = %q, want %q", got, "spritz-acp-bridge@example.invalid")
 	}
 }
 

--- a/images/examples/openclaw/entrypoint.sh
+++ b/images/examples/openclaw/entrypoint.sh
@@ -20,21 +20,97 @@ detect_bridge_gateway_host() {
     return
   fi
 
-  local host_ips="" candidate=""
-  if host_ips="$(hostname -i 2>/dev/null)"; then
-    candidate="$(printf '%s\n' "${host_ips}" | tr ' ' '\n' | awk '/^[0-9]+\./ { print; exit }')"
-    if [[ -n "${candidate}" ]]; then
-      printf '%s\n' "${candidate}"
-      return
-    fi
-    candidate="$(printf '%s\n' "${host_ips}" | tr ' ' '\n' | sed -n '/./{p;q;}')"
-    if [[ -n "${candidate}" ]]; then
-      printf '%s\n' "${candidate}"
-      return
-    fi
-  fi
-
   printf '127.0.0.1\n'
+}
+
+prepare_acp_trusted_proxy_bridge() {
+  node - "${config_path}" <<'NODE'
+const fs = require("node:fs");
+
+const configPath = process.argv[2];
+const raw = fs.readFileSync(configPath, "utf8");
+const cfg = JSON.parse(raw);
+const gateway = cfg.gateway ?? {};
+const auth = gateway.auth ?? {};
+const trustedProxy = auth.trustedProxy ?? {};
+const trustedProxies = Array.isArray(gateway.trustedProxies) ? gateway.trustedProxies : [];
+const authMode = typeof auth.mode === "string" ? auth.mode.trim() : "";
+
+if (authMode !== "trusted-proxy") {
+  process.stdout.write("{}");
+  process.exit(0);
+}
+
+const mergedTrustedProxies = [];
+for (const value of [...trustedProxies, "127.0.0.1", "::1"]) {
+  if (typeof value !== "string") {
+    continue;
+  }
+  const trimmed = value.trim();
+  if (!trimmed || mergedTrustedProxies.includes(trimmed)) {
+    continue;
+  }
+  mergedTrustedProxies.push(trimmed);
+}
+
+gateway.trustedProxies = mergedTrustedProxies;
+cfg.gateway = gateway;
+fs.writeFileSync(configPath, JSON.stringify(cfg, null, 2) + "\n");
+
+const bridgeUser = process.env.SPRITZ_OPENCLAW_ACP_TRUSTED_PROXY_USER?.trim() || "spritz-acp-bridge";
+const bridgeEmail =
+  process.env.SPRITZ_OPENCLAW_ACP_TRUSTED_PROXY_EMAIL?.trim() ||
+  "spritz-acp-bridge@example.invalid";
+const userHeader =
+  typeof trustedProxy.userHeader === "string" && trustedProxy.userHeader.trim()
+    ? trustedProxy.userHeader.trim()
+    : "x-forwarded-user";
+const requiredHeaders = Array.isArray(trustedProxy.requiredHeaders)
+  ? trustedProxy.requiredHeaders
+  : [];
+
+const headers = {
+  "x-forwarded-user": bridgeUser,
+  "x-forwarded-email": bridgeEmail,
+  "x-forwarded-proto": "https",
+  "x-forwarded-host": "localhost",
+  "x-forwarded-for": "127.0.0.1",
+  "x-real-ip": "127.0.0.1",
+};
+
+headers[userHeader.toLowerCase()] = userHeader.toLowerCase().includes("email")
+  ? bridgeEmail
+  : bridgeUser;
+
+for (const value of requiredHeaders) {
+  if (typeof value !== "string") {
+    continue;
+  }
+  const header = value.trim().toLowerCase();
+  if (!header || headers[header]) {
+    continue;
+  }
+  if (header.includes("email")) {
+    headers[header] = bridgeEmail;
+    continue;
+  }
+  if (header === "x-forwarded-proto") {
+    headers[header] = "https";
+    continue;
+  }
+  if (header === "x-forwarded-host") {
+    headers[header] = "localhost";
+    continue;
+  }
+  if (header === "x-forwarded-for" || header === "x-real-ip") {
+    headers[header] = "127.0.0.1";
+    continue;
+  }
+  headers[header] = "1";
+}
+
+process.stdout.write(JSON.stringify(headers));
+NODE
 }
 
 mkdir -p "${config_dir}"
@@ -61,6 +137,10 @@ chmod 600 "${config_path}" || true
 
 # Force OpenClaw to use the same file path we prepared above.
 export OPENCLAW_CONFIG_PATH="${config_path}"
+
+if [[ -z "${SPRITZ_OPENCLAW_ACP_GATEWAY_HEADERS_JSON:-}" ]]; then
+  export SPRITZ_OPENCLAW_ACP_GATEWAY_HEADERS_JSON="$(prepare_acp_trusted_proxy_bridge)"
+fi
 
 # Keep gateway defaults deterministic for Spritz web routing.
 openclaw config set gateway.mode "${gateway_mode}" >/dev/null
@@ -101,7 +181,7 @@ fi
 
 bridge_gateway_host="$(detect_bridge_gateway_host)"
 export SPRITZ_OPENCLAW_ACP_GATEWAY_URL="${SPRITZ_OPENCLAW_ACP_GATEWAY_URL:-ws://${bridge_gateway_host}:${gateway_port}}"
-export SPRITZ_OPENCLAW_ACP_ALLOW_INSECURE_PRIVATE_WS="${SPRITZ_OPENCLAW_ACP_ALLOW_INSECURE_PRIVATE_WS:-1}"
+export SPRITZ_OPENCLAW_ACP_ALLOW_INSECURE_PRIVATE_WS="${SPRITZ_OPENCLAW_ACP_ALLOW_INSECURE_PRIVATE_WS:-0}"
 export SPRITZ_OPENCLAW_ACP_GATEWAY_TOKEN_FILE="${SPRITZ_OPENCLAW_ACP_GATEWAY_TOKEN_FILE:-${gateway_token_file}}"
 export SPRITZ_OPENCLAW_ACP_LISTEN_ADDR="${SPRITZ_OPENCLAW_ACP_LISTEN_ADDR:-${acp_bind}:${acp_port}}"
 export SPRITZ_OPENCLAW_ACP_PATH="${SPRITZ_OPENCLAW_ACP_PATH:-${acp_path}}"


### PR DESCRIPTION
## TL;DR
This makes the Spritz OpenClaw ACP bridge work when the OpenClaw gateway is running in trusted-proxy auth mode. It also rewrites the top-level README so the project status and alpha scope are explicit.

## Summary
- route the image-owned ACP bridge to loopback and inject trusted-proxy headers for the internal gateway hop
- add bridge regression coverage for header injection and env parsing
- document the alpha status and the updated OpenClaw ACP runtime contract

## Review focus
- internal OpenClaw bridge auth behavior when `gateway.auth.mode=trusted-proxy`
- whether the loopback header injector is the right long-term image-owned compatibility layer
- README positioning and alpha-language clarity

## Test plan
- [x] `go test ./...` in `images/examples/openclaw/acpbridge`
- [x] `bash -n images/examples/openclaw/entrypoint.sh`
- [x] `npx -y @simpledoc/simpledoc check`