### PR TITLE
fix(ui): redesign ACP chat layout

### DIFF
--- a/ui/public/acp-page-layout.test.mjs
+++ b/ui/public/acp-page-layout.test.mjs
@@ -1,0 +1,140 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import vm from 'node:vm';
+
+function createElement(tagName) {
+  return {
+    tagName,
+    hidden: false,
+    disabled: false,
+    textContent: '',
+    innerHTML: '',
+    value: '',
+    className: '',
+    children: [],
+    dataset: {},
+    style: {},
+    append(...items) {
+      this.children.push(...items);
+    },
+    appendChild(item) {
+      this.children.push(item);
+    },
+    remove() {
+      this.removed = true;
+    },
+    addEventListener() {},
+    setAttribute(name, value) {
+      this[name] = value;
+    },
+    querySelector() {
+      return null;
+    },
+    contains() {
+      return false;
+    },
+  };
+}
+
+function loadModules() {
+  const document = { createElement };
+  const window = {
+    document,
+    location: {
+      hash: '#chat/young-crest/conv-1',
+      assign() {},
+      replace() {},
+      origin: 'https://example.test',
+    },
+    open() {},
+    setTimeout,
+    clearTimeout,
+    SpritzACPClient: {
+      createACPClient() {
+        return {
+          start: async () => {},
+          isReady: () => false,
+          cancelPrompt() {},
+          dispose() {},
+        };
+      },
+      extractACPText(value) {
+        return typeof value?.text === 'string' ? value.text : '';
+      },
+    },
+  };
+  window.window = window;
+  const context = vm.createContext({ window, document, console, setTimeout, clearTimeout });
+  context.globalThis = context.window;
+  const renderScript = fs.readFileSync('/Users/onur/repos/spritz/ui/public/acp-render.js', 'utf8');
+  vm.runInContext(renderScript, context, { filename: 'acp-render.js' });
+  const pageScript = fs.readFileSync('/Users/onur/repos/spritz/ui/public/acp-page.js', 'utf8');
+  vm.runInContext(pageScript, context, { filename: 'acp-page.js' });
+  return { window, document };
+}
+
+test('ACP page renders a two-pane shell with a single sidebar rail', async () => {
+  const { window } = loadModules();
+  const shellEl = createElement('main');
+  const createSection = createElement('section');
+  const listSection = createElement('section');
+
+  window.SpritzACPPage.renderACPPage('young-crest', 'conv-1', {
+    activePage: null,
+    apiBaseUrl: '',
+    authBearerTokenParam: 'token',
+    getAuthToken() {
+      return '';
+    },
+    async request(path) {
+      if (path === '/acp/agents') {
+        return {
+          items: [
+            {
+              spritz: {
+                metadata: { name: 'young-crest' },
+                status: {
+                  acp: {
+                    agentInfo: { title: 'OpenClaw ACP Gateway', name: 'openclaw-acp', version: '2026.3.8' },
+                  },
+                  url: 'https://example.test/w/young-crest/',
+                },
+              },
+            },
+          ],
+        };
+      }
+      if (path.startsWith('/acp/conversations?')) {
+        return {
+          items: [
+            {
+              metadata: { name: 'conv-1' },
+              spec: { title: 'Test conversation', sessionId: 'sess-1' },
+              status: { updatedAt: '2026-03-10T05:44:00Z' },
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected path ${path}`);
+    },
+    showNotice() {},
+    buildOpenUrl(url) {
+      return url;
+    },
+    cleanupTerminal() {},
+    shellEl,
+    createSection,
+    listSection,
+    setHeaderCopy() {},
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(shellEl.children.length, 1);
+  const card = shellEl.children[0];
+  assert.equal(card.className.includes('acp-shell'), true);
+  assert.equal(card.children.length, 2);
+  assert.equal(card.children[0].className.includes('acp-sidebar'), true);
+  assert.equal(card.children[1].className.includes('acp-main'), true);
+});

--- a/ui/public/acp-page.js
+++ b/ui/public/acp-page.js
@@ -1,5 +1,6 @@
 (function (global) {
-  const { createACPClient, extractACPText } = global.SpritzACPClient;
+  const { createACPClient } = global.SpritzACPClient;
+  const ACPRender = global.SpritzACPRender;
 
   function chatPagePath(name = '', conversationId = '') {
     if (!name) return '#chat';
@@ -68,27 +69,6 @@
     });
   }
 
-  function defaultACPThreadTitle(agent, conversation) {
-    return (
-      conversation?.spec?.title ||
-      agent?.spritz?.status?.acp?.agentInfo?.title ||
-      agent?.spritz?.status?.acp?.agentInfo?.name ||
-      agent?.spritz?.metadata?.name ||
-      'Agent'
-    );
-  }
-
-  function buildACPThreadMeta(agent, conversation) {
-    const version = agent?.spritz?.status?.acp?.agentInfo?.version;
-    const sessionId = conversation?.spec?.sessionId;
-    const parts = [
-      agent?.spritz?.metadata?.name || '',
-      version ? `v${version}` : '',
-      sessionId ? `session ${sessionId}` : 'new conversation',
-    ].filter(Boolean);
-    return parts.join(' · ');
-  }
-
   function createACPPageState(name, conversationId, deps) {
     return {
       deps,
@@ -98,9 +78,9 @@
       selectedAgent: null,
       conversations: [],
       selectedConversation: null,
-      messages: [],
+      transcript: ACPRender.createTranscript(),
       permissionQueue: [],
-      toolCallIndex: new Map(),
+      previewByConversationId: new Map(),
       promptInFlight: false,
       client: null,
       reconnectTimer: null,
@@ -108,119 +88,162 @@
     };
   }
 
-  function renderACPAgentList(page) {
-    if (!page.agentListEl) return;
-    page.agentListEl.innerHTML = '';
+  function getAgentTitle(agent) {
+    return (
+      agent?.spritz?.status?.acp?.agentInfo?.title ||
+      agent?.spritz?.status?.acp?.agentInfo?.name ||
+      agent?.spritz?.metadata?.name ||
+      'Agent'
+    );
+  }
+
+  function getAgentVersion(agent) {
+    return agent?.spritz?.status?.acp?.agentInfo?.version || '';
+  }
+
+  function getAgentAvatarLabel(agent) {
+    const title = getAgentTitle(agent);
+    const words = title.split(/\s+/).filter(Boolean);
+    return (words[0]?.[0] || 'A') + (words[1]?.[0] || words[0]?.[1] || '');
+  }
+
+  function formatRelativeTime(value) {
+    if (!value) return '';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return '';
+    const now = new Date();
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const target = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+    const diffDays = Math.round((today.getTime() - target.getTime()) / 86400000);
+    if (diffDays === 0) {
+      return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    }
+    if (diffDays === 1) {
+      return 'Yesterday';
+    }
+    if (diffDays > 1 && diffDays < 7) {
+      return date.toLocaleDateString([], { weekday: 'short' });
+    }
+    return date.toLocaleDateString([], { day: '2-digit', month: '2-digit', year: 'numeric' });
+  }
+
+  function buildThreadMeta(agent, conversation) {
+    const parts = [];
+    if (agent?.spritz?.metadata?.name) {
+      parts.push(agent.spritz.metadata.name);
+    }
+    if (getAgentVersion(agent)) {
+      parts.push(`v${getAgentVersion(agent)}`);
+    }
+    if (conversation?.spec?.sessionId) {
+      parts.push(`session ${conversation.spec.sessionId}`);
+    }
+    return parts.join(' · ');
+  }
+
+  function getConversationUpdatedAt(conversation) {
+    return (
+      conversation?.status?.updatedAt ||
+      conversation?.metadata?.creationTimestamp ||
+      conversation?.spec?.updatedAt ||
+      ''
+    );
+  }
+
+  function updateConversationPreview(page) {
+    if (!page.selectedConversation?.metadata?.name) return;
+    const preview = ACPRender.getPreviewText(page.transcript);
+    if (preview) {
+      page.previewByConversationId.set(page.selectedConversation.metadata.name, preview);
+    }
+  }
+
+  function renderAgentPicker(page) {
+    if (!page.agentSelectEl) return;
+    page.agentSelectEl.innerHTML = '';
     if (!page.agents.length) {
-      const empty = document.createElement('p');
-      empty.className = 'acp-empty';
-      empty.textContent = 'No ACP-ready spritzes yet.';
-      page.agentListEl.appendChild(empty);
+      const option = document.createElement('option');
+      option.value = '';
+      option.textContent = 'No ACP-ready workspaces';
+      page.agentSelectEl.appendChild(option);
+      page.agentSelectEl.disabled = true;
       return;
     }
+    page.agentSelectEl.disabled = false;
     page.agents.forEach((agent) => {
-      const name = agent?.spritz?.metadata?.name;
-      const button = document.createElement('button');
-      button.type = 'button';
-      button.className = 'acp-agent-item';
-      button.dataset.active = String(name === page.selectedName);
-      button.onclick = () => {
-        if (!name) return;
-        window.location.assign(chatPagePath(name));
-      };
-      const title = document.createElement('strong');
-      title.textContent =
-        agent?.spritz?.status?.acp?.agentInfo?.title ||
-        agent?.spritz?.status?.acp?.agentInfo?.name ||
-        name ||
-        'Agent';
-      const meta = document.createElement('small');
-      meta.textContent = name || '';
-      button.append(title, meta);
-      page.agentListEl.appendChild(button);
+      const name = agent?.spritz?.metadata?.name || '';
+      const option = document.createElement('option');
+      option.value = name;
+      option.textContent = `${getAgentTitle(agent)} · ${name}`;
+      option.selected = name === page.selectedName;
+      page.agentSelectEl.appendChild(option);
     });
   }
 
-  function renderACPConversationList(page) {
-    if (!page.conversationListEl) return;
-    page.conversationListEl.innerHTML = '';
+  function renderConversationList(page) {
+    if (!page.threadListEl) return;
+    page.threadListEl.innerHTML = '';
     if (!page.selectedAgent) {
       const empty = document.createElement('p');
-      empty.className = 'acp-empty';
-      empty.textContent = 'Choose an ACP-ready spritz first.';
-      page.conversationListEl.appendChild(empty);
+      empty.className = 'acp-empty acp-empty--sidebar';
+      empty.textContent = 'Choose an ACP-ready workspace to load conversations.';
+      page.threadListEl.appendChild(empty);
       page.newConversationBtn.disabled = true;
       return;
     }
     page.newConversationBtn.disabled = false;
     if (!page.conversations.length) {
       const empty = document.createElement('p');
-      empty.className = 'acp-empty';
-      empty.textContent = 'No conversations yet. Create one to start chatting.';
-      page.conversationListEl.appendChild(empty);
+      empty.className = 'acp-empty acp-empty--sidebar';
+      empty.textContent = 'No conversations yet. Start one from the button above.';
+      page.threadListEl.appendChild(empty);
       return;
     }
+
     page.conversations.forEach((conversation) => {
+      const id = conversation.metadata?.name || '';
       const button = document.createElement('button');
       button.type = 'button';
-      button.className = 'acp-conversation-item';
-      button.dataset.active = String(conversation.metadata?.name === page.selectedConversationId);
+      button.className = 'acp-thread-item';
+      button.dataset.active = String(id === page.selectedConversationId);
       button.onclick = () => {
-        window.location.assign(chatPagePath(page.selectedName, conversation.metadata?.name || ''));
+        window.location.assign(chatPagePath(page.selectedName, id));
       };
+
+      const avatar = document.createElement('div');
+      avatar.className = 'acp-thread-avatar';
+      avatar.textContent = getAgentAvatarLabel(page.selectedAgent).slice(0, 2).toUpperCase();
+
+      const body = document.createElement('div');
+      body.className = 'acp-thread-item-body';
+      const top = document.createElement('div');
+      top.className = 'acp-thread-item-top';
       const title = document.createElement('strong');
+      title.className = 'acp-thread-item-title';
       title.textContent = conversation.spec?.title || 'New conversation';
-      const meta = document.createElement('small');
-      meta.textContent = buildACPThreadMeta(page.selectedAgent, conversation);
-      button.append(title, meta);
-      page.conversationListEl.appendChild(button);
+      const time = document.createElement('span');
+      time.className = 'acp-thread-item-time';
+      time.textContent = formatRelativeTime(getConversationUpdatedAt(conversation));
+      top.append(title, time);
+
+      const preview = document.createElement('p');
+      preview.className = 'acp-thread-item-preview';
+      preview.textContent =
+        page.previewByConversationId.get(id) ||
+        buildThreadMeta(page.selectedAgent, conversation) ||
+        'Ready to chat';
+
+      const meta = document.createElement('p');
+      meta.className = 'acp-thread-item-meta';
+      meta.textContent = buildThreadMeta(page.selectedAgent, conversation);
+
+      body.append(top, preview, meta);
+      button.append(avatar, body);
+      page.threadListEl.appendChild(button);
     });
   }
 
-  function renderACPMessageElement(message) {
-    const item = document.createElement('div');
-    item.className = 'acp-message';
-    item.dataset.kind = message.kind;
-
-    if (message.kind === 'tool' || message.kind === 'plan' || message.kind === 'system') {
-      const header = document.createElement('div');
-      header.className = 'acp-message-header';
-      const label = document.createElement('strong');
-      label.textContent = message.label || 'Update';
-      const meta = document.createElement('span');
-      meta.textContent = message.meta || '';
-      header.append(label, meta);
-      item.appendChild(header);
-    }
-
-    if (message.kind === 'plan' && Array.isArray(message.entries)) {
-      const list = document.createElement('ol');
-      list.className = 'acp-message-plan';
-      message.entries.forEach((entry) => {
-        const li = document.createElement('li');
-        const parts = [entry.content || '', entry.status || '', entry.priority || ''].filter(Boolean);
-        li.textContent = parts.join(' · ');
-        list.appendChild(li);
-      });
-      item.appendChild(list);
-      return item;
-    }
-
-    const text = document.createElement('div');
-    text.textContent = message.text || '';
-    item.appendChild(text);
-
-    if (message.kind === 'tool' && message.extra) {
-      const extra = document.createElement('div');
-      extra.className = 'acp-tool-content';
-      extra.textContent = message.extra;
-      item.appendChild(extra);
-    }
-
-    return item;
-  }
-
-  function renderACPPermissionPrompt(page) {
+  function renderPermissionPrompt(page) {
     if (!page.permissionEl || !page.permissionTextEl || !page.permissionOptionsEl) return;
     const current = page.permissionQueue[0];
     if (!current) {
@@ -251,122 +274,105 @@
           page.deps.showNotice(err.message || 'Failed to send permission response.');
         } finally {
           page.permissionQueue.shift();
-          renderACPPermissionPrompt(page);
+          renderPermissionPrompt(page);
         }
       };
       page.permissionOptionsEl.appendChild(button);
     });
   }
 
-  function renderACPThread(page) {
-    if (!page.threadTitleEl || !page.threadMetaEl || !page.threadBodyEl) return;
+  function renderCommandBar(page) {
+    if (!page.commandBarEl) return;
+    page.commandBarEl.innerHTML = '';
+    const items = ACPRender.buildCommandItems(page.transcript.availableCommands);
+    if (!items.length) {
+      page.commandBarEl.hidden = true;
+      return;
+    }
+    page.commandBarEl.hidden = false;
+    items.forEach((item) => {
+      const tag = document.createElement('span');
+      tag.className = 'acp-command-pill';
+      tag.textContent = item.label;
+      if (item.title) tag.title = item.title;
+      page.commandBarEl.appendChild(tag);
+    });
+  }
+
+  function renderModeBar(page) {
+    if (!page.statusMetaEl) return;
+    page.statusMetaEl.innerHTML = '';
+    const badges = [];
+    if (page.transcript.currentMode) {
+      badges.push({ label: `Mode · ${page.transcript.currentMode}` });
+    }
+    if (page.transcript.usage && page.transcript.usage.used !== null && page.transcript.usage.size !== null) {
+      badges.push({ label: `${page.transcript.usage.used}/${page.transcript.usage.size} used` });
+    }
+    badges.forEach((badgeInfo) => {
+      const badge = document.createElement('span');
+      badge.className = 'acp-inline-badge';
+      badge.textContent = badgeInfo.label;
+      page.statusMetaEl.appendChild(badge);
+    });
+  }
+
+  function renderThread(page) {
+    if (!page.threadTitleEl || !page.threadMetaEl || !page.threadStreamEl) return;
     const openUrl = page.deps.buildOpenUrl(page.selectedAgent?.spritz?.status?.url, page.selectedAgent?.spritz);
     page.openBtn.disabled = !openUrl;
-    page.threadTitleEl.textContent = defaultACPThreadTitle(page.selectedAgent, page.selectedConversation);
-    page.threadMetaEl.textContent = buildACPThreadMeta(page.selectedAgent, page.selectedConversation);
-    page.threadBodyEl.innerHTML = '';
+    page.threadTitleEl.textContent = page.selectedConversation?.spec?.title || getAgentTitle(page.selectedAgent);
+    page.threadMetaEl.textContent = buildThreadMeta(page.selectedAgent, page.selectedConversation);
+    page.threadStreamEl.innerHTML = '';
+    renderCommandBar(page);
+    renderModeBar(page);
 
     if (!page.selectedAgent) {
       const empty = document.createElement('div');
       empty.className = 'acp-empty';
-      empty.textContent = 'Choose an ACP-ready spritz to start chatting.';
-      page.threadBodyEl.appendChild(empty);
-      renderACPPermissionPrompt(page);
+      empty.textContent = 'Choose an ACP-ready workspace to start chatting.';
+      page.threadStreamEl.appendChild(empty);
+      renderPermissionPrompt(page);
       return;
     }
 
     if (!page.selectedConversation) {
       const empty = document.createElement('div');
       empty.className = 'acp-empty';
-      empty.textContent = 'Choose or create a conversation to start chatting.';
-      page.threadBodyEl.appendChild(empty);
-      renderACPPermissionPrompt(page);
+      empty.textContent = 'Choose a conversation or start a new one.';
+      page.threadStreamEl.appendChild(empty);
+      renderPermissionPrompt(page);
       return;
     }
 
-    if (!page.messages.length) {
-      const empty = document.createElement('div');
-      empty.className = 'acp-empty';
-      empty.textContent = 'Conversation is ready. Send a prompt to start.';
-      page.threadBodyEl.appendChild(empty);
+    if (!page.transcript.messages.length) {
+      const intro = document.createElement('div');
+      intro.className = 'acp-welcome-card';
+      const heading = document.createElement('strong');
+      heading.textContent = getAgentTitle(page.selectedAgent);
+      const copy = document.createElement('p');
+      copy.textContent = 'Conversation is ready. Send a message to begin.';
+      intro.append(heading, copy);
+      page.threadStreamEl.appendChild(intro);
     } else {
-      page.messages.forEach((message) => {
-        page.threadBodyEl.appendChild(renderACPMessageElement(message));
+      page.transcript.messages.forEach((message) => {
+        page.threadStreamEl.appendChild(ACPRender.renderMessage(message));
       });
     }
     page.threadBodyEl.scrollTop = page.threadBodyEl.scrollHeight;
-    renderACPPermissionPrompt(page);
+    renderPermissionPrompt(page);
   }
 
-  function setACPStatus(page, text) {
+  function setStatus(page, text) {
     if (!page.statusEl) return;
     page.statusEl.textContent = text || '';
   }
 
-  function syncACPComposer(page) {
+  function syncComposer(page) {
     const disabled = !page.client || !page.client.isReady() || !page.selectedConversation;
     if (page.composerEl) page.composerEl.disabled = disabled || page.promptInFlight;
     if (page.sendBtn) page.sendBtn.disabled = disabled || page.promptInFlight;
     if (page.cancelBtn) page.cancelBtn.disabled = !page.promptInFlight;
-  }
-
-  function pushACPMessage(page, message) {
-    page.messages.push({
-      id: message.id || `${message.kind}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
-      kind: message.kind,
-      label: message.label || '',
-      meta: message.meta || '',
-      text: message.text || '',
-      extra: message.extra || '',
-      entries: message.entries || null,
-      toolCallId: message.toolCallId || '',
-      streaming: Boolean(message.streaming),
-    });
-    renderACPThread(page);
-  }
-
-  function appendACPChunk(page, kind, text) {
-    const chunk = String(text || '');
-    if (!chunk) return;
-    const last = page.messages[page.messages.length - 1];
-    if (last && last.kind === kind && last.streaming) {
-      last.text += chunk;
-    } else {
-      pushACPMessage(page, { kind, text: chunk, streaming: true });
-    }
-    renderACPThread(page);
-  }
-
-  function finalizeACPStreams(page) {
-    page.messages.forEach((message) => {
-      if (message.kind === 'assistant' || message.kind === 'user') {
-        message.streaming = false;
-      }
-    });
-  }
-
-  function upsertACPToolCall(page, update) {
-    const toolCallId = update.toolCallId || `tool-${Date.now()}`;
-    const text = extractACPText(update.content);
-    const existingIndex = page.toolCallIndex.get(toolCallId);
-    const label = update.title || 'Tool call';
-    const meta = update.status || update.kind || '';
-    if (existingIndex !== undefined) {
-      const existing = page.messages[existingIndex];
-      existing.label = label;
-      existing.meta = meta;
-      if (text) existing.extra = text;
-    } else {
-      page.toolCallIndex.set(toolCallId, page.messages.length);
-      pushACPMessage(page, {
-        kind: 'tool',
-        label,
-        meta,
-        extra: text,
-        toolCallId,
-      });
-    }
-    renderACPThread(page);
   }
 
   async function patchSelectedConversation(page, payload) {
@@ -377,50 +383,23 @@
     page.conversations = page.conversations.map((item) =>
       item.metadata?.name === updated.metadata?.name ? updated : item,
     );
-    renderACPConversationList(page);
-    renderACPThread(page);
+    renderConversationList(page);
+    renderThread(page);
   }
 
   function applyACPUpdate(page, update) {
-    const kind = update?.sessionUpdate || 'unknown';
-    if (kind === 'user_message_chunk') {
-      appendACPChunk(page, 'user', extractACPText(update.content));
-      return;
+    const result = ACPRender.applySessionUpdate(page.transcript, update);
+    if (result?.conversationTitle) {
+      patchSelectedConversation(page, { title: result.conversationTitle }).catch(() => {});
     }
-    if (kind === 'agent_message_chunk') {
-      appendACPChunk(page, 'assistant', extractACPText(update.content));
-      return;
-    }
-    if (kind === 'tool_call' || kind === 'tool_call_update') {
-      upsertACPToolCall(page, update);
-      return;
-    }
-    if (kind === 'plan') {
-      pushACPMessage(page, {
-        kind: 'plan',
-        label: 'Plan',
-        entries: Array.isArray(update.entries) ? update.entries : [],
-      });
-      return;
-    }
-    if (kind === 'session_info_update') {
-      const title = update?.title || update?.sessionInfo?.title;
-      if (title) {
-        patchSelectedConversation(page, { title }).catch(() => {});
-      }
-      return;
-    }
-    pushACPMessage(page, {
-      kind: 'system',
-      label: kind,
-      text: JSON.stringify(update, null, 2),
-    });
+    updateConversationPreview(page);
+    renderConversationList(page);
+    renderThread(page);
   }
 
-  function clearConversationRuntime(page) {
-    page.messages = [];
+  function resetConversationRuntime(page) {
+    page.transcript = ACPRender.createTranscript();
     page.permissionQueue = [];
-    page.toolCallIndex = new Map();
     page.promptInFlight = false;
     if (page.client) {
       page.client.dispose();
@@ -430,7 +409,7 @@
       clearTimeout(page.reconnectTimer);
       page.reconnectTimer = null;
     }
-    syncACPComposer(page);
+    syncComposer(page);
   }
 
   function scheduleReconnect(page) {
@@ -440,27 +419,27 @@
     }
     page.reconnectTimer = setTimeout(() => {
       connectSelectedConversation(page).catch((err) => {
-        setACPStatus(page, err.message || 'Disconnected');
+        setStatus(page, err.message || 'Disconnected');
       });
     }, 2000);
-    setACPStatus(page, 'Disconnected. Reconnecting…');
+    setStatus(page, 'Disconnected. Reconnecting…');
   }
 
   async function connectSelectedConversation(page) {
-    clearConversationRuntime(page);
+    resetConversationRuntime(page);
     if (!page.selectedAgent || !page.selectedConversation) {
-      renderACPThread(page);
+      renderThread(page);
       return;
     }
-    renderACPThread(page);
+    renderThread(page);
     page.client = createACPClient({
       wsUrl: acpWsUrl(page.selectedName, page.deps),
       conversation: page.selectedConversation,
       onStatus(text) {
-        setACPStatus(page, text);
+        setStatus(page, text);
       },
       onReadyChange() {
-        syncACPComposer(page);
+        syncComposer(page);
       },
       onAgentInfo(agentInfo) {
         if (!page.selectedAgent) return;
@@ -477,15 +456,16 @@
             },
           },
         };
-        renderACPAgentList(page);
-        renderACPThread(page);
+        renderAgentPicker(page);
+        renderConversationList(page);
+        renderThread(page);
       },
       onUpdate(update) {
         applyACPUpdate(page, update);
       },
       onPermissionRequest(entry) {
         page.permissionQueue.push(entry);
-        renderACPPermissionPrompt(page);
+        renderPermissionPrompt(page);
       },
       async onSessionId(sessionId) {
         await patchSelectedConversation(page, { sessionId });
@@ -493,31 +473,34 @@
       onPromptStateChange(value) {
         page.promptInFlight = value;
         if (!value) {
-          finalizeACPStreams(page);
+          ACPRender.finalizeStreaming(page.transcript);
+          updateConversationPreview(page);
+          renderConversationList(page);
         }
-        syncACPComposer(page);
+        syncComposer(page);
+        renderThread(page);
       },
       onClose() {
         scheduleReconnect(page);
       },
       onProtocolError(err) {
-        pushACPMessage(page, { kind: 'system', label: 'protocol', text: err.message || 'Invalid ACP message.' });
+        page.deps.showNotice(err.message || 'Invalid ACP message.', 'info');
       },
     });
-    syncACPComposer(page);
+    syncComposer(page);
     await page.client.start();
   }
 
   async function selectConversation(page, conversationId) {
     page.selectedConversationId = conversationId || '';
     page.selectedConversation = page.conversations.find((item) => item.metadata?.name === conversationId) || null;
-    clearConversationRuntime(page);
-    renderACPConversationList(page);
-    renderACPThread(page);
+    resetConversationRuntime(page);
+    renderConversationList(page);
+    renderThread(page);
     if (page.selectedConversation) {
       await connectSelectedConversation(page);
     } else {
-      setACPStatus(page, 'Choose or create a conversation.');
+      setStatus(page, 'Choose or create a conversation.');
     }
   }
 
@@ -526,17 +509,18 @@
       page.conversations = [];
       page.selectedConversation = null;
       page.selectedConversationId = '';
-      renderACPConversationList(page);
-      renderACPThread(page);
+      renderConversationList(page);
+      renderThread(page);
       return;
     }
     page.conversations = await listACPConversationsData(page.deps, page.selectedName);
     const routeConversationId = conversationIdFromHash(window.location.hash || '');
     const resolvedConversationId =
-      page.conversations.some((item) => item.metadata?.name === routeConversationId)
-        ? routeConversationId
-        : page.conversations[0]?.metadata?.name || '';
-    renderACPConversationList(page);
+      page.conversations.find((item) => item.metadata?.name === routeConversationId)?.metadata?.name ||
+      page.selectedConversationId ||
+      page.conversations[0]?.metadata?.name ||
+      '';
+    renderConversationList(page);
     if (routeConversationId && resolvedConversationId !== routeConversationId) {
       window.location.replace(chatPagePath(page.selectedName, resolvedConversationId));
       return;
@@ -546,18 +530,18 @@
 
   async function loadACPPage(page) {
     try {
-      setACPStatus(page, 'Loading agents…');
+      setStatus(page, 'Loading workspaces…');
       page.agents = await fetchACPAgentsData(page.deps);
-      renderACPAgentList(page);
+      renderAgentPicker(page);
       if (!page.agents.length) {
         page.selectedAgent = null;
         page.conversations = [];
         page.selectedConversation = null;
         page.selectedConversationId = '';
-        clearConversationRuntime(page);
-        renderACPConversationList(page);
-        renderACPThread(page);
-        setACPStatus(page, 'No ACP-ready spritzes.');
+        resetConversationRuntime(page);
+        renderConversationList(page);
+        renderThread(page);
+        setStatus(page, 'No ACP-ready workspaces.');
         return;
       }
 
@@ -571,14 +555,14 @@
 
       page.selectedName = resolvedName;
       page.selectedAgent = page.agents.find((item) => item?.spritz?.metadata?.name === resolvedName) || null;
-      renderACPConversationList(page);
-      renderACPThread(page);
+      renderConversationList(page);
+      renderThread(page);
       await refreshConversations(page);
       if (!page.selectedConversation) {
-        setACPStatus(page, 'Choose or create a conversation.');
+        setStatus(page, 'Choose or create a conversation.');
       }
     } catch (err) {
-      setACPStatus(page, err.message || 'Failed to load ACP page.');
+      setStatus(page, err.message || 'Failed to load ACP page.');
       page.deps.showNotice(err.message || 'Failed to load ACP page.');
     }
   }
@@ -590,77 +574,92 @@
     }
     if (deps.createSection) deps.createSection.hidden = true;
     if (deps.listSection) deps.listSection.hidden = true;
-    deps.setHeaderCopy('Spritz · Agent chat', 'ACP-ready workspaces via the Spritz gateway.');
+    if (deps.shellEl?.dataset) deps.shellEl.dataset.view = 'chat';
+    deps.setHeaderCopy('Spritz', 'Agent chat');
 
     const page = createACPPageState(name, conversationId, deps);
 
-    const card = document.createElement('section');
-    card.className = 'card acp-card';
+    const shell = document.createElement('section');
+    shell.className = 'card acp-shell';
 
-    const agentSidebar = document.createElement('aside');
-    agentSidebar.className = 'acp-sidebar';
-    const agentHeader = document.createElement('div');
-    agentHeader.className = 'acp-sidebar-header';
-    const agentTitle = document.createElement('h2');
-    agentTitle.textContent = 'Agents';
-    const agentMeta = document.createElement('p');
-    agentMeta.textContent = 'ACP-ready spritzes appear here automatically.';
-    const agentActions = document.createElement('div');
-    agentActions.className = 'acp-sidebar-actions';
+    const sidebar = document.createElement('aside');
+    sidebar.className = 'acp-sidebar';
+    const sidebarTop = document.createElement('div');
+    sidebarTop.className = 'acp-sidebar-top';
+
+    const nav = document.createElement('div');
+    nav.className = 'acp-sidebar-nav';
     const backLink = document.createElement('a');
     backLink.href = '/';
     backLink.className = 'header-link';
     backLink.textContent = 'Back';
     const refreshButton = document.createElement('button');
     refreshButton.type = 'button';
+    refreshButton.className = 'ghost';
     refreshButton.textContent = 'Refresh';
-    agentActions.append(backLink, refreshButton);
-    agentHeader.append(agentTitle, agentMeta, agentActions);
-    const agentList = document.createElement('div');
-    agentList.className = 'acp-agent-list';
-    agentSidebar.append(agentHeader, agentList);
+    nav.append(backLink, refreshButton);
 
-    const conversationSidebar = document.createElement('aside');
-    conversationSidebar.className = 'acp-conversation-sidebar';
-    const conversationHeader = document.createElement('div');
-    conversationHeader.className = 'acp-sidebar-header';
-    const conversationTitle = document.createElement('h2');
-    conversationTitle.textContent = 'Conversations';
-    const conversationMeta = document.createElement('p');
-    conversationMeta.textContent = 'Each thread keeps its own ACP session.';
-    const conversationActions = document.createElement('div');
-    conversationActions.className = 'acp-sidebar-actions';
+    const titleGroup = document.createElement('div');
+    titleGroup.className = 'acp-sidebar-title';
+    const title = document.createElement('h2');
+    title.textContent = 'Agent chat';
+    const subtitle = document.createElement('p');
+    subtitle.textContent = 'Talk to ACP-ready workspaces through Spritz.';
+    titleGroup.append(title, subtitle);
+
+    const agentSelect = document.createElement('select');
+    agentSelect.className = 'acp-agent-select';
+
     const newConversationButton = document.createElement('button');
     newConversationButton.type = 'button';
     newConversationButton.textContent = 'New conversation';
-    conversationActions.append(newConversationButton);
-    conversationHeader.append(conversationTitle, conversationMeta, conversationActions);
-    const conversationList = document.createElement('div');
-    conversationList.className = 'acp-conversation-list';
-    conversationSidebar.append(conversationHeader, conversationList);
 
-    const thread = document.createElement('div');
-    thread.className = 'acp-thread';
-    const threadHeader = document.createElement('div');
-    threadHeader.className = 'acp-thread-header';
-    const threadHeaderCopy = document.createElement('div');
+    const threadList = document.createElement('div');
+    threadList.className = 'acp-thread-list';
+
+    sidebarTop.append(nav, titleGroup, agentSelect, newConversationButton);
+    sidebar.append(sidebarTop, threadList);
+
+    const main = document.createElement('section');
+    main.className = 'acp-main';
+
+    const header = document.createElement('div');
+    header.className = 'acp-main-header';
+    const headerCopy = document.createElement('div');
+    headerCopy.className = 'acp-main-copy';
     const threadTitle = document.createElement('h2');
     threadTitle.textContent = 'Agent';
     const threadMeta = document.createElement('p');
-    threadMeta.textContent = '';
-    threadHeaderCopy.append(threadTitle, threadMeta);
-    const threadActions = document.createElement('div');
-    threadActions.className = 'acp-thread-actions';
+    headerCopy.append(threadTitle, threadMeta);
+
+    const headerActions = document.createElement('div');
+    headerActions.className = 'acp-main-actions';
     const openButton = document.createElement('button');
     openButton.type = 'button';
     openButton.textContent = 'Open workspace';
-    threadActions.append(openButton);
-    threadHeader.append(threadHeaderCopy, threadActions);
+    headerActions.append(openButton);
 
-    const threadBody = document.createElement('div');
-    threadBody.className = 'acp-thread-body';
+    const headerTop = document.createElement('div');
+    headerTop.className = 'acp-main-header-top';
+    headerTop.append(headerCopy, headerActions);
+
+    const commandBar = document.createElement('div');
+    commandBar.className = 'acp-command-bar';
+    commandBar.hidden = true;
+
+    header.append(headerTop, commandBar);
+
+    const body = document.createElement('div');
+    body.className = 'acp-main-body';
+    const stream = document.createElement('div');
+    stream.className = 'acp-stream';
+    body.appendChild(stream);
+
     const footer = document.createElement('div');
-    footer.className = 'acp-thread-footer';
+    footer.className = 'acp-main-footer';
+    const footerInner = document.createElement('div');
+    footerInner.className = 'acp-footer-inner';
+
     const permissionBox = document.createElement('div');
     permissionBox.className = 'acp-permission';
     permissionBox.hidden = true;
@@ -673,10 +672,12 @@
     statusRow.className = 'acp-status-row';
     const statusEl = document.createElement('span');
     statusEl.className = 'acp-status';
+    const statusMeta = document.createElement('div');
+    statusMeta.className = 'acp-status-meta';
     const hint = document.createElement('span');
     hint.className = 'acp-hint';
     hint.textContent = 'Enter sends. Shift+Enter adds a new line.';
-    statusRow.append(statusEl, hint);
+    statusRow.append(statusEl, statusMeta, hint);
 
     const composer = document.createElement('div');
     composer.className = 'acp-composer';
@@ -693,22 +694,27 @@
     cancelButton.textContent = 'Cancel turn';
     composerActions.append(sendButton, cancelButton);
     composer.append(composerInput, composerActions);
-    footer.append(permissionBox, statusRow, composer);
 
-    thread.append(threadHeader, threadBody, footer);
-    card.append(agentSidebar, conversationSidebar, thread);
-    deps.shellEl.append(card);
+    footerInner.append(permissionBox, statusRow, composer);
+    footer.appendChild(footerInner);
 
-    page.card = card;
-    page.agentListEl = agentList;
-    page.conversationListEl = conversationList;
+    main.append(header, body, footer);
+    shell.append(sidebar, main);
+    deps.shellEl.append(shell);
+
+    page.card = shell;
+    page.agentSelectEl = agentSelect;
+    page.threadListEl = threadList;
     page.threadTitleEl = threadTitle;
     page.threadMetaEl = threadMeta;
-    page.threadBodyEl = threadBody;
+    page.commandBarEl = commandBar;
+    page.threadBodyEl = body;
+    page.threadStreamEl = stream;
     page.permissionEl = permissionBox;
     page.permissionTextEl = permissionText;
     page.permissionOptionsEl = permissionOptions;
     page.statusEl = statusEl;
+    page.statusMetaEl = statusMeta;
     page.composerEl = composerInput;
     page.sendBtn = sendButton;
     page.cancelBtn = cancelButton;
@@ -720,12 +726,17 @@
       loadACPPage(page);
     });
 
+    agentSelect.addEventListener('change', () => {
+      if (!agentSelect.value) return;
+      window.location.assign(chatPagePath(agentSelect.value));
+    });
+
     newConversationButton.addEventListener('click', async () => {
       if (!page.selectedName) return;
       try {
         const conversation = await createACPConversationData(page.deps, page.selectedName);
         page.conversations = [conversation, ...page.conversations];
-        renderACPConversationList(page);
+        renderConversationList(page);
         window.location.assign(chatPagePath(page.selectedName, conversation.metadata?.name || ''));
       } catch (err) {
         page.deps.showNotice(err.message || 'Failed to create conversation.');
@@ -743,20 +754,27 @@
       const text = composerInput.value.trim();
       if (!text || !page.client || !page.selectedConversation) return;
       composerInput.value = '';
-      pushACPMessage(page, { kind: 'user', text });
+      ACPRender.applySessionUpdate(page.transcript, {
+        sessionUpdate: 'user_message_chunk',
+        content: { type: 'text', text },
+      });
+      ACPRender.finalizeStreaming(page.transcript);
+      updateConversationPreview(page);
+      renderConversationList(page);
+      renderThread(page);
       if (!page.selectedConversation.spec?.title || page.selectedConversation.spec.title === 'New conversation') {
         const nextTitle = text.slice(0, 80);
         patchSelectedConversation(page, { title: nextTitle }).catch(() => {});
       }
-      setACPStatus(page, 'Waiting for agent…');
+      setStatus(page, 'Waiting for agent…');
       try {
         const result = await page.client.sendPrompt(text);
-        setACPStatus(page, result?.stopReason ? `Completed · ${result.stopReason}` : 'Completed');
+        setStatus(page, result?.stopReason ? `Completed · ${result.stopReason}` : 'Completed');
       } catch (err) {
         page.deps.showNotice(err.message || 'Failed to send ACP prompt.');
       } finally {
-        syncACPComposer(page);
-        renderACPThread(page);
+        syncComposer(page);
+        renderThread(page);
       }
     });
 
@@ -773,18 +791,19 @@
 
     page.destroy = function destroy() {
       page.destroyed = true;
-      clearConversationRuntime(page);
+      resetConversationRuntime(page);
       if (page.card) {
         page.card.remove();
       }
       if (deps.createSection) deps.createSection.hidden = false;
       if (deps.listSection) deps.listSection.hidden = false;
+      if (deps.shellEl?.dataset) delete deps.shellEl.dataset.view;
     };
 
-    syncACPComposer(page);
-    renderACPAgentList(page);
-    renderACPConversationList(page);
-    renderACPThread(page);
+    syncComposer(page);
+    renderAgentPicker(page);
+    renderConversationList(page);
+    renderThread(page);
     loadACPPage(page);
     return page;
   }

--- a/ui/public/acp-render.js
+++ b/ui/public/acp-render.js
@@ -1,0 +1,421 @@
+(function (global) {
+  const extractACPText =
+    global.SpritzACPClient?.extractACPText ||
+    function fallbackExtractACPText(value) {
+      if (value === null || value === undefined) return '';
+      if (typeof value === 'string') return value;
+      if (Array.isArray(value)) {
+        return value.map((item) => fallbackExtractACPText(item)).filter(Boolean).join('\n');
+      }
+      if (typeof value !== 'object') return String(value);
+      if (typeof value.text === 'string') return value.text;
+      if (value.type === 'content' && value.content) return fallbackExtractACPText(value.content);
+      if (value.content) return fallbackExtractACPText(value.content);
+      if (value.resource) {
+        if (typeof value.resource.text === 'string') return value.resource.text;
+        if (typeof value.resource.uri === 'string') return value.resource.uri;
+      }
+      return '';
+    };
+
+  function createId(prefix) {
+    return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  }
+
+  function createTranscript() {
+    return {
+      messages: [],
+      toolCallIndex: new Map(),
+      availableCommands: [],
+      currentMode: '',
+      usage: null,
+    };
+  }
+
+  function stringifyDetails(value) {
+    if (value === undefined || value === null || value === '') return '';
+    if (typeof value === 'string') return value;
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return String(value);
+    }
+  }
+
+  function excerpt(text, maxLength = 120) {
+    const normalized = String(text || '').replace(/\s+/g, ' ').trim();
+    if (!normalized) return '';
+    if (normalized.length <= maxLength) return normalized;
+    return `${normalized.slice(0, maxLength - 1)}…`;
+  }
+
+  function pushMessage(transcript, message) {
+    transcript.messages.push({
+      id: message.id || createId(message.kind || 'message'),
+      kind: message.kind,
+      title: message.title || '',
+      status: message.status || '',
+      tone: message.tone || '',
+      meta: message.meta || '',
+      blocks: Array.isArray(message.blocks) ? message.blocks : [],
+      streaming: Boolean(message.streaming),
+      toolCallId: message.toolCallId || '',
+    });
+    return transcript.messages[transcript.messages.length - 1];
+  }
+
+  function createTextBlocks(text) {
+    const normalized = String(text || '');
+    if (!normalized) return [];
+    return [{ type: 'text', text: normalized }];
+  }
+
+  function appendStreamingText(transcript, kind, text) {
+    const chunk = String(text || '');
+    if (!chunk) return;
+    const last = transcript.messages[transcript.messages.length - 1];
+    if (last && last.kind === kind && last.streaming) {
+      const textBlock = last.blocks.find((block) => block.type === 'text');
+      if (textBlock) {
+        textBlock.text += chunk;
+      } else {
+        last.blocks.push({ type: 'text', text: chunk });
+      }
+      return;
+    }
+    pushMessage(transcript, {
+      kind,
+      streaming: true,
+      blocks: createTextBlocks(chunk),
+    });
+  }
+
+  function finalizeStreaming(transcript) {
+    transcript.messages.forEach((message) => {
+      if (message.kind === 'assistant' || message.kind === 'user') {
+        message.streaming = false;
+      }
+    });
+  }
+
+  function buildToolBlocks(update, existing) {
+    const blocks = [];
+    const inputText = stringifyDetails(update.rawInput);
+    const resultText = stringifyDetails(update.rawOutput);
+    if (inputText) {
+      blocks.push({ type: 'details', title: 'Input', text: inputText, open: false });
+    } else if (existing) {
+      const priorInput = existing.blocks.find((block) => block.type === 'details' && block.title === 'Input');
+      if (priorInput) blocks.push(priorInput);
+    }
+    if (resultText) {
+      blocks.push({ type: 'details', title: 'Result', text: resultText, open: true });
+    } else if (existing) {
+      const priorResult = existing.blocks.find((block) => block.type === 'details' && block.title === 'Result');
+      if (priorResult) blocks.push(priorResult);
+    }
+    return blocks;
+  }
+
+  function upsertToolCall(transcript, update) {
+    const toolCallId = update.toolCallId || createId('tool');
+    const existingIndex = transcript.toolCallIndex.get(toolCallId);
+    const existing = existingIndex !== undefined ? transcript.messages[existingIndex] : null;
+    const title = update.title || existing?.title || 'Tool call';
+    const status = update.status || existing?.status || 'pending';
+    const next = {
+      kind: 'tool',
+      title,
+      status,
+      tone: status === 'completed' ? 'success' : status === 'failed' ? 'danger' : 'info',
+      meta: update.kind || existing?.meta || '',
+      blocks: buildToolBlocks(update, existing),
+      toolCallId,
+    };
+
+    if (existing) {
+      transcript.messages[existingIndex] = {
+        ...existing,
+        ...next,
+      };
+      return;
+    }
+
+    transcript.toolCallIndex.set(toolCallId, transcript.messages.length);
+    pushMessage(transcript, next);
+  }
+
+  function createUsageBlocks(update) {
+    const entries = [];
+    if (typeof update.used === 'number') {
+      entries.push({ label: 'Used', value: String(update.used) });
+    }
+    if (typeof update.size === 'number') {
+      entries.push({ label: 'Budget', value: String(update.size) });
+    }
+    if (update.label) {
+      entries.push({ label: 'Label', value: String(update.label) });
+    }
+    return entries;
+  }
+
+  function humanizeUpdateKind(kind) {
+    return String(kind || 'Update')
+      .replace(/_/g, ' ')
+      .replace(/\b\w/g, (match) => match.toUpperCase());
+  }
+
+  function applySessionUpdate(transcript, update) {
+    const kind = update?.sessionUpdate || 'unknown';
+    if (kind === 'user_message_chunk') {
+      appendStreamingText(transcript, 'user', extractACPText(update.content));
+      return null;
+    }
+    if (kind === 'agent_message_chunk') {
+      appendStreamingText(transcript, 'assistant', extractACPText(update.content));
+      return null;
+    }
+    if (kind === 'tool_call' || kind === 'tool_call_update') {
+      upsertToolCall(transcript, update);
+      return null;
+    }
+    if (kind === 'available_commands_update') {
+      transcript.availableCommands = Array.isArray(update.availableCommands) ? update.availableCommands : [];
+      return null;
+    }
+    if (kind === 'current_mode_update') {
+      transcript.currentMode = String(update.mode || update.currentMode || '').trim();
+      return null;
+    }
+    if (kind === 'usage_update') {
+      transcript.usage = {
+        label: String(update.label || 'Usage'),
+        used: typeof update.used === 'number' ? update.used : null,
+        size: typeof update.size === 'number' ? update.size : null,
+      };
+      if (transcript.usage.used === null && transcript.usage.size === null) {
+        transcript.usage = null;
+      }
+      return null;
+    }
+    if (kind === 'plan') {
+      pushMessage(transcript, {
+        kind: 'plan',
+        title: 'Plan',
+        blocks: [
+          {
+            type: 'plan',
+            entries: Array.isArray(update.entries) ? update.entries : [],
+          },
+        ],
+      });
+      return null;
+    }
+    if (kind === 'session_info_update') {
+      return {
+        conversationTitle: update?.title || update?.sessionInfo?.title || '',
+      };
+    }
+    if (kind === 'config_option_update') {
+      pushMessage(transcript, {
+        kind: 'system',
+        title: 'Setting updated',
+        tone: 'muted',
+        blocks: [
+          {
+            type: 'keyValue',
+            entries: [
+              { label: 'Key', value: String(update.key || '') },
+              { label: 'Value', value: String(update.value || '') },
+            ].filter((entry) => entry.value),
+          },
+        ],
+      });
+      return null;
+    }
+    pushMessage(transcript, {
+      kind: 'system',
+      title: humanizeUpdateKind(kind),
+      tone: 'muted',
+      blocks: [
+        {
+          type: 'details',
+          title: 'Payload',
+          text: stringifyDetails(update),
+          open: false,
+        },
+      ],
+    });
+    return null;
+  }
+
+  function renderRichText(text) {
+    const fragment = document.createDocumentFragment ? document.createDocumentFragment() : document.createElement('div');
+    const source = String(text || '');
+    const pattern = /```([\w-]+)?\n?([\s\S]*?)```/g;
+    let lastIndex = 0;
+    let match;
+    while ((match = pattern.exec(source))) {
+      const before = source.slice(lastIndex, match.index);
+      appendParagraphs(fragment, before);
+      const pre = document.createElement('pre');
+      pre.className = 'acp-code-block';
+      if (match[1]) {
+        pre.dataset.language = match[1];
+      }
+      const code = document.createElement('code');
+      code.textContent = match[2].trim();
+      pre.appendChild(code);
+      fragment.appendChild(pre);
+      lastIndex = pattern.lastIndex;
+    }
+    appendParagraphs(fragment, source.slice(lastIndex));
+    return fragment;
+  }
+
+  function appendParagraphs(parent, text) {
+    const chunks = String(text || '')
+      .split(/\n{2,}/)
+      .map((part) => part.trim())
+      .filter(Boolean);
+    chunks.forEach((chunk) => {
+      const paragraph = document.createElement('p');
+      paragraph.className = 'acp-rich-paragraph';
+      paragraph.textContent = chunk;
+      parent.appendChild(paragraph);
+    });
+  }
+
+  function renderBlock(block) {
+    if (!block) return null;
+    if (block.type === 'text') {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'acp-block acp-block--text';
+      wrapper.appendChild(renderRichText(block.text || ''));
+      return wrapper;
+    }
+    if (block.type === 'plan') {
+      const list = document.createElement('ol');
+      list.className = 'acp-plan-list';
+      (block.entries || []).forEach((entry) => {
+        const item = document.createElement('li');
+        const line = [entry.content || '', entry.status || '', entry.priority || ''].filter(Boolean).join(' · ');
+        item.textContent = line || 'Pending step';
+        list.appendChild(item);
+      });
+      return list;
+    }
+    if (block.type === 'tags') {
+      const row = document.createElement('div');
+      row.className = 'acp-tag-row';
+      (block.items || []).forEach((item) => {
+        const tag = document.createElement('span');
+        tag.className = 'acp-tag';
+        tag.textContent = item.label || item.name || '';
+        if (item.title) tag.title = item.title;
+        row.appendChild(tag);
+      });
+      return row;
+    }
+    if (block.type === 'keyValue') {
+      const grid = document.createElement('dl');
+      grid.className = 'acp-key-value';
+      (block.entries || []).forEach((entry) => {
+        const term = document.createElement('dt');
+        term.textContent = entry.label || '';
+        const value = document.createElement('dd');
+        value.textContent = entry.value || '';
+        grid.append(term, value);
+      });
+      return grid;
+    }
+    if (block.type === 'details') {
+      const details = document.createElement('details');
+      details.className = 'acp-details';
+      details.open = Boolean(block.open);
+      const summary = document.createElement('summary');
+      summary.textContent = block.title || 'Details';
+      const pre = document.createElement('pre');
+      pre.className = 'acp-details-body';
+      pre.textContent = block.text || '';
+      details.append(summary, pre);
+      return details;
+    }
+    return null;
+  }
+
+  function renderMessage(message) {
+    const article = document.createElement('article');
+    article.className = `acp-message acp-message--${message.kind}`;
+    article.dataset.kind = message.kind;
+
+    const bubble = document.createElement('div');
+    bubble.className = message.kind === 'user' || message.kind === 'assistant' ? 'acp-bubble' : 'acp-event-card';
+
+    if (message.title || message.status || message.meta) {
+      const header = document.createElement('div');
+      header.className = 'acp-message-meta';
+      const title = document.createElement('strong');
+      title.textContent = message.title || (message.kind === 'assistant' ? 'Assistant' : message.kind === 'user' ? 'You' : 'Update');
+      header.appendChild(title);
+      if (message.status || message.meta) {
+        const meta = document.createElement('div');
+        meta.className = 'acp-meta-stack';
+        if (message.meta) {
+          const metaText = document.createElement('span');
+          metaText.className = 'acp-message-meta-text';
+          metaText.textContent = message.meta;
+          meta.appendChild(metaText);
+        }
+        if (message.status) {
+          const badge = document.createElement('span');
+          badge.className = 'acp-status-pill';
+          badge.dataset.tone = message.tone || 'info';
+          badge.textContent = message.status.replace(/_/g, ' ');
+          meta.appendChild(badge);
+        }
+        header.appendChild(meta);
+      }
+      bubble.appendChild(header);
+    }
+
+    message.blocks.forEach((block) => {
+      const node = renderBlock(block);
+      if (node) bubble.appendChild(node);
+    });
+
+    article.appendChild(bubble);
+    return article;
+  }
+
+  function getPreviewText(transcript) {
+    for (let index = transcript.messages.length - 1; index >= 0; index -= 1) {
+      const message = transcript.messages[index];
+      if (!message) continue;
+      if (message.kind === 'assistant' || message.kind === 'user') {
+        const textBlock = message.blocks.find((block) => block.type === 'text' && block.text);
+        if (textBlock) return excerpt(textBlock.text);
+      }
+      if (message.kind === 'tool') {
+        return excerpt(`${message.title || 'Tool call'} · ${message.status || 'running'}`);
+      }
+    }
+    return '';
+  }
+
+  function buildCommandItems(commands) {
+    return (Array.isArray(commands) ? commands : []).map((command) => ({
+      label: `/${command.name || 'command'}`,
+      title: command.description || '',
+    }));
+  }
+
+  global.SpritzACPRender = {
+    buildCommandItems,
+    createTranscript,
+    applySessionUpdate,
+    finalizeStreaming,
+    getPreviewText,
+    renderMessage,
+  };
+})(window);

--- a/ui/public/acp-render.test.mjs
+++ b/ui/public/acp-render.test.mjs
@@ -1,0 +1,91 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import vm from 'node:vm';
+
+function createElement(tagName) {
+  return {
+    tagName,
+    children: [],
+    className: '',
+    dataset: {},
+    textContent: '',
+    open: false,
+    append(...items) {
+      this.children.push(...items);
+    },
+    appendChild(item) {
+      this.children.push(item);
+    },
+    addEventListener() {},
+    setAttribute(name, value) {
+      this[name] = value;
+    },
+  };
+}
+
+function loadRenderModule() {
+  const document = { createElement };
+  const window = {
+    document,
+    SpritzACPClient: {
+      extractACPText(value) {
+        if (value == null) return '';
+        if (typeof value === 'string') return value;
+        if (Array.isArray(value)) return value.map((item) => this.extractACPText(item)).join('\n');
+        if (typeof value.text === 'string') return value.text;
+        if (value.content) return this.extractACPText(value.content);
+        if (value.resource?.text) return value.resource.text;
+        return '';
+      },
+    },
+  };
+  window.window = window;
+  const context = vm.createContext({ window, document, console });
+  context.globalThis = context.window;
+  const script = fs.readFileSync('/Users/onur/repos/spritz/ui/public/acp-render.js', 'utf8');
+  vm.runInContext(script, context, { filename: 'acp-render.js' });
+  return window.SpritzACPRender;
+}
+
+test('ACP render adapter keeps commands out of transcript and upserts tool cards', () => {
+  const ACPRender = loadRenderModule();
+  const transcript = ACPRender.createTranscript();
+
+  ACPRender.applySessionUpdate(transcript, {
+    sessionUpdate: 'available_commands_update',
+    availableCommands: [
+      { name: 'help', description: 'Show help' },
+      { name: 'bash', description: 'Run bash' },
+    ],
+  });
+
+  assert.equal(transcript.messages.length, 0);
+  assert.deepEqual(
+    transcript.availableCommands.map((item) => item.name),
+    ['help', 'bash'],
+  );
+
+  ACPRender.applySessionUpdate(transcript, {
+    sessionUpdate: 'tool_call',
+    toolCallId: 'tool-1',
+    title: 'Search workspace',
+    status: 'in_progress',
+    rawInput: { query: 'acp' },
+  });
+
+  ACPRender.applySessionUpdate(transcript, {
+    sessionUpdate: 'tool_call_update',
+    toolCallId: 'tool-1',
+    status: 'completed',
+    rawOutput: { result: 'done' },
+  });
+
+  assert.equal(transcript.messages.length, 1);
+  const toolCard = transcript.messages[0];
+  assert.equal(toolCard.kind, 'tool');
+  assert.equal(toolCard.title, 'Search workspace');
+  assert.equal(toolCard.status, 'completed');
+  assert.equal(toolCard.blocks.some((block) => block.type === 'details' && block.title === 'Input'), true);
+  assert.equal(toolCard.blocks.some((block) => block.type === 'details' && block.title === 'Result'), true);
+});

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -83,6 +83,7 @@ ttl: 8h"
 
     <script src="/config.js?v=__SPRITZ_UI_ASSET_VERSION__"></script>
     <script src="/acp-client.js?v=__SPRITZ_UI_ASSET_VERSION__"></script>
+    <script src="/acp-render.js?v=__SPRITZ_UI_ASSET_VERSION__"></script>
     <script src="/acp-page.js?v=__SPRITZ_UI_ASSET_VERSION__"></script>
     <script src="/preset-panel.js?v=__SPRITZ_UI_ASSET_VERSION__"></script>
     <script src="/app.js?v=__SPRITZ_UI_ASSET_VERSION__"></script>

--- a/ui/public/styles.css
+++ b/ui/public/styles.css
@@ -194,141 +194,217 @@ button.ghost {
   min-height: 60vh;
 }
 
-.acp-card {
+.shell[data-view="chat"] {
+  max-width: none;
+  min-height: 100vh;
+  padding: 20px;
+}
+
+.shell[data-view="chat"] > header {
+  display: none;
+}
+
+.shell[data-view="chat"] > #notice {
+  max-width: 860px;
+  margin: 0 auto;
+}
+
+.acp-shell {
   display: grid;
-  grid-template-columns: 280px 280px 1fr;
-  gap: 20px;
-  min-height: 70vh;
+  grid-template-columns: 320px minmax(0, 1fr);
+  min-height: calc(100vh - 40px);
   padding: 0;
   overflow: hidden;
 }
 
 .acp-sidebar {
-  border-right: 1px solid #e5e8ec;
   display: flex;
   flex-direction: column;
-  min-height: 70vh;
+  border-right: 1px solid #e5e8ec;
+  background: rgba(247, 247, 248, 0.96);
+  min-height: calc(100vh - 40px);
 }
 
-.acp-conversation-sidebar {
-  border-right: 1px solid #e5e8ec;
+.acp-sidebar-top {
   display: flex;
   flex-direction: column;
-  min-height: 70vh;
-}
-
-.acp-sidebar-header {
-  padding: 24px 24px 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+  gap: 16px;
+  padding: 20px;
   border-bottom: 1px solid #e5e8ec;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(247, 247, 248, 0.94));
 }
 
-.acp-sidebar-header h2,
-.acp-thread-header h2 {
-  margin: 0;
-}
-
-.acp-sidebar-header p,
-.acp-thread-header p {
-  margin: 0;
-  opacity: 0.65;
-}
-
-.acp-sidebar-actions {
+.acp-sidebar-nav {
   display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
 }
 
-.acp-agent-list {
-  display: flex;
-  flex-direction: column;
-  padding: 12px;
-  gap: 8px;
-  overflow: auto;
-}
-
-.acp-conversation-list {
-  display: flex;
-  flex-direction: column;
-  padding: 12px;
-  gap: 8px;
-  overflow: auto;
-}
-
-.acp-agent-item {
-  border: 1px solid #e5e8ec;
-  border-radius: 16px;
-  background: white;
-  padding: 14px 16px;
+.acp-sidebar-title {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  text-align: left;
 }
 
-.acp-agent-item[data-active="true"] {
-  border-color: #2e3a46;
-  background: #f3f5f7;
+.acp-sidebar-title h2,
+.acp-main-copy h2 {
+  margin: 0;
 }
 
-.acp-conversation-item {
-  border: 1px solid #e5e8ec;
+.acp-sidebar-title p,
+.acp-main-copy p {
+  margin: 0;
+  opacity: 0.68;
+}
+
+.acp-agent-select {
+  width: 100%;
+  padding: 12px 14px;
   border-radius: 16px;
+  border: 1px solid #d7dbe0;
   background: white;
-  padding: 14px 16px;
+  color: #1f2a33;
+  font: inherit;
+}
+
+.acp-thread-list {
+  flex: 1;
+  overflow: auto;
+  padding: 12px;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
+}
+
+.acp-thread-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  width: 100%;
+  padding: 12px 14px;
+  border-radius: 18px;
+  border: 0;
+  background: transparent;
+  color: inherit;
   text-align: left;
 }
 
-.acp-conversation-item[data-active="true"] {
-  border-color: #2e3a46;
-  background: #f3f5f7;
+.acp-thread-item:hover,
+.acp-thread-item[data-active="true"] {
+  background: white;
+  box-shadow: 0 8px 28px rgba(15, 23, 42, 0.08);
 }
 
-.acp-agent-item strong {
+.acp-thread-avatar {
+  width: 42px;
+  height: 42px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #2e3a46;
+  color: white;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.acp-thread-item-body {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.acp-thread-item-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.acp-thread-item-title {
   font-size: 15px;
 }
 
-.acp-agent-item small,
-.acp-conversation-item small {
-  opacity: 0.65;
+.acp-thread-item-time,
+.acp-thread-item-meta {
+  font-size: 12px;
+  opacity: 0.62;
 }
 
-.acp-thread {
+.acp-thread-item-preview {
+  margin: 0;
+  font-size: 13px;
+  color: #5d6772;
+}
+
+.acp-thread-item-meta {
+  margin: 0;
+}
+
+.acp-main {
   display: flex;
   flex-direction: column;
-  min-height: 70vh;
+  min-width: 0;
+  min-height: calc(100vh - 40px);
+  background:
+    radial-gradient(circle at top left, rgba(120, 177, 255, 0.08), transparent 28%),
+    linear-gradient(180deg, #f7f8fa 0%, #eef1f5 100%);
 }
 
-.acp-thread-header {
-  padding: 24px 24px 16px;
-  border-bottom: 1px solid #e5e8ec;
+.acp-main-header {
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid rgba(229, 232, 236, 0.9);
+  background: rgba(255, 255, 255, 0.82);
+  backdrop-filter: blur(16px);
+}
+
+.acp-main-header-top {
   display: flex;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 16px;
-  align-items: flex-start;
 }
 
-.acp-thread-actions {
+.acp-main-actions {
   display: flex;
   gap: 8px;
 }
 
-.acp-thread-body {
+.acp-command-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding-top: 14px;
+}
+
+.acp-command-pill,
+.acp-inline-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(46, 58, 70, 0.12);
+  background: rgba(255, 255, 255, 0.84);
+  font-size: 12px;
+}
+
+.acp-main-body {
   flex: 1;
-  padding: 20px 24px;
+  overflow: auto;
+  padding: 28px 24px 12px;
+}
+
+.acp-stream {
+  max-width: 880px;
+  margin: 0 auto;
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  overflow: auto;
-  background:
-    radial-gradient(circle at top right, rgba(120, 177, 255, 0.08), transparent 30%),
-    linear-gradient(180deg, rgba(248, 249, 251, 0.95), rgba(244, 246, 248, 0.95));
+  gap: 16px;
 }
 
 .acp-empty {
@@ -338,69 +414,215 @@ button.ghost {
   opacity: 0.7;
 }
 
-.acp-message {
-  max-width: min(720px, 88%);
-  border-radius: 20px;
-  padding: 14px 16px;
-  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.06);
-  white-space: pre-wrap;
-  word-break: break-word;
+.acp-empty--sidebar {
+  margin: 24px 12px;
+  text-align: left;
 }
 
-.acp-message[data-kind="user"] {
+.acp-welcome-card {
+  max-width: 680px;
+  margin: auto;
+  padding: 24px;
+  border-radius: 24px;
+  border: 1px solid rgba(46, 58, 70, 0.08);
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 18px 44px rgba(15, 23, 42, 0.08);
+}
+
+.acp-welcome-card strong {
+  display: block;
+  font-size: 20px;
+  margin-bottom: 8px;
+}
+
+.acp-welcome-card p {
+  margin: 0;
+  color: #5d6772;
+}
+
+.acp-message {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: min(820px, 86%);
+}
+
+.acp-message--user {
   align-self: flex-end;
+}
+
+.acp-message--assistant {
+  align-self: flex-start;
+}
+
+.acp-message--tool,
+.acp-message--plan,
+.acp-message--system {
+  align-self: stretch;
+  max-width: 100%;
+}
+
+.acp-bubble,
+.acp-event-card {
+  border-radius: 24px;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.06);
+}
+
+.acp-bubble {
+  padding: 16px 18px;
+  border: 1px solid rgba(229, 232, 236, 0.9);
+  background: white;
+}
+
+.acp-message--user .acp-bubble {
   background: #2e3a46;
   color: white;
-  border-bottom-right-radius: 8px;
+  border-color: transparent;
+  border-bottom-right-radius: 10px;
 }
 
-.acp-message[data-kind="assistant"] {
-  align-self: flex-start;
-  background: white;
-  border: 1px solid #e5e8ec;
-  border-bottom-left-radius: 8px;
+.acp-message--assistant .acp-bubble {
+  border-bottom-left-radius: 10px;
 }
 
-.acp-message[data-kind="tool"],
-.acp-message[data-kind="plan"],
-.acp-message[data-kind="system"] {
-  align-self: center;
-  background: rgba(255, 255, 255, 0.92);
-  border: 1px solid rgba(46, 58, 70, 0.12);
-  max-width: min(760px, 94%);
+.acp-event-card {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 16px 18px;
+  border: 1px solid rgba(46, 58, 70, 0.1);
+  background: rgba(255, 255, 255, 0.9);
 }
 
-.acp-message-header {
+.acp-message-meta {
   display: flex;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 12px;
-  margin-bottom: 8px;
-  font-size: 12px;
-  opacity: 0.7;
+  margin-bottom: 10px;
 }
 
-.acp-message-plan {
+.acp-meta-stack {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.acp-message-meta-text {
+  font-size: 12px;
+  opacity: 0.64;
+}
+
+.acp-status-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  text-transform: capitalize;
+  background: rgba(55, 130, 255, 0.12);
+  color: #1c3f8a;
+}
+
+.acp-status-pill[data-tone="success"] {
+  background: rgba(22, 163, 74, 0.14);
+  color: #166534;
+}
+
+.acp-status-pill[data-tone="danger"] {
+  background: rgba(220, 38, 38, 0.12);
+  color: #991b1b;
+}
+
+.acp-block {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.acp-rich-paragraph {
+  margin: 0;
+  line-height: 1.6;
+  white-space: pre-wrap;
+}
+
+.acp-code-block,
+.acp-details-body {
+  margin: 0;
+  padding: 14px 16px;
+  border-radius: 16px;
+  background: #101827;
+  color: #f8fafc;
+  overflow: auto;
+  font-size: 12px;
+  line-height: 1.55;
+  font-family: "SFMono-Regular", "JetBrains Mono", "Menlo", monospace;
+}
+
+.acp-details {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.acp-details summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.acp-plan-list {
   margin: 0;
   padding-left: 20px;
 }
 
-.acp-message-plan li + li {
+.acp-plan-list li + li {
   margin-top: 6px;
 }
 
-.acp-tool-content {
-  margin-top: 10px;
-  padding-top: 10px;
-  border-top: 1px solid rgba(46, 58, 70, 0.1);
+.acp-key-value {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 8px 12px;
+  margin: 0;
 }
 
-.acp-thread-footer {
-  border-top: 1px solid #e5e8ec;
-  padding: 16px 24px 24px;
+.acp-key-value dt {
+  font-weight: 600;
+}
+
+.acp-key-value dd {
+  margin: 0;
+  opacity: 0.74;
+}
+
+.acp-tag-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.acp-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(46, 58, 70, 0.08);
+  font-size: 12px;
+}
+
+.acp-main-footer {
+  border-top: 1px solid rgba(229, 232, 236, 0.9);
+  background: rgba(255, 255, 255, 0.92);
+}
+
+.acp-footer-inner {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 16px 24px 22px;
   display: flex;
   flex-direction: column;
   gap: 12px;
-  background: white;
 }
 
 .acp-permission {
@@ -424,15 +646,22 @@ button.ghost {
 }
 
 .acp-status-row {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: auto auto 1fr;
   gap: 12px;
   align-items: center;
   font-size: 13px;
 }
 
 .acp-status {
-  opacity: 0.7;
+  opacity: 0.72;
+}
+
+.acp-status-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
 }
 
 .acp-composer {
@@ -443,6 +672,11 @@ button.ghost {
 
 .acp-composer textarea {
   min-height: 120px;
+  font-family: inherit;
+  font-size: 16px;
+  line-height: 1.55;
+  border-radius: 18px;
+  padding: 14px 16px;
 }
 
 .acp-composer-actions {
@@ -455,6 +689,7 @@ button.ghost {
 .acp-hint {
   font-size: 12px;
   opacity: 0.65;
+  justify-self: end;
 }
 
 .terminal-bar {
@@ -492,8 +727,14 @@ button.ghost {
     align-items: stretch;
   }
 
-  .acp-card {
+  .shell[data-view="chat"] {
+    padding: 0;
+  }
+
+  .acp-shell {
     grid-template-columns: 1fr;
+    min-height: 100vh;
+    border-radius: 0;
   }
 
   .acp-sidebar {
@@ -502,17 +743,20 @@ button.ghost {
     border-bottom: 1px solid #e5e8ec;
   }
 
-  .acp-conversation-sidebar {
+  .acp-main {
     min-height: auto;
-    border-right: 0;
-    border-bottom: 1px solid #e5e8ec;
   }
 
-  .acp-thread-header,
+  .acp-main-header-top,
   .acp-status-row,
   .acp-composer-actions {
+    display: flex;
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .acp-hint {
+    justify-self: start;
   }
 
   .acp-message {


### PR DESCRIPTION
## Summary
- collapse the ACP page into a sandbox-style two-pane chat shell
- add a typed ACP renderer so commands and tool calls render as structured chat content instead of raw JSON
- add regression tests for the new renderer and layout contract
