### PR TITLE
fix(ui): restore image preset selector

### DIFF
--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -39,7 +39,7 @@ const listSection = listEl?.closest('section');
 let activeTerminalSession = null;
 let activeTerminalName = '';
 let activeACPPage = null;
-let presetsInitialized = false;
+let presetController = null;
 let activePresetEnv = null;
 const authRedirectStorageKey = 'spritz-auth-redirected';
 let authRefreshInFlight = null;
@@ -1353,6 +1353,23 @@ function cleanupACP() {
   }
 }
 
+function setupPresets() {
+  if (presetController) return;
+  const module = window.SpritzPresetPanel;
+  if (!module || typeof module.setupPresetPanel !== 'function') return;
+  presetController = module.setupPresetPanel({
+    document,
+    form,
+    presets,
+    hideRepoInputs,
+    applyRepoDefaults,
+    normalizePresetEnv,
+    setActivePresetEnv(env) {
+      activePresetEnv = env;
+    },
+  });
+}
+
 function handleRoute() {
   const chatName = chatNameFromPath();
   if (window.location.hash === '#chat' || chatName) {
@@ -1444,12 +1461,7 @@ if (form && refreshBtn) {
 
       form.reset();
       activePresetEnv = null;
-      const presetSelect = document.getElementById('preset-select');
-      if (presetSelect) {
-        presetSelect.value = '';
-        const help = form.querySelector('.preset-help');
-        if (help) help.textContent = '';
-      }
+      if (presetController) presetController.reset();
       applyNameDefaults();
       applyRepoDefaults();
       applyUserConfigDefaults();

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -84,6 +84,7 @@ ttl: 8h"
     <script src="/config.js?v=__SPRITZ_UI_ASSET_VERSION__"></script>
     <script src="/acp-client.js?v=__SPRITZ_UI_ASSET_VERSION__"></script>
     <script src="/acp-page.js?v=__SPRITZ_UI_ASSET_VERSION__"></script>
+    <script src="/preset-panel.js?v=__SPRITZ_UI_ASSET_VERSION__"></script>
     <script src="/app.js?v=__SPRITZ_UI_ASSET_VERSION__"></script>
   </body>
 </html>

--- a/ui/public/preset-panel.js
+++ b/ui/public/preset-panel.js
@@ -1,0 +1,110 @@
+(function (root, factory) {
+  const exports = factory();
+  if (typeof module === 'object' && module.exports) {
+    module.exports = exports;
+  }
+  root.SpritzPresetPanel = exports;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+  function setupPresetPanel(options) {
+    const {
+      document,
+      form,
+      presets,
+      hideRepoInputs,
+      applyRepoDefaults,
+      normalizePresetEnv,
+      setActivePresetEnv,
+    } = options || {};
+
+    if (!document || !form || !Array.isArray(presets) || presets.length === 0) {
+      return null;
+    }
+
+    const existingSelect = document.getElementById('preset-select');
+    if (existingSelect) {
+      return {
+        reset() {
+          existingSelect.value = '';
+          const help = form.querySelector('.preset-help');
+          if (help) help.textContent = '';
+          setActivePresetEnv(null);
+        },
+      };
+    }
+
+    const imageInput = form.querySelector('input[name="image"]');
+    const repoInput = form.querySelector('input[name="repo"]');
+    const branchInput = form.querySelector('input[name="branch"]');
+    const ttlInput = form.querySelector('input[name="ttl"]');
+    if (!imageInput) {
+      return null;
+    }
+
+    if (typeof applyRepoDefaults === 'function') {
+      applyRepoDefaults();
+    }
+
+    const panel = document.createElement('div');
+    panel.className = 'preset-panel';
+
+    const label = document.createElement('label');
+    label.textContent = 'Preset';
+
+    const select = document.createElement('select');
+    select.id = 'preset-select';
+
+    const customOption = document.createElement('option');
+    customOption.value = '';
+    customOption.textContent = 'Custom';
+    select.append(customOption);
+
+    presets.forEach((preset, index) => {
+      const option = document.createElement('option');
+      option.value = String(index);
+      option.textContent = `${preset.name} (${preset.image})`;
+      select.append(option);
+    });
+
+    const help = document.createElement('small');
+    help.className = 'preset-help';
+
+    label.append(select);
+    panel.append(label, help);
+    form.prepend(panel);
+
+    const applyPreset = (preset) => {
+      if (!preset) return;
+      imageInput.value = preset.image || '';
+      if (!hideRepoInputs) {
+        if (repoInput && preset.repoUrl !== undefined) repoInput.value = preset.repoUrl || '';
+        if (branchInput && preset.branch !== undefined) branchInput.value = preset.branch || '';
+      }
+      if (ttlInput && preset.ttl !== undefined) ttlInput.value = preset.ttl || '';
+      help.textContent = preset.description || '';
+      setActivePresetEnv(typeof normalizePresetEnv === 'function' ? normalizePresetEnv(preset.env) : null);
+    };
+
+    const reset = () => {
+      select.value = '';
+      help.textContent = '';
+      setActivePresetEnv(null);
+    };
+
+    select.addEventListener('change', () => {
+      if (!select.value) {
+        reset();
+        return;
+      }
+      applyPreset(presets[Number(select.value)]);
+    });
+
+    if (!imageInput.value && presets[0]) {
+      select.value = '0';
+      applyPreset(presets[0]);
+    }
+
+    return { reset };
+  }
+
+  return { setupPresetPanel };
+});

--- a/ui/public/preset-panel.test.mjs
+++ b/ui/public/preset-panel.test.mjs
@@ -1,0 +1,219 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+class FakeElement {
+  constructor(tagName, ownerDocument) {
+    this.tagName = String(tagName || '').toLowerCase();
+    this.ownerDocument = ownerDocument;
+    this.children = [];
+    this.parentNode = null;
+    this.attributes = new Map();
+    this.listeners = new Map();
+    this.className = '';
+    this.hidden = false;
+    this.disabled = false;
+    this.value = '';
+    this._textContent = '';
+    this._id = '';
+  }
+
+  set id(value) {
+    this._id = String(value || '');
+    if (this._id) {
+      this.ownerDocument.byId.set(this._id, this);
+    }
+  }
+
+  get id() {
+    return this._id;
+  }
+
+  append(...items) {
+    for (const item of items) {
+      if (item === null || item === undefined) continue;
+      if (item instanceof FakeElement) {
+        item.parentNode = this;
+        this.children.push(item);
+        continue;
+      }
+      const textNode = new FakeElement('#text', this.ownerDocument);
+      textNode.textContent = String(item);
+      textNode.parentNode = this;
+      this.children.push(textNode);
+    }
+  }
+
+  prepend(...items) {
+    const prepared = [];
+    for (const item of items) {
+      if (item === null || item === undefined) continue;
+      if (item instanceof FakeElement) {
+        item.parentNode = this;
+        prepared.push(item);
+        continue;
+      }
+      const textNode = new FakeElement('#text', this.ownerDocument);
+      textNode.textContent = String(item);
+      textNode.parentNode = this;
+      prepared.push(textNode);
+    }
+    this.children = [...prepared, ...this.children];
+  }
+
+  addEventListener(type, handler) {
+    this.listeners.set(type, handler);
+  }
+
+  dispatchEvent(event) {
+    const handler = this.listeners.get(event.type);
+    if (handler) {
+      handler.call(this, event);
+    }
+  }
+
+  querySelector(selector) {
+    return this.ownerDocument.querySelectorWithin(this, selector);
+  }
+
+  set textContent(value) {
+    this._textContent = String(value || '');
+    this.children = [];
+  }
+
+  get textContent() {
+    if (this.children.length) {
+      return this.children.map((child) => child.textContent).join('');
+    }
+    return this._textContent;
+  }
+}
+
+class FakeDocument {
+  constructor() {
+    this.byId = new Map();
+  }
+
+  createElement(tagName) {
+    return new FakeElement(tagName, this);
+  }
+
+  getElementById(id) {
+    return this.byId.get(id) || null;
+  }
+
+  querySelectorWithin(root, selector) {
+    const match = (node) => {
+      if (!(node instanceof FakeElement)) return false;
+      if (selector === '.preset-help') {
+        return node.className.split(/\s+/).includes('preset-help');
+      }
+      if (selector === '#preset-select') {
+        return node.id === 'preset-select';
+      }
+      const inputNameMatch = selector.match(/^(input|textarea)\[name="([^"]+)"\]$/);
+      if (inputNameMatch) {
+        const [, tagName, name] = inputNameMatch;
+        return node.tagName === tagName && node.attributes.get('name') === name;
+      }
+      return false;
+    };
+
+    const stack = [...root.children];
+    while (stack.length) {
+      const node = stack.shift();
+      if (match(node)) return node;
+      stack.unshift(...node.children);
+    }
+    return null;
+  }
+}
+
+function namedField(document, tagName, name) {
+  const element = document.createElement(tagName);
+  element.attributes.set('name', name);
+  return element;
+}
+
+function buildFormFixture() {
+  const document = new FakeDocument();
+  const form = document.createElement('form');
+  const imageInput = namedField(document, 'input', 'image');
+  const repoInput = namedField(document, 'input', 'repo');
+  const branchInput = namedField(document, 'input', 'branch');
+  const ttlInput = namedField(document, 'input', 'ttl');
+  form.append(imageInput, repoInput, branchInput, ttlInput);
+  return { document, form, imageInput, repoInput, branchInput, ttlInput };
+}
+
+test('setupPresetPanel injects the preset selector and updates image fields', async () => {
+  const require = createRequire(import.meta.url);
+  const { setupPresetPanel } = require('./preset-panel.js');
+
+  const { document, form, imageInput, repoInput, branchInput, ttlInput } = buildFormFixture();
+  let activeEnv = null;
+  let repoDefaultsApplied = 0;
+  const presets = [
+    {
+      name: 'Starter Devbox',
+      image: 'spritz-starter:latest',
+      description: 'Starter image',
+      repoUrl: 'https://example.com/a.git',
+      branch: 'main',
+      ttl: '8h',
+      env: [{ name: 'FOO', value: 'bar' }],
+    },
+    {
+      name: 'OpenClaw Devbox',
+      image: 'spritz-openclaw:latest',
+      description: 'OpenClaw image',
+      repoUrl: 'https://example.com/b.git',
+      branch: 'staging',
+      ttl: '12h',
+      env: [{ name: 'BAZ', value: 'qux' }],
+    },
+  ];
+
+  const controller = setupPresetPanel({
+    document,
+    form,
+    presets,
+    hideRepoInputs: false,
+    applyRepoDefaults() {
+      repoDefaultsApplied += 1;
+    },
+    normalizePresetEnv(env) {
+      return env;
+    },
+    setActivePresetEnv(env) {
+      activeEnv = env;
+    },
+  });
+
+  assert.ok(controller, 'expected a preset controller');
+  assert.equal(repoDefaultsApplied, 1);
+
+  const presetSelect = document.getElementById('preset-select');
+  assert.ok(presetSelect, 'expected preset select to be injected');
+  assert.equal(imageInput.value, 'spritz-starter:latest');
+  assert.equal(repoInput.value, 'https://example.com/a.git');
+  assert.equal(branchInput.value, 'main');
+  assert.equal(ttlInput.value, '8h');
+  assert.deepEqual(activeEnv, [{ name: 'FOO', value: 'bar' }]);
+  assert.equal(form.querySelector('.preset-help').textContent, 'Starter image');
+
+  presetSelect.value = '1';
+  presetSelect.dispatchEvent({ type: 'change' });
+
+  assert.equal(imageInput.value, 'spritz-openclaw:latest');
+  assert.equal(repoInput.value, 'https://example.com/b.git');
+  assert.equal(branchInput.value, 'staging');
+  assert.equal(ttlInput.value, '12h');
+  assert.deepEqual(activeEnv, [{ name: 'BAZ', value: 'qux' }]);
+  assert.equal(form.querySelector('.preset-help').textContent, 'OpenClaw image');
+
+  controller.reset();
+  assert.equal(presetSelect.value, '');
+  assert.equal(form.querySelector('.preset-help').textContent, '');
+  assert.equal(activeEnv, null);
+});


### PR DESCRIPTION
## TL;DR
On staging, the create UI regressed: I can't choose the image I want to boot anymore.

## Summary
- restore preset/image selection wiring in the create form via a dedicated preset panel module
- load the preset panel before app startup and reset it cleanly after create
- add a focused regression test covering preset injection and image updates

## Review focus
- create-form preset wiring on the non-chat route
- preset reset behavior after spritz creation
- no regressions in plain static script loading order

## Test plan
- [x] `node --test ui/public/preset-panel.test.mjs`
- [x] `node --check ui/public/preset-panel.js`
- [x] `node --check ui/public/app.js`
