### PR TITLE
fix(api): decouple owner visibility from labels

### DIFF
--- a/api/acp_agents.go
+++ b/api/acp_agents.go
@@ -29,9 +29,6 @@ func (s *server) listACPAgents(c echo.Context) error {
 	if namespace != "" {
 		opts = append(opts, client.InNamespace(namespace))
 	}
-	if s.auth.enabled() && !principal.IsAdmin {
-		opts = append(opts, client.MatchingLabels{ownerLabelKey: ownerLabelValue(principal.ID)})
-	}
 	if err := s.client.List(c.Request().Context(), list, opts...); err != nil {
 		return writeError(c, http.StatusInternalServerError, err.Error())
 	}

--- a/api/acp_test.go
+++ b/api/acp_test.go
@@ -264,3 +264,40 @@ func TestListAndPatchACPConversationsByID(t *testing.T) {
 		t.Fatalf("expected patched conversation fields, got %#v", getPayload.Data.Spec)
 	}
 }
+
+func TestListACPAgentsUsesSpecOwnerWhenOwnerLabelMissing(t *testing.T) {
+	ownedMissingLabel := readyACPSpritz("tidy-otter", "user-1")
+	ownedMissingLabel.Labels = nil
+	mislabelledOtherOwner := readyACPSpritz("wrong-owner", "user-2")
+	mislabelledOtherOwner.Labels = map[string]string{ownerLabelKey: ownerLabelValue("user-1")}
+
+	s := newACPTestServer(t, ownedMissingLabel, mislabelledOtherOwner)
+	e := echo.New()
+	secured := e.Group("", s.authMiddleware())
+	secured.GET("/api/acp/agents", s.listACPAgents)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/acp/agents", nil)
+	req.Header.Set("X-Spritz-User-Id", "user-1")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var payload struct {
+		Status string `json:"status"`
+		Data   struct {
+			Items []acpAgentResponse `json:"items"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to decode agents response: %v", err)
+	}
+	if len(payload.Data.Items) != 1 {
+		t.Fatalf("expected exactly one ACP-ready agent, got %d", len(payload.Data.Items))
+	}
+	if payload.Data.Items[0].Spritz.Name != "tidy-otter" {
+		t.Fatalf("expected tidy-otter in ACP list, got %q", payload.Data.Items[0].Spritz.Name)
+	}
+}

--- a/api/main.go
+++ b/api/main.go
@@ -399,9 +399,6 @@ func (s *server) listSpritzes(c echo.Context) error {
 	if namespace != "" {
 		opts = append(opts, client.InNamespace(namespace))
 	}
-	if s.auth.enabled() && !principal.IsAdmin {
-		opts = append(opts, client.MatchingLabels{ownerLabelKey: ownerLabelValue(principal.ID)})
-	}
 
 	if err := s.client.List(c.Request().Context(), list, opts...); err != nil {
 		return writeError(c, http.StatusInternalServerError, err.Error())

--- a/api/main_owner_visibility_test.go
+++ b/api/main_owner_visibility_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	spritzv1 "spritz.sh/operator/api/v1"
+)
+
+func newListSpritzTestServer(t *testing.T, objects ...client.Object) *server {
+	t.Helper()
+	scheme := newTestSpritzScheme(t)
+	builder := fake.NewClientBuilder().WithScheme(scheme)
+	if len(objects) > 0 {
+		builder = builder.WithObjects(objects...)
+	}
+	return &server{
+		client:    builder.Build(),
+		scheme:    scheme,
+		namespace: "spritz-test",
+		auth: authConfig{
+			mode:     authModeHeader,
+			headerID: "X-Spritz-User-Id",
+		},
+		internalAuth: internalAuthConfig{enabled: false},
+	}
+}
+
+func spritzForOwner(name, ownerID string, labels map[string]string) *spritzv1.Spritz {
+	return &spritzv1.Spritz{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "spritz-test",
+			Labels:    labels,
+		},
+		Spec: spritzv1.SpritzSpec{
+			Image: "example.com/spritz:latest",
+			Owner: spritzv1.SpritzOwner{ID: ownerID},
+		},
+		Status: spritzv1.SpritzStatus{Phase: "Ready"},
+	}
+}
+
+func TestListSpritzesUsesSpecOwnerWhenOwnerLabelMissing(t *testing.T) {
+	ownedMissingLabel := spritzForOwner("tidy-otter", "user-1", nil)
+	mislabelledOtherOwner := spritzForOwner("wrong-owner", "user-2", map[string]string{
+		ownerLabelKey: ownerLabelValue("user-1"),
+	})
+
+	s := newListSpritzTestServer(t, ownedMissingLabel, mislabelledOtherOwner)
+	e := echo.New()
+	secured := e.Group("", s.authMiddleware())
+	secured.GET("/api/spritzes", s.listSpritzes)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/spritzes", nil)
+	req.Header.Set("X-Spritz-User-Id", "user-1")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var payload struct {
+		Status string `json:"status"`
+		Data   struct {
+			Items []spritzv1.Spritz `json:"items"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to decode list response: %v", err)
+	}
+	if len(payload.Data.Items) != 1 {
+		t.Fatalf("expected exactly one visible spritz, got %d", len(payload.Data.Items))
+	}
+	if payload.Data.Items[0].Name != "tidy-otter" {
+		t.Fatalf("expected tidy-otter, got %q", payload.Data.Items[0].Name)
+	}
+}

--- a/operator/controllers/owner_label_test.go
+++ b/operator/controllers/owner_label_test.go
@@ -1,0 +1,45 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	spritzv1 "spritz.sh/operator/api/v1"
+)
+
+func TestReconcileLifecycleEnsuresOwnerLabel(t *testing.T) {
+	scheme := newControllerTestScheme(t)
+	spritz := &spritzv1.Spritz{
+		ObjectMeta: metav1.ObjectMeta{Name: "tidy-otter", Namespace: "spritz-test"},
+		Spec: spritzv1.SpritzSpec{
+			Image: "example.com/openclaw:latest",
+			Owner: spritzv1.SpritzOwner{ID: "user-1"},
+		},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(spritz).Build()
+	reconciler := &SpritzReconciler{Client: k8sClient, Scheme: scheme}
+
+	done, err := reconciler.reconcileLifecycle(context.Background(), spritz)
+	if err != nil {
+		t.Fatalf("reconcileLifecycle returned error: %v", err)
+	}
+	if !done {
+		t.Fatal("expected reconcileLifecycle to request a requeue after updating metadata")
+	}
+
+	stored := &spritzv1.Spritz{}
+	if err := k8sClient.Get(context.Background(), client.ObjectKey{Name: spritz.Name, Namespace: spritz.Namespace}, stored); err != nil {
+		t.Fatalf("failed to load updated spritz: %v", err)
+	}
+	if !controllerutil.ContainsFinalizer(stored, spritzFinalizer) {
+		t.Fatalf("expected finalizer %q to be set", spritzFinalizer)
+	}
+	if stored.Labels["spritz.sh/owner"] != ownerLabelValue(spritz.Spec.Owner.ID) {
+		t.Fatalf("expected owner label %q, got %#v", ownerLabelValue(spritz.Spec.Owner.ID), stored.Labels)
+	}
+}

--- a/operator/controllers/spritz_controller.go
+++ b/operator/controllers/spritz_controller.go
@@ -36,6 +36,7 @@ const (
 	defaultSSHMode             = "service"
 	spritzContainerName        = "spritz"
 	spritzFinalizer            = "spritz.sh/finalizer"
+	ownerLabelKey             = "spritz.sh/owner"
 	defaultTTLGrace            = 5 * time.Minute
 	defaultRepoInitImage       = "alpine/git:2.45.2"
 	repoAuthMountPath          = "/var/run/spritz/repo-auth"
@@ -203,8 +204,12 @@ func (r *SpritzReconciler) reconcileLifecycle(ctx context.Context, spritz *sprit
 		return true, nil
 	}
 
+	metadataUpdated := reconcileSpritzMetadata(spritz)
 	if !controllerutil.ContainsFinalizer(spritz, spritzFinalizer) {
 		controllerutil.AddFinalizer(spritz, spritzFinalizer)
+		metadataUpdated = true
+	}
+	if metadataUpdated {
 		if err := r.Update(ctx, spritz); err != nil {
 			return true, err
 		}
@@ -212,6 +217,22 @@ func (r *SpritzReconciler) reconcileLifecycle(ctx context.Context, spritz *sprit
 	}
 
 	return false, nil
+}
+
+func reconcileSpritzMetadata(spritz *spritzv1.Spritz) bool {
+	ownerID := strings.TrimSpace(spritz.Spec.Owner.ID)
+	if ownerID == "" {
+		return false
+	}
+	desiredOwnerLabel := ownerLabelValue(ownerID)
+	if spritz.Labels == nil {
+		spritz.Labels = map[string]string{}
+	}
+	if spritz.Labels[ownerLabelKey] == desiredOwnerLabel {
+		return false
+	}
+	spritz.Labels[ownerLabelKey] = desiredOwnerLabel
+	return true
 }
 
 func (r *SpritzReconciler) reconcileResources(ctx context.Context, spritz *spritzv1.Spritz) error {
@@ -758,7 +779,7 @@ func baseLabels(spritz *spritzv1.Spritz) map[string]string {
 		"spritz.sh/name": spritz.Name,
 	}
 	if spritz.Spec.Owner.ID != "" {
-		labels["spritz.sh/owner"] = ownerLabelValue(spritz.Spec.Owner.ID)
+		labels[ownerLabelKey] = ownerLabelValue(spritz.Spec.Owner.ID)
 	}
 	return labels
 }


### PR DESCRIPTION
## TL;DR
Running spritzes could disappear from the UI even though they still belonged to the same owner and were still directly reachable.
This makes visibility follow `spec.owner.id`, and makes the operator repair the derived owner label on the CR itself.

## Summary
- stop using the derived owner label as the filtering source of truth in spritz and ACP list endpoints
- reconcile the `spritz.sh/owner` label from `spec.owner.id` during operator lifecycle updates
- add regression coverage for missing or stale owner labels in both API and operator tests

## Review focus
- list visibility should now remain correct when labels are missing or stale
- operator metadata reconciliation should only repair the derived owner label and finalizer
- no behavior change for direct authorization checks, which still use `spec.owner.id`

## Test plan
- [x] `cd api && go test ./...`
- [x] `cd operator && go test ./...`
