### PR TITLE
fix(openclaw): generate ACP compat module at image build

### DIFF
--- a/images/examples/openclaw/Dockerfile
+++ b/images/examples/openclaw/Dockerfile
@@ -28,6 +28,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 ARG OPENCLAW_VERSION=latest
 
+COPY examples/openclaw/generate-openclaw-acp-compat.mjs /usr/local/bin/spritz-generate-openclaw-acp-compat
+
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     bash \
@@ -59,6 +61,8 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 RUN npm install -g "openclaw@${OPENCLAW_VERSION}" \
+  && node /usr/local/bin/spritz-generate-openclaw-acp-compat /usr/local/lib/node_modules/openclaw \
+  && test -f /usr/local/lib/node_modules/openclaw/dist/spritz-acp-compat.js \
   && cd /usr/local/lib/node_modules/openclaw/extensions/acpx \
   && npm install --omit=dev --no-save \
   && test -x /usr/local/lib/node_modules/openclaw/extensions/acpx/node_modules/.bin/acpx

--- a/images/examples/openclaw/acp-wrapper.mjs
+++ b/images/examples/openclaw/acp-wrapper.mjs
@@ -203,25 +203,21 @@ async function importOpenclawDependency(specifier, env = process.env) {
   return await import(pathToFileURL(resolvedPath).href);
 }
 
-async function importOpenclawModule(relativePath, env = process.env) {
+export async function loadOpenclawCompat(env = process.env) {
   const packageRoot = resolveOpenclawPackageRoot(env);
-  const resolvedPath = path.join(packageRoot, relativePath);
+  const resolvedPath = path.join(packageRoot, "dist", "spritz-acp-compat.js");
   return await import(pathToFileURL(resolvedPath).href);
 }
 
 async function serveSpritzOpenclawAcp(opts = {}, env = process.env) {
   const sdk = await importOpenclawDependency("@agentclientprotocol/sdk", env);
-  const { loadConfig } = await importOpenclawModule("dist/config/config.js", env);
-  const { buildGatewayConnectionDetails } = await importOpenclawModule(
-    "dist/gateway/call.js",
-    env,
-  );
-  const { GatewayClient } = await importOpenclawModule("dist/gateway/client.js", env);
-  const { resolveGatewayConnectionAuth } = await importOpenclawModule(
-    "dist/gateway/connection-auth.js",
-    env,
-  );
-  const { AcpGatewayAgent } = await importOpenclawModule("dist/acp/translator.js", env);
+  const {
+    AcpGatewayAgent,
+    GatewayClient,
+    buildGatewayConnectionDetails,
+    loadConfig,
+    resolveGatewayConnectionAuth,
+  } = await loadOpenclawCompat(env);
 
   const AgentSideConnection =
     sdk.AgentSideConnection ?? sdk.default?.AgentSideConnection;

--- a/images/examples/openclaw/acp-wrapper.test.mjs
+++ b/images/examples/openclaw/acp-wrapper.test.mjs
@@ -1,8 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 import {
   buildGatewayClientOptions,
+  loadOpenclawCompat,
   parseArgs,
   useTrustedProxyControlUiBridge,
 } from './acp-wrapper.mjs';
@@ -65,4 +69,31 @@ test('useTrustedProxyControlUiBridge reads truthy env values', () => {
   assert.equal(useTrustedProxyControlUiBridge({ SPRITZ_OPENCLAW_ACP_USE_CONTROL_UI_BRIDGE: 'true' }), true);
   assert.equal(useTrustedProxyControlUiBridge({ SPRITZ_OPENCLAW_ACP_USE_CONTROL_UI_BRIDGE: '0' }), false);
   assert.equal(useTrustedProxyControlUiBridge({}), false);
+});
+
+test('loadOpenclawCompat loads the generated stable compat module from the package root', async () => {
+  const packageRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'spritz-openclaw-package-'));
+  const distDir = path.join(packageRoot, 'dist');
+  fs.mkdirSync(distDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(distDir, 'spritz-acp-compat.js'),
+    [
+      'export class GatewayClient {}',
+      'export class AcpGatewayAgent {}',
+      'export function loadConfig() { return { ok: true }; }',
+      'export function buildGatewayConnectionDetails() { return { url: "ws://127.0.0.1:8080" }; }',
+      'export async function resolveGatewayConnectionAuth() { return { token: "secret" }; }',
+      '',
+    ].join('\n'),
+  );
+
+  const compat = await loadOpenclawCompat({
+    SPRITZ_OPENCLAW_PACKAGE_ROOT: packageRoot,
+  });
+
+  assert.equal(compat.GatewayClient.name, 'GatewayClient');
+  assert.equal(compat.AcpGatewayAgent.name, 'AcpGatewayAgent');
+  assert.deepEqual(compat.loadConfig(), { ok: true });
+  assert.equal(compat.buildGatewayConnectionDetails().url, 'ws://127.0.0.1:8080');
+  assert.deepEqual(await compat.resolveGatewayConnectionAuth(), { token: 'secret' });
 });

--- a/images/examples/openclaw/generate-openclaw-acp-compat.mjs
+++ b/images/examples/openclaw/generate-openclaw-acp-compat.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const ACP_CLI_COMPAT_BASENAME = "spritz-acp-cli-compat.js";
+export const ACP_COMPAT_BASENAME = "spritz-acp-compat.js";
+
+function requireMatch(source, pattern, label) {
+  const match = source.match(pattern);
+  if (!match?.[1]) {
+    throw new Error(`Failed to resolve ${label} from the installed OpenClaw ACP bundle.`);
+  }
+  return match[1];
+}
+
+function assertReadableFile(filePath, label) {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`${label} not found: ${filePath}`);
+  }
+}
+
+export function resolveOpenclawPackageRoot(args = process.argv.slice(2), env = process.env) {
+  const cliValue = args[0]?.trim();
+  if (cliValue) {
+    return path.resolve(cliValue);
+  }
+  const envValue = env.OPENCLAW_PACKAGE_ROOT?.trim();
+  if (envValue) {
+    return path.resolve(envValue);
+  }
+  return "/usr/local/lib/node_modules/openclaw";
+}
+
+export function selectAcpCliBundle(distDir) {
+  const entry = fs
+    .readdirSync(distDir)
+    .filter((name) => /^acp-cli-.*\.js$/.test(name))
+    .sort()[0];
+  if (!entry) {
+    throw new Error(`No acp-cli bundle found under ${distDir}`);
+  }
+  return entry;
+}
+
+export function resolveAcpCliDependencies(acpCliSource) {
+  return {
+    callBasename: requireMatch(
+      acpCliSource,
+      /import\s+\{[^}]*GatewayClient[^}]*buildGatewayConnectionDetails[^}]*\}\s+from\s+"\.\/([^"]+)"/,
+      "GatewayClient/buildGatewayConnectionDetails bundle",
+    ),
+    connectionAuthBasename: requireMatch(
+      acpCliSource,
+      /import\s+\{[^}]*resolveGatewayConnectionAuth[^}]*\}\s+from\s+"\.\/([^"]+)"/,
+      "resolveGatewayConnectionAuth bundle",
+    ),
+    messageChannelBasename: requireMatch(
+      acpCliSource,
+      /import\s+\{[^}]*GATEWAY_CLIENT_NAMES[^}]*GATEWAY_CLIENT_MODES[^}]*\}\s+from\s+"\.\/([^"]+)"/,
+      "gateway client constants bundle",
+    ),
+  };
+}
+
+export function buildAcpCliCompatSource(acpCliSource) {
+  if (!acpCliSource.includes("serveAcpGateway")) {
+    throw new Error("Installed OpenClaw ACP bundle is missing serveAcpGateway.");
+  }
+  if (!acpCliSource.includes("AcpGatewayAgent")) {
+    throw new Error("Installed OpenClaw ACP bundle is missing AcpGatewayAgent.");
+  }
+  return `${acpCliSource}\nexport { AcpGatewayAgent, serveAcpGateway };\n`;
+}
+
+export function buildCompatModuleSource(params) {
+  return `import { loadConfig } from "./index.js";
+import * as callModule from "./${params.callBasename}";
+import * as connectionAuthModule from "./${params.connectionAuthBasename}";
+import * as messageChannelModule from "./${params.messageChannelBasename}";
+import {
+  AcpGatewayAgent,
+  registerAcpCli,
+  serveAcpGateway,
+} from "./${ACP_CLI_COMPAT_BASENAME}";
+
+function pickNamedFunction(moduleNs, name) {
+  for (const value of Object.values(moduleNs)) {
+    if (typeof value === "function" && value.name === name) {
+      return value;
+    }
+  }
+  throw new Error(\`OpenClaw ACP compat export not found: \${name}\`);
+}
+
+function pickNamedObject(moduleNs, name) {
+  for (const value of Object.values(moduleNs)) {
+    if (value && typeof value === "object" && value.constructor === Object && name in value) {
+      return value;
+    }
+  }
+  throw new Error(\`OpenClaw ACP compat object not found: \${name}\`);
+}
+
+const GatewayClient = pickNamedFunction(callModule, "GatewayClient");
+const buildGatewayConnectionDetails = pickNamedFunction(
+  callModule,
+  "buildGatewayConnectionDetails",
+);
+const resolveGatewayConnectionAuth = pickNamedFunction(
+  connectionAuthModule,
+  "resolveGatewayConnectionAuth",
+);
+const GATEWAY_CLIENT_NAMES = pickNamedObject(messageChannelModule, "CONTROL_UI");
+const GATEWAY_CLIENT_MODES = pickNamedObject(messageChannelModule, "WEBCHAT");
+
+export {
+  AcpGatewayAgent,
+  GatewayClient,
+  GATEWAY_CLIENT_MODES,
+  GATEWAY_CLIENT_NAMES,
+  buildGatewayConnectionDetails,
+  loadConfig,
+  registerAcpCli,
+  resolveGatewayConnectionAuth,
+  serveAcpGateway,
+};
+`;
+}
+
+export function generateOpenclawAcpCompat(packageRoot) {
+  const distDir = path.join(packageRoot, "dist");
+  assertReadableFile(packageRoot, "OpenClaw package root");
+  assertReadableFile(distDir, "OpenClaw dist directory");
+
+  const acpCliBasename = selectAcpCliBundle(distDir);
+  const acpCliPath = path.join(distDir, acpCliBasename);
+  const acpCliSource = fs.readFileSync(acpCliPath, "utf8");
+  const dependencies = resolveAcpCliDependencies(acpCliSource);
+
+  const callPath = path.join(distDir, dependencies.callBasename);
+  const connectionAuthPath = path.join(distDir, dependencies.connectionAuthBasename);
+  const messageChannelPath = path.join(distDir, dependencies.messageChannelBasename);
+  const indexPath = path.join(distDir, "index.js");
+
+  assertReadableFile(callPath, "OpenClaw call bundle");
+  assertReadableFile(connectionAuthPath, "OpenClaw connection-auth bundle");
+  assertReadableFile(messageChannelPath, "OpenClaw message-channel bundle");
+  assertReadableFile(indexPath, "OpenClaw dist index");
+
+  const acpCliCompatPath = path.join(distDir, ACP_CLI_COMPAT_BASENAME);
+  const compatPath = path.join(distDir, ACP_COMPAT_BASENAME);
+
+  fs.writeFileSync(acpCliCompatPath, buildAcpCliCompatSource(acpCliSource));
+  fs.writeFileSync(
+    compatPath,
+    buildCompatModuleSource({
+      ...dependencies,
+      acpCliBasename,
+    }),
+  );
+
+  return {
+    acpCliBasename,
+    acpCliCompatPath,
+    compatPath,
+    ...dependencies,
+  };
+}
+
+async function main() {
+  const packageRoot = resolveOpenclawPackageRoot();
+  const result = generateOpenclawAcpCompat(packageRoot);
+  process.stdout.write(
+    `${JSON.stringify({
+      packageRoot,
+      compatPath: result.compatPath,
+      acpCliCompatPath: result.acpCliCompatPath,
+      callBasename: result.callBasename,
+      connectionAuthBasename: result.connectionAuthBasename,
+      messageChannelBasename: result.messageChannelBasename,
+    })}\n`,
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(String(error));
+    process.exit(1);
+  });
+}

--- a/images/examples/openclaw/generate-openclaw-acp-compat.test.mjs
+++ b/images/examples/openclaw/generate-openclaw-acp-compat.test.mjs
@@ -1,0 +1,104 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import {
+  ACP_CLI_COMPAT_BASENAME,
+  ACP_COMPAT_BASENAME,
+  generateOpenclawAcpCompat,
+  resolveAcpCliDependencies,
+} from "./generate-openclaw-acp-compat.mjs";
+
+function makeTempPackageRoot() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "spritz-openclaw-compat-"));
+}
+
+test("resolveAcpCliDependencies extracts the hashed bundles imported by acp-cli", () => {
+  const dependencies = resolveAcpCliDependencies(`
+    import { h as GATEWAY_CLIENT_NAMES, m as GATEWAY_CLIENT_MODES } from "./message-channel-abc123.js";
+    import { p as GatewayClient, t as buildGatewayConnectionDetails } from "./call-def456.js";
+    import { t as resolveGatewayConnectionAuth } from "./connection-auth-ghi789.js";
+  `);
+
+  assert.deepEqual(dependencies, {
+    callBasename: "call-def456.js",
+    connectionAuthBasename: "connection-auth-ghi789.js",
+    messageChannelBasename: "message-channel-abc123.js",
+  });
+});
+
+test("generateOpenclawAcpCompat writes stable compat modules for the installed package", async () => {
+  const packageRoot = makeTempPackageRoot();
+  const distDir = path.join(packageRoot, "dist");
+  fs.mkdirSync(distDir, { recursive: true });
+
+  fs.writeFileSync(
+    path.join(distDir, "index.js"),
+    'export function loadConfig() { return { gateway: { mode: "local" } }; }\n',
+  );
+  fs.writeFileSync(
+    path.join(distDir, "call-demo.js"),
+    [
+      'export class GatewayClient {}',
+      'export function buildGatewayConnectionDetails() { return { url: "ws://127.0.0.1:8080", urlSource: "local loopback" }; }',
+      "",
+    ].join("\n"),
+  );
+  fs.writeFileSync(
+    path.join(distDir, "connection-auth-demo.js"),
+    'export async function resolveGatewayConnectionAuth() { return { token: "token" }; }\n',
+  );
+  fs.writeFileSync(
+    path.join(distDir, "message-channel-demo.js"),
+    [
+      'export const GATEWAY_CLIENT_NAMES = { CLI: "cli", CONTROL_UI: "openclaw-control-ui" };',
+      'export const GATEWAY_CLIENT_MODES = { CLI: "cli", WEBCHAT: "webchat" };',
+      "",
+    ].join("\n"),
+  );
+  fs.writeFileSync(
+    path.join(distDir, "acp-cli-demo.js"),
+    [
+      'import { GATEWAY_CLIENT_NAMES, GATEWAY_CLIENT_MODES } from "./message-channel-demo.js";',
+      'import { GatewayClient, buildGatewayConnectionDetails } from "./call-demo.js";',
+      'import { resolveGatewayConnectionAuth } from "./connection-auth-demo.js";',
+      "class AcpGatewayAgent {}",
+      "async function serveAcpGateway() {",
+      "  return {",
+      "    GatewayClient,",
+      "    buildGatewayConnectionDetails,",
+      "    resolveGatewayConnectionAuth,",
+      "    GATEWAY_CLIENT_NAMES,",
+      "    GATEWAY_CLIENT_MODES,",
+      "  };",
+      "}",
+      "function registerAcpCli() {}",
+      "export { registerAcpCli };",
+      "",
+    ].join("\n"),
+  );
+
+  const result = generateOpenclawAcpCompat(packageRoot);
+
+  assert.equal(result.callBasename, "call-demo.js");
+  assert.equal(result.connectionAuthBasename, "connection-auth-demo.js");
+  assert.equal(result.messageChannelBasename, "message-channel-demo.js");
+  assert.equal(path.basename(result.acpCliCompatPath), ACP_CLI_COMPAT_BASENAME);
+  assert.equal(path.basename(result.compatPath), ACP_COMPAT_BASENAME);
+
+  const compatModule = await import(pathToFileURL(result.compatPath).href);
+  const acpCliCompatModule = await import(pathToFileURL(result.acpCliCompatPath).href);
+
+  assert.equal(typeof compatModule.loadConfig, "function");
+  assert.equal(compatModule.GatewayClient.name, "GatewayClient");
+  assert.equal(compatModule.buildGatewayConnectionDetails().url, "ws://127.0.0.1:8080");
+  assert.deepEqual(await compatModule.resolveGatewayConnectionAuth(), { token: "token" });
+  assert.equal(compatModule.GATEWAY_CLIENT_NAMES.CONTROL_UI, "openclaw-control-ui");
+  assert.equal(compatModule.GATEWAY_CLIENT_MODES.WEBCHAT, "webchat");
+  assert.equal(acpCliCompatModule.AcpGatewayAgent.name, "AcpGatewayAgent");
+  assert.equal(typeof acpCliCompatModule.serveAcpGateway, "function");
+  assert.equal(typeof acpCliCompatModule.registerAcpCli, "function");
+});

--- a/images/examples/openclaw/image-contract.test.mjs
+++ b/images/examples/openclaw/image-contract.test.mjs
@@ -8,6 +8,28 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const dockerfilePath = path.join(__dirname, "Dockerfile");
 const entrypointPath = path.join(__dirname, "entrypoint.sh");
 
+test("openclaw image copies the ACP compat generator into /usr/local/bin", () => {
+  const dockerfile = fs.readFileSync(dockerfilePath, "utf8");
+
+  assert.match(
+    dockerfile,
+    /COPY examples\/openclaw\/generate-openclaw-acp-compat\.mjs \/usr\/local\/bin\/spritz-generate-openclaw-acp-compat/,
+  );
+});
+
+test("openclaw image generates the stable ACP compat module after installing OpenClaw", () => {
+  const dockerfile = fs.readFileSync(dockerfilePath, "utf8");
+
+  assert.match(
+    dockerfile,
+    /node \/usr\/local\/bin\/spritz-generate-openclaw-acp-compat \/usr\/local\/lib\/node_modules\/openclaw/,
+  );
+  assert.match(
+    dockerfile,
+    /test -f \/usr\/local\/lib\/node_modules\/openclaw\/dist\/spritz-acp-compat\.js/,
+  );
+});
+
 test("openclaw image copies the ACP wrapper into /usr/local/bin", () => {
   const dockerfile = fs.readFileSync(dockerfilePath, "utf8");
 


### PR DESCRIPTION
## Summary
- generate a stable OpenClaw ACP compat module during image build from the installed package
- load that stable compat module from the wrapper instead of hardcoded dead OpenClaw internals
- cover the generator, wrapper, and image contract with focused tests

## Testing
- node --test images/examples/openclaw/image-contract.test.mjs images/examples/openclaw/generate-openclaw-acp-compat.test.mjs images/examples/openclaw/acp-wrapper.test.mjs
- node --check images/examples/openclaw/generate-openclaw-acp-compat.mjs
- node --check images/examples/openclaw/acp-wrapper.mjs