### PR TITLE
fix(openclaw): derive trusted proxy origin from gateway url

### DIFF
--- a/images/examples/openclaw/acpbridge/main.go
+++ b/images/examples/openclaw/acpbridge/main.go
@@ -272,7 +272,7 @@ func startGatewayProxy(
 			upstreamConn, _, err := dialer.DialContext(
 				r.Context(),
 				upstreamURL,
-				normalizeGatewayProxyHeaders(headers, trustedProxyControlUI),
+				normalizeGatewayProxyHeaders(headers, upstreamURL, trustedProxyControlUI),
 			)
 			if err != nil {
 				logger.Printf("gateway proxy upstream dial failed: %v", err)
@@ -326,13 +326,30 @@ func startGatewayProxy(
 
 type websocketFrameTransformer func(messageType int, payload []byte) (int, []byte, error)
 
-func normalizeGatewayProxyHeaders(headers http.Header, trustedProxyControlUI bool) http.Header {
+func normalizeGatewayProxyHeaders(
+	headers http.Header,
+	upstreamURL string,
+	trustedProxyControlUI bool,
+) http.Header {
 	if len(headers) == 0 {
 		return nil
 	}
 	normalized := headers.Clone()
 	if !trustedProxyControlUI || normalized.Get("Origin") != "" {
 		return normalized
+	}
+	if parsed, err := url.Parse(strings.TrimSpace(upstreamURL)); err == nil {
+		switch parsed.Scheme {
+		case "wss":
+			normalized.Set("Origin", "https://"+parsed.Host)
+			return normalized
+		case "ws":
+			normalized.Set("Origin", "http://"+parsed.Host)
+			return normalized
+		case "https", "http":
+			normalized.Set("Origin", parsed.Scheme+"://"+parsed.Host)
+			return normalized
+		}
 	}
 	scheme := strings.TrimSpace(normalized.Get("X-Forwarded-Proto"))
 	if scheme == "" {

--- a/images/examples/openclaw/acpbridge/main_test.go
+++ b/images/examples/openclaw/acpbridge/main_test.go
@@ -174,9 +174,10 @@ func TestGatewayProxyTrustedProxyRewritesConnectHandshake(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	upstreamWSURL := "ws" + strings.TrimPrefix(upstream.URL, "http")
 	proxyURL, shutdown, err := startGatewayProxy(
 		ctx,
-		"ws"+strings.TrimPrefix(upstream.URL, "http"),
+		upstreamWSURL,
 		http.Header{
 			"X-Forwarded-User":  []string{"spritz-acp-bridge"},
 			"X-Forwarded-Email": []string{"spritz-acp-bridge@example.invalid"},
@@ -230,8 +231,8 @@ func TestGatewayProxyTrustedProxyRewritesConnectHandshake(t *testing.T) {
 	}
 
 	headers := <-upstreamSeenHeaders
-	if got := headers.Get("Origin"); got != "https://localhost" {
-		t.Fatalf("Origin = %q, want %q", got, "https://localhost")
+	if got := headers.Get("Origin"); got != upstream.URL {
+		t.Fatalf("Origin = %q, want %q", got, upstream.URL)
 	}
 
 	payload := <-upstreamSeenPayload
@@ -254,6 +255,19 @@ func TestGatewayProxyTrustedProxyRewritesConnectHandshake(t *testing.T) {
 	}
 	if _, exists := params["device"]; exists {
 		t.Fatalf("device = %#v, want omitted", params["device"])
+	}
+}
+
+func TestNormalizeGatewayProxyHeadersKeepsExplicitOrigin(t *testing.T) {
+	headers := normalizeGatewayProxyHeaders(
+		http.Header{
+			"Origin": []string{"https://staging.example.com"},
+		},
+		"ws://127.0.0.1:8080",
+		true,
+	)
+	if got := headers.Get("Origin"); got != "https://staging.example.com" {
+		t.Fatalf("Origin = %q, want %q", got, "https://staging.example.com")
 	}
 }
 


### PR DESCRIPTION
## Summary
- derive the trusted-proxy  header from the actual gateway upstream URL
- keep explicitly provided  headers unchanged
- update ACP bridge regression coverage for the local OpenClaw gateway hop

## Testing
- cd images/examples/openclaw/acpbridge && go test ./...
- git diff --check