### PR TITLE
fix(openclaw): bundle acpx runtime dependency

### DIFF
--- a/images/examples/openclaw/Dockerfile
+++ b/images/examples/openclaw/Dockerfile
@@ -58,7 +58,10 @@ RUN apt-get update \
     xdg-utils \
   && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g "openclaw@${OPENCLAW_VERSION}"
+RUN npm install -g "openclaw@${OPENCLAW_VERSION}" \
+  && cd /usr/local/lib/node_modules/openclaw/extensions/acpx \
+  && npm install --omit=dev --no-save \
+  && test -x /usr/local/lib/node_modules/openclaw/extensions/acpx/node_modules/.bin/acpx
 
 RUN useradd -m -s /bin/bash dev \
   && mkdir -p /home/dev/.openclaw \


### PR DESCRIPTION
## Summary
- install the OpenClaw acpx plugin dependency during image build instead of relying on runtime plugin-local install
- fail the image build if the expected bundled acpx binary is missing
- remove the EACCES path that prevented ACP prompts from producing responses

## Testing
- git diff --check
- live staging validation showed the current image fails because `extensions/acpx/node_modules/.bin/acpx` is missing and runtime install hits EACCES
