### PR TITLE
fix(openclaw): map ACP sessions onto gateway session keys

### DIFF
--- a/images/examples/openclaw/README.md
+++ b/images/examples/openclaw/README.md
@@ -48,6 +48,8 @@ The image also starts an internal ACP compatibility bridge by default:
 - listen address: `0.0.0.0:2529`
 - WebSocket path: `/`
 - backend: per-connection `spritz-openclaw-acp-wrapper` stdio bridge to the local gateway over loopback
+- session mapping: ACP session IDs are deterministically mapped onto normal OpenClaw
+  agent-scoped gateway session keys so reconnects work without ACP clients knowing OpenClaw internals
 
 This keeps the Spritz ACP contract stable even though OpenClaw's native ACP support is currently
 stdio-only.
@@ -71,6 +73,8 @@ Auto-start related runtime overrides:
 - `SPRITZ_OPENCLAW_ACP_GATEWAY_HEADERS_JSON` (optional; JSON object of headers injected into the bridge's upstream gateway connection)
 - `SPRITZ_OPENCLAW_ACP_TRUSTED_PROXY_USER` (optional; default internal trusted-proxy user identity)
 - `SPRITZ_OPENCLAW_ACP_TRUSTED_PROXY_EMAIL` (optional; default internal trusted-proxy email identity)
+- `SPRITZ_OPENCLAW_ACP_FALLBACK_AGENT_ID` (default: `main`; agent id used when the bridge maps ACP UUID session IDs onto OpenClaw gateway session keys)
+- `SPRITZ_OPENCLAW_ACP_FALLBACK_SESSION_PREFIX` (default: `spritz-acp`; session-key namespace used for ACP-managed gateway transcripts)
 - `SPRITZ_OPENCLAW_ACP_ALLOW_INSECURE_PRIVATE_WS` (default: `0`; only needed when overriding the bridge target away from loopback onto a trusted private-network `ws://` endpoint)
 
 When the OpenClaw gateway itself is configured with `gateway.auth.mode="trusted-proxy"`, the

--- a/images/examples/openclaw/acp-wrapper.mjs
+++ b/images/examples/openclaw/acp-wrapper.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { createRequire } from "node:module";
@@ -18,6 +19,10 @@ const GATEWAY_CLIENT_MODES = {
 
 const TRUTHY_VALUES = new Set(["1", "true", "yes", "on"]);
 const DEFAULT_OPENCLAW_PACKAGE_ROOT = "/usr/local/lib/node_modules/openclaw";
+const DEFAULT_FALLBACK_AGENT_ID = "main";
+const DEFAULT_FALLBACK_SESSION_PREFIX = "spritz-acp";
+const UUIDISH_SESSION_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 /**
  * Returns whether the image-owned ACP bridge should impersonate a trusted-proxy
@@ -29,6 +34,144 @@ export function useTrustedProxyControlUiBridge(env = process.env) {
     return false;
   }
   return TRUTHY_VALUES.has(raw.trim().toLowerCase());
+}
+
+function normalizeBridgeToken(value, fallback) {
+  if (typeof value !== "string") {
+    return fallback;
+  }
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return normalized || fallback;
+}
+
+function readMetaString(record, keys) {
+  for (const key of keys) {
+    const value = record?.[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function readMetaBool(record, keys) {
+  for (const key of keys) {
+    const value = record?.[key];
+    if (typeof value === "boolean") {
+      return value;
+    }
+    if (typeof value === "string") {
+      const normalized = value.trim().toLowerCase();
+      if (normalized === "true") return true;
+      if (normalized === "false") return false;
+    }
+  }
+  return undefined;
+}
+
+function parseSessionMeta(meta) {
+  if (!meta || typeof meta !== "object" || Array.isArray(meta)) {
+    return {};
+  }
+  return {
+    sessionKey: readMetaString(meta, ["sessionKey", "session", "key"]),
+    sessionLabel: readMetaString(meta, ["sessionLabel", "label"]),
+    resetSession: readMetaBool(meta, ["resetSession", "reset"]),
+    requireExisting: readMetaBool(meta, ["requireExistingSession", "requireExisting"]),
+    prefixCwd: readMetaBool(meta, ["prefixCwd"]),
+  };
+}
+
+/**
+ * Returns the deterministic gateway session key used for ACP session IDs that
+ * do not already carry an explicit gateway session key.
+ */
+export function buildBridgeFallbackSessionKey(sessionId, env = process.env) {
+  const normalizedSessionID =
+    typeof sessionId === "string" && sessionId.trim() ? sessionId.trim() : randomUUID();
+  const agentId = normalizeBridgeToken(
+    env.SPRITZ_OPENCLAW_ACP_FALLBACK_AGENT_ID,
+    DEFAULT_FALLBACK_AGENT_ID,
+  );
+  const prefix = normalizeBridgeToken(
+    env.SPRITZ_OPENCLAW_ACP_FALLBACK_SESSION_PREFIX,
+    DEFAULT_FALLBACK_SESSION_PREFIX,
+  );
+  return `agent:${agentId}:${prefix}:${normalizedSessionID}`;
+}
+
+/**
+ * Preserves explicit/listed gateway session keys and only maps ACP-generated
+ * UUID session IDs onto deterministic OpenClaw gateway session keys.
+ */
+export function resolveBridgeFallbackSessionKey(sessionId, env = process.env) {
+  const normalized = typeof sessionId === "string" ? sessionId.trim() : "";
+  if (!normalized) {
+    return buildBridgeFallbackSessionKey("", env);
+  }
+  if (!UUIDISH_SESSION_ID_PATTERN.test(normalized)) {
+    return normalized;
+  }
+  return buildBridgeFallbackSessionKey(normalized, env);
+}
+
+/**
+ * Extends OpenClaw's ACP gateway agent so the default ACP session flow maps to
+ * normal agent-scoped gateway sessions instead of ACP runtime session keys.
+ */
+export function createSpritzAcpGatewayAgentClass(AcpGatewayAgent, env = process.env) {
+  return class SpritzOpenclawAcpGatewayAgent extends AcpGatewayAgent {
+    async newSession(params) {
+      if (params.mcpServers.length > 0) {
+        this.log(`ignoring ${params.mcpServers.length} MCP servers`);
+      }
+      this.enforceSessionCreateRateLimit("newSession");
+
+      const sessionId = randomUUID();
+      const meta = parseSessionMeta(params?._meta);
+      const sessionKey = await this.resolveSessionKeyFromMeta({
+        meta,
+        fallbackKey: resolveBridgeFallbackSessionKey(sessionId, env),
+      });
+
+      const session = this.sessionStore.createSession({
+        sessionId,
+        sessionKey,
+        cwd: params.cwd,
+      });
+      this.log(`newSession: ${session.sessionId} -> ${session.sessionKey}`);
+      await this.sendAvailableCommands(session.sessionId);
+      return { sessionId: session.sessionId };
+    }
+
+    async loadSession(params) {
+      if (params.mcpServers.length > 0) {
+        this.log(`ignoring ${params.mcpServers.length} MCP servers`);
+      }
+      if (!this.sessionStore.hasSession(params.sessionId)) {
+        this.enforceSessionCreateRateLimit("loadSession");
+      }
+
+      const meta = parseSessionMeta(params?._meta);
+      const sessionKey = await this.resolveSessionKeyFromMeta({
+        meta,
+        fallbackKey: resolveBridgeFallbackSessionKey(params.sessionId, env),
+      });
+
+      const session = this.sessionStore.createSession({
+        sessionId: params.sessionId,
+        sessionKey,
+        cwd: params.cwd,
+      });
+      this.log(`loadSession: ${session.sessionId} -> ${session.sessionKey}`);
+      await this.sendAvailableCommands(session.sessionId);
+      return {};
+    }
+  };
 }
 
 /**
@@ -330,9 +473,10 @@ async function serveSpritzOpenclawAcp(opts = {}, env = process.env) {
   const input = Writable.toWeb(process.stdout);
   const output = Readable.toWeb(process.stdin);
   const stream = ndJsonStream(input, output);
+  const SpritzAcpGatewayAgent = createSpritzAcpGatewayAgentClass(AcpGatewayAgent, env);
 
   new AgentSideConnection((connectionInstance) => {
-    agent = new AcpGatewayAgent(connectionInstance, gateway, opts);
+    agent = new SpritzAcpGatewayAgent(connectionInstance, gateway, opts);
     agent.start();
     return agent;
   }, stream);

--- a/images/examples/openclaw/acp-wrapper.test.mjs
+++ b/images/examples/openclaw/acp-wrapper.test.mjs
@@ -6,8 +6,11 @@ import path from 'node:path';
 
 import {
   buildGatewayClientOptions,
+  buildBridgeFallbackSessionKey,
+  createSpritzAcpGatewayAgentClass,
   loadOpenclawCompat,
   parseArgs,
+  resolveBridgeFallbackSessionKey,
   useTrustedProxyControlUiBridge,
 } from './acp-wrapper.mjs';
 
@@ -69,6 +72,85 @@ test('useTrustedProxyControlUiBridge reads truthy env values', () => {
   assert.equal(useTrustedProxyControlUiBridge({ SPRITZ_OPENCLAW_ACP_USE_CONTROL_UI_BRIDGE: 'true' }), true);
   assert.equal(useTrustedProxyControlUiBridge({ SPRITZ_OPENCLAW_ACP_USE_CONTROL_UI_BRIDGE: '0' }), false);
   assert.equal(useTrustedProxyControlUiBridge({}), false);
+});
+
+test('buildBridgeFallbackSessionKey maps ACP session ids onto normal agent-scoped gateway keys', () => {
+  const sessionKey = buildBridgeFallbackSessionKey('123e4567-e89b-42d3-a456-426614174000');
+
+  assert.equal(sessionKey, 'agent:main:spritz-acp:123e4567-e89b-42d3-a456-426614174000');
+});
+
+test('resolveBridgeFallbackSessionKey preserves existing gateway session keys', () => {
+  assert.equal(resolveBridgeFallbackSessionKey('agent:main:main'), 'agent:main:main');
+  assert.equal(resolveBridgeFallbackSessionKey('main'), 'main');
+  assert.equal(
+    resolveBridgeFallbackSessionKey('123e4567-e89b-42d3-a456-426614174000'),
+    'agent:main:spritz-acp:123e4567-e89b-42d3-a456-426614174000',
+  );
+});
+
+test('createSpritzAcpGatewayAgentClass uses mapped fallback keys for new and loaded sessions', async () => {
+  class FakeBaseAgent {
+    constructor() {
+      this.logged = [];
+      this.rateLimits = [];
+      this.sessionStore = {
+        entries: new Map(),
+        createSession: ({ sessionId, sessionKey, cwd }) => {
+          const session = { sessionId, sessionKey, cwd };
+          this.sessionStore.entries.set(sessionId, session);
+          return session;
+        },
+        hasSession: (sessionId) => this.sessionStore.entries.has(sessionId),
+      };
+      this.sentAvailableCommands = [];
+    }
+
+    log(message) {
+      this.logged.push(message);
+    }
+
+    enforceSessionCreateRateLimit(method) {
+      this.rateLimits.push(method);
+    }
+
+    async resolveSessionKeyFromMeta({ fallbackKey }) {
+      return fallbackKey;
+    }
+
+    async sendAvailableCommands(sessionId) {
+      this.sentAvailableCommands.push(sessionId);
+    }
+  }
+
+  const SpritzAgent = createSpritzAcpGatewayAgentClass(FakeBaseAgent, {});
+  const agent = new SpritzAgent();
+
+  const created = await agent.newSession({
+    cwd: '/home/dev',
+    mcpServers: [],
+  });
+
+  const createdSession = agent.sessionStore.entries.get(created.sessionId);
+  assert.match(created.sessionId, /^[0-9a-f-]{36}$/i);
+  assert.equal(
+    createdSession.sessionKey,
+    `agent:main:spritz-acp:${created.sessionId}`,
+  );
+
+  await agent.loadSession({
+    sessionId: created.sessionId,
+    cwd: '/home/dev',
+    mcpServers: [],
+  });
+
+  const loadedSession = agent.sessionStore.entries.get(created.sessionId);
+  assert.equal(
+    loadedSession.sessionKey,
+    `agent:main:spritz-acp:${created.sessionId}`,
+  );
+  assert.deepEqual(agent.rateLimits, ['newSession']);
+  assert.deepEqual(agent.sentAvailableCommands, [created.sessionId, created.sessionId]);
 });
 
 test('loadOpenclawCompat loads the generated stable compat module from the package root', async () => {


### PR DESCRIPTION
## Summary
- map ACP UUID session ids onto normal OpenClaw agent-scoped gateway session keys
- preserve explicit gateway session keys for ACP list/load flows
- document the wrapper session-key behavior and add focused wrapper tests

## Testing
- cd /Users/onur/repos/spritz && node --test images/examples/openclaw/acp-wrapper.test.mjs
- cd /Users/onur/repos/spritz && node --check images/examples/openclaw/acp-wrapper.mjs
- cd /Users/onur/repos/spritz && node --test images/examples/openclaw/image-contract.test.mjs images/examples/openclaw/generate-openclaw-acp-compat.test.mjs
- cd /Users/onur/repos/spritz && git diff --check
- cd /Users/onur/repos/spritz && bash -n images/examples/openclaw/entrypoint.sh