### PR TITLE
fix(ui): restore acp chat state and toast errors

### DIFF
--- a/ui/public/acp-client.js
+++ b/ui/public/acp-client.js
@@ -45,8 +45,18 @@
     let sessionId = conversation?.spec?.sessionId || '';
     let loadSessionSupported = false;
 
-    function cleanupPending(errorMessage) {
-      pending.forEach(({ reject }) => reject(new Error(errorMessage)));
+    function createACPError(code, message) {
+      const error = new Error(message);
+      error.code = code;
+      return error;
+    }
+
+    function cleanupPending(error) {
+      const resolvedError =
+        error instanceof Error
+          ? error
+          : createACPError('ACP_REQUEST_CANCELLED', String(error || 'ACP request cancelled.'));
+      pending.forEach(({ reject }) => reject(resolvedError));
       pending.clear();
     }
 
@@ -205,7 +215,7 @@
         };
         ws.onclose = () => {
           ready = false;
-          cleanupPending('ACP connection closed.');
+          cleanupPending(createACPError('ACP_CONNECTION_CLOSED', 'ACP connection closed.'));
           if (typeof onReadyChange === 'function') {
             onReadyChange(false);
           }
@@ -243,7 +253,7 @@
       dispose() {
         disposed = true;
         ready = false;
-        cleanupPending('ACP client disposed.');
+        cleanupPending(createACPError('ACP_CLIENT_DISPOSED', 'ACP client disposed.'));
         try {
           if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) {
             ws.close();

--- a/ui/public/acp-page-cache.test.mjs
+++ b/ui/public/acp-page-cache.test.mjs
@@ -1,0 +1,183 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import vm from 'node:vm';
+
+function createStorage(seed = {}) {
+  const values = new Map(Object.entries(seed));
+  return {
+    getItem(key) {
+      return values.has(key) ? values.get(key) : null;
+    },
+    setItem(key, value) {
+      values.set(key, String(value));
+    },
+    removeItem(key) {
+      values.delete(key);
+    },
+  };
+}
+
+function createElement(tagName) {
+  return {
+    tagName,
+    hidden: false,
+    disabled: false,
+    textContent: '',
+    innerHTML: '',
+    value: '',
+    className: '',
+    children: [],
+    dataset: {},
+    style: {},
+    append(...items) {
+      this.children.push(...items);
+    },
+    appendChild(item) {
+      this.children.push(item);
+    },
+    remove() {
+      this.removed = true;
+    },
+    addEventListener() {},
+    setAttribute(name, value) {
+      this[name] = value;
+    },
+    querySelector() {
+      return null;
+    },
+    contains() {
+      return false;
+    },
+  };
+}
+
+function collectText(node) {
+  if (!node) return '';
+  const own = typeof node.textContent === 'string' ? node.textContent : '';
+  const childText = Array.isArray(node.children) ? node.children.map((child) => collectText(child)).join(' ') : '';
+  return `${own} ${childText}`.replace(/\s+/g, ' ').trim();
+}
+
+function loadModules(storageSeed = {}) {
+  const document = { createElement };
+  const window = {
+    document,
+    location: {
+      hash: '#chat/young-crest/conv-1',
+      assign() {},
+      replace() {},
+      origin: 'https://example.test',
+    },
+    sessionStorage: createStorage(storageSeed),
+    open() {},
+    setTimeout,
+    clearTimeout,
+    SpritzACPClient: {
+      createACPClient() {
+        return {
+          start: async () => {},
+          isReady: () => true,
+          cancelPrompt() {},
+          dispose() {},
+        };
+      },
+      extractACPText(value) {
+        return typeof value?.text === 'string' ? value.text : '';
+      },
+    },
+  };
+  window.window = window;
+  const context = vm.createContext({ window, document, console, setTimeout, clearTimeout, URL, URLSearchParams });
+  context.globalThis = context.window;
+  vm.runInContext(fs.readFileSync('/Users/onur/repos/spritz/ui/public/acp-render.js', 'utf8'), context, {
+    filename: 'acp-render.js',
+  });
+  vm.runInContext(fs.readFileSync('/Users/onur/repos/spritz/ui/public/acp-page.js', 'utf8'), context, {
+    filename: 'acp-page.js',
+  });
+  return window;
+}
+
+test('ACP page restores cached transcript when revisiting a conversation', async () => {
+  const cacheKey = 'spritz:acp:transcript:conv-1';
+  const window = loadModules({
+    [cacheKey]: JSON.stringify({
+      version: 1,
+      conversationId: 'conv-1',
+      transcript: {
+        messages: [
+          {
+            id: 'assistant-1',
+            kind: 'assistant',
+            title: '',
+            status: '',
+            tone: '',
+            meta: '',
+            blocks: [{ type: 'text', text: 'Cached assistant reply.' }],
+            streaming: false,
+            toolCallId: '',
+          },
+        ],
+        availableCommands: [],
+        currentMode: '',
+        usage: null,
+      },
+    }),
+  });
+
+  const shellEl = createElement('main');
+  const createSection = createElement('section');
+  const listSection = createElement('section');
+
+  window.SpritzACPPage.renderACPPage('young-crest', 'conv-1', {
+    activePage: null,
+    apiBaseUrl: '',
+    authBearerTokenParam: 'token',
+    getAuthToken() {
+      return '';
+    },
+    async request(path) {
+      if (path === '/acp/agents') {
+        return {
+          items: [
+            {
+              spritz: {
+                metadata: { name: 'young-crest' },
+                status: {
+                  acp: { agentInfo: { title: 'OpenClaw ACP Gateway', version: '2026.3.8' } },
+                },
+              },
+            },
+          ],
+        };
+      }
+      if (path.startsWith('/acp/conversations?')) {
+        return {
+          items: [
+            {
+              metadata: { name: 'conv-1' },
+              spec: { title: 'Cached conversation', sessionId: 'sess-1' },
+              status: { updatedAt: '2026-03-10T06:00:00Z' },
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected path ${path}`);
+    },
+    showNotice() {},
+    buildOpenUrl(url) {
+      return url;
+    },
+    cleanupTerminal() {},
+    shellEl,
+    createSection,
+    listSection,
+    setHeaderCopy() {},
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.match(collectText(shellEl), /Cached assistant reply\./);
+});

--- a/ui/public/acp-page-notice.test.mjs
+++ b/ui/public/acp-page-notice.test.mjs
@@ -1,0 +1,220 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import vm from 'node:vm';
+
+function createElement(tagName) {
+  return {
+    tagName,
+    hidden: false,
+    disabled: false,
+    textContent: '',
+    innerHTML: '',
+    value: '',
+    className: '',
+    children: [],
+    dataset: {},
+    style: {},
+    append(...items) {
+      this.children.push(...items);
+    },
+    appendChild(item) {
+      this.children.push(item);
+    },
+    remove() {
+      this.removed = true;
+    },
+    addEventListener() {},
+    setAttribute(name, value) {
+      this[name] = value;
+    },
+    querySelector() {
+      return null;
+    },
+  };
+}
+
+function loadModules(createACPClient) {
+  const document = { createElement };
+  const window = {
+    document,
+    location: {
+      hash: '#chat/young-crest/conv-1',
+      assign() {},
+      replace() {},
+      origin: 'https://example.test',
+    },
+    open() {},
+    setTimeout,
+    clearTimeout,
+    SpritzACPClient: {
+      createACPClient,
+      extractACPText(value) {
+        return typeof value?.text === 'string' ? value.text : '';
+      },
+    },
+  };
+  window.window = window;
+  const context = vm.createContext({ window, document, console, setTimeout, clearTimeout, URL, URLSearchParams });
+  context.globalThis = context.window;
+  vm.runInContext(fs.readFileSync('/Users/onur/repos/spritz/ui/public/acp-render.js', 'utf8'), context, {
+    filename: 'acp-render.js',
+  });
+  vm.runInContext(fs.readFileSync('/Users/onur/repos/spritz/ui/public/acp-page.js', 'utf8'), context, {
+    filename: 'acp-page.js',
+  });
+  return window;
+}
+
+test('ACP client dispose errors do not surface as global notices', async () => {
+  const noticeMessages = [];
+  const toastMessages = [];
+  const disposedError = Object.assign(new Error('ACP client disposed.'), { code: 'ACP_CLIENT_DISPOSED' });
+  const window = loadModules(() => ({
+    start: async () => {
+      throw disposedError;
+    },
+    isReady: () => false,
+    cancelPrompt() {},
+    dispose() {},
+  }));
+  const shellEl = createElement('main');
+  const createSection = createElement('section');
+  const listSection = createElement('section');
+
+  window.SpritzACPPage.renderACPPage('young-crest', 'conv-1', {
+    activePage: null,
+    apiBaseUrl: '',
+    authBearerTokenParam: 'token',
+    getAuthToken() {
+      return '';
+    },
+    async request(path) {
+      if (path === '/acp/agents') {
+        return {
+          items: [
+            {
+              spritz: {
+                metadata: { name: 'young-crest' },
+                status: {
+                  acp: { agentInfo: { title: 'OpenClaw ACP Gateway', version: '2026.3.8' } },
+                },
+              },
+            },
+          ],
+        };
+      }
+      if (path.startsWith('/acp/conversations?')) {
+        return {
+          items: [
+            {
+              metadata: { name: 'conv-1' },
+              spec: { title: 'Test conversation', sessionId: 'sess-1' },
+              status: { updatedAt: '2026-03-10T05:44:00Z' },
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected path ${path}`);
+    },
+    showNotice(message) {
+      noticeMessages.push(message);
+    },
+    clearNotice() {
+      noticeMessages.push('');
+    },
+    showToast(message) {
+      toastMessages.push(message);
+    },
+    buildOpenUrl(url) {
+      return url;
+    },
+    cleanupTerminal() {},
+    shellEl,
+    createSection,
+    listSection,
+    setHeaderCopy() {},
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.deepEqual(noticeMessages.filter(Boolean), []);
+  assert.deepEqual(toastMessages, []);
+});
+
+test('ACP page surfaces real startup errors as toasts', async () => {
+  const noticeMessages = [];
+  const toastMessages = [];
+  const window = loadModules(() => ({
+    start: async () => {
+      throw new Error('Failed to connect to ACP gateway.');
+    },
+    isReady: () => false,
+    cancelPrompt() {},
+    dispose() {},
+  }));
+  const shellEl = createElement('main');
+  const createSection = createElement('section');
+  const listSection = createElement('section');
+
+  window.SpritzACPPage.renderACPPage('young-crest', 'conv-1', {
+    activePage: null,
+    apiBaseUrl: '',
+    authBearerTokenParam: 'token',
+    getAuthToken() {
+      return '';
+    },
+    async request(path) {
+      if (path === '/acp/agents') {
+        return {
+          items: [
+            {
+              spritz: {
+                metadata: { name: 'young-crest' },
+                status: {
+                  acp: { agentInfo: { title: 'OpenClaw ACP Gateway', version: '2026.3.8' } },
+                },
+              },
+            },
+          ],
+        };
+      }
+      if (path.startsWith('/acp/conversations?')) {
+        return {
+          items: [
+            {
+              metadata: { name: 'conv-1' },
+              spec: { title: 'Test conversation', sessionId: 'sess-1' },
+              status: { updatedAt: '2026-03-10T05:44:00Z' },
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected path ${path}`);
+    },
+    showNotice(message) {
+      noticeMessages.push(message);
+    },
+    clearNotice() {
+      noticeMessages.push('');
+    },
+    showToast(message) {
+      toastMessages.push(message);
+    },
+    buildOpenUrl(url) {
+      return url;
+    },
+    cleanupTerminal() {},
+    shellEl,
+    createSection,
+    listSection,
+    setHeaderCopy() {},
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.deepEqual(noticeMessages.filter(Boolean), []);
+  assert.deepEqual(toastMessages, ['Failed to connect to ACP gateway.']);
+});

--- a/ui/public/acp-page.js
+++ b/ui/public/acp-page.js
@@ -1,6 +1,10 @@
 (function (global) {
   const { createACPClient } = global.SpritzACPClient;
   const ACPRender = global.SpritzACPRender;
+  const ACP_TRANSCRIPT_CACHE_VERSION = 1;
+  const ACP_TRANSCRIPT_CACHE_PREFIX = 'spritz:acp:transcript:';
+  const ACP_TRANSCRIPT_CACHE_INDEX_KEY = 'spritz:acp:transcript:index';
+  const ACP_TRANSCRIPT_CACHE_LIMIT = 25;
 
   function chatPagePath(name = '', conversationId = '') {
     if (!name) return '#chat';
@@ -85,7 +89,152 @@
       client: null,
       reconnectTimer: null,
       destroyed: false,
+      bootstrapComplete: false,
+      cacheHydratedTranscript: false,
+      cacheReplacedByReplay: false,
     };
+  }
+
+  function isBenignACPError(err) {
+    const code = String(err?.code || '');
+    const message = String(err?.message || '');
+    return (
+      code === 'ACP_CLIENT_DISPOSED' ||
+      code === 'ACP_CONNECTION_CLOSED' ||
+      message === 'ACP client disposed.' ||
+      message === 'ACP connection closed.'
+    );
+  }
+
+  function clearACPNotice(page) {
+    if (typeof page.deps.clearNotice === 'function') {
+      page.deps.clearNotice();
+      return;
+    }
+    if (typeof page.deps.showNotice === 'function') {
+      page.deps.showNotice('');
+    }
+  }
+
+  function showACPToast(page, message, kind = 'error') {
+    if (!message) return;
+    if (typeof page.deps.showToast === 'function') {
+      page.deps.showToast(message, kind);
+      return;
+    }
+    if (typeof page.deps.showNotice === 'function') {
+      page.deps.showNotice(message, kind);
+    }
+  }
+
+  function safeSessionStorage() {
+    try {
+      return window.sessionStorage || window.localStorage || null;
+    } catch {
+      return null;
+    }
+  }
+
+  function readTranscriptCacheIndex(storage) {
+    if (!storage) return [];
+    try {
+      const raw = storage.getItem(ACP_TRANSCRIPT_CACHE_INDEX_KEY);
+      const parsed = raw ? JSON.parse(raw) : [];
+      return Array.isArray(parsed) ? parsed.filter((item) => typeof item === 'string' && item) : [];
+    } catch {
+      return [];
+    }
+  }
+
+  function writeTranscriptCacheIndex(storage, ids) {
+    if (!storage) return;
+    try {
+      storage.setItem(ACP_TRANSCRIPT_CACHE_INDEX_KEY, JSON.stringify(ids));
+    } catch {
+      // ignore storage errors
+    }
+  }
+
+  function conversationTranscriptCacheKey(conversationId) {
+    return `${ACP_TRANSCRIPT_CACHE_PREFIX}${conversationId}`;
+  }
+
+  function readCachedConversationRecord(conversationId) {
+    const normalizedId = String(conversationId || '').trim();
+    if (!normalizedId) return null;
+    const storage = safeSessionStorage();
+    if (!storage) return null;
+    try {
+      const raw = storage.getItem(conversationTranscriptCacheKey(normalizedId));
+      if (!raw) return null;
+      const parsed = JSON.parse(raw);
+      if (parsed?.version !== ACP_TRANSCRIPT_CACHE_VERSION || typeof parsed !== 'object') {
+        return null;
+      }
+      return parsed;
+    } catch {
+      return null;
+    }
+  }
+
+  function writeCachedConversationRecord(page) {
+    const conversationId = page.selectedConversation?.metadata?.name || '';
+    if (!conversationId) return;
+    const storage = safeSessionStorage();
+    if (!storage) return;
+
+    const preview = ACPRender.getPreviewText(page.transcript);
+    const payload = {
+      version: ACP_TRANSCRIPT_CACHE_VERSION,
+      conversationId,
+      spritzName: page.selectedName || '',
+      sessionId: page.selectedConversation?.spec?.sessionId || '',
+      updatedAt: new Date().toISOString(),
+      preview,
+      transcript: ACPRender.serializeTranscript(page.transcript),
+    };
+    try {
+      storage.setItem(conversationTranscriptCacheKey(conversationId), JSON.stringify(payload));
+      const nextIndex = [conversationId, ...readTranscriptCacheIndex(storage).filter((item) => item !== conversationId)];
+      const prunedIndex = nextIndex.slice(0, ACP_TRANSCRIPT_CACHE_LIMIT);
+      writeTranscriptCacheIndex(storage, prunedIndex);
+      nextIndex.slice(ACP_TRANSCRIPT_CACHE_LIMIT).forEach((staleId) => {
+        storage.removeItem(conversationTranscriptCacheKey(staleId));
+      });
+    } catch {
+      // ignore storage errors
+    }
+    if (preview) {
+      page.previewByConversationId.set(conversationId, preview);
+    }
+  }
+
+  function hydrateCachedConversationPreviews(page) {
+    page.conversations.forEach((conversation) => {
+      const id = conversation?.metadata?.name || '';
+      if (!id) return;
+      const cached = readCachedConversationRecord(id);
+      if (cached?.preview) {
+        page.previewByConversationId.set(id, cached.preview);
+      }
+    });
+  }
+
+  function restoreCachedConversationTranscript(page) {
+    const conversationId = page.selectedConversation?.metadata?.name || '';
+    if (!conversationId) return false;
+    const cached = readCachedConversationRecord(conversationId);
+    if (!cached?.transcript) return false;
+    page.transcript = ACPRender.hydrateTranscript(cached.transcript);
+    if (cached.preview) {
+      page.previewByConversationId.set(conversationId, cached.preview);
+    }
+    return page.transcript.messages.length > 0;
+  }
+
+  function reportACPError(page, err, fallback, kind = 'error') {
+    if (isBenignACPError(err)) return;
+    showACPToast(page, err?.message || fallback, kind);
   }
 
   function getAgentTitle(agent) {
@@ -271,7 +420,7 @@
             },
           });
         } catch (err) {
-          page.deps.showNotice(err.message || 'Failed to send permission response.');
+          reportACPError(page, err, 'Failed to send permission response.');
         } finally {
           page.permissionQueue.shift();
           renderPermissionPrompt(page);
@@ -393,6 +542,7 @@
       patchSelectedConversation(page, { title: result.conversationTitle }).catch(() => {});
     }
     updateConversationPreview(page);
+    writeCachedConversationRecord(page);
     renderConversationList(page);
     renderThread(page);
   }
@@ -426,11 +576,14 @@
   }
 
   async function connectSelectedConversation(page) {
-    resetConversationRuntime(page);
     if (!page.selectedAgent || !page.selectedConversation) {
+      resetConversationRuntime(page);
       renderThread(page);
       return;
     }
+    page.bootstrapComplete = false;
+    page.cacheHydratedTranscript = page.transcript.messages.length > 0;
+    page.cacheReplacedByReplay = false;
     renderThread(page);
     page.client = createACPClient({
       wsUrl: acpWsUrl(page.selectedName, page.deps),
@@ -461,6 +614,15 @@
         renderThread(page);
       },
       onUpdate(update) {
+        if (
+          !page.bootstrapComplete &&
+          page.cacheHydratedTranscript &&
+          !page.cacheReplacedByReplay &&
+          ACPRender.isTranscriptBearingUpdate(update)
+        ) {
+          page.transcript = ACPRender.createTranscript();
+          page.cacheReplacedByReplay = true;
+        }
         applyACPUpdate(page, update);
       },
       onPermissionRequest(entry) {
@@ -475,6 +637,7 @@
         if (!value) {
           ACPRender.finalizeStreaming(page.transcript);
           updateConversationPreview(page);
+          writeCachedConversationRecord(page);
           renderConversationList(page);
         }
         syncComposer(page);
@@ -484,17 +647,23 @@
         scheduleReconnect(page);
       },
       onProtocolError(err) {
-        page.deps.showNotice(err.message || 'Invalid ACP message.', 'info');
+        reportACPError(page, err, 'Invalid ACP message.', 'info');
       },
     });
     syncComposer(page);
     await page.client.start();
+    page.bootstrapComplete = true;
+    writeCachedConversationRecord(page);
+    clearACPNotice(page);
   }
 
   async function selectConversation(page, conversationId) {
     page.selectedConversationId = conversationId || '';
     page.selectedConversation = page.conversations.find((item) => item.metadata?.name === conversationId) || null;
     resetConversationRuntime(page);
+    if (page.selectedConversation) {
+      restoreCachedConversationTranscript(page);
+    }
     renderConversationList(page);
     renderThread(page);
     if (page.selectedConversation) {
@@ -514,6 +683,7 @@
       return;
     }
     page.conversations = await listACPConversationsData(page.deps, page.selectedName);
+    hydrateCachedConversationPreviews(page);
     const routeConversationId = conversationIdFromHash(window.location.hash || '');
     const resolvedConversationId =
       page.conversations.find((item) => item.metadata?.name === routeConversationId)?.metadata?.name ||
@@ -530,6 +700,7 @@
 
   async function loadACPPage(page) {
     try {
+      clearACPNotice(page);
       setStatus(page, 'Loading workspaces…');
       page.agents = await fetchACPAgentsData(page.deps);
       renderAgentPicker(page);
@@ -562,8 +733,11 @@
         setStatus(page, 'Choose or create a conversation.');
       }
     } catch (err) {
+      if (isBenignACPError(err)) {
+        return;
+      }
       setStatus(page, err.message || 'Failed to load ACP page.');
-      page.deps.showNotice(err.message || 'Failed to load ACP page.');
+      reportACPError(page, err, 'Failed to load ACP page.');
     }
   }
 
@@ -739,7 +913,7 @@
         renderConversationList(page);
         window.location.assign(chatPagePath(page.selectedName, conversation.metadata?.name || ''));
       } catch (err) {
-        page.deps.showNotice(err.message || 'Failed to create conversation.');
+        reportACPError(page, err, 'Failed to create conversation.');
       }
     });
 
@@ -771,7 +945,7 @@
         const result = await page.client.sendPrompt(text);
         setStatus(page, result?.stopReason ? `Completed · ${result.stopReason}` : 'Completed');
       } catch (err) {
-        page.deps.showNotice(err.message || 'Failed to send ACP prompt.');
+        reportACPError(page, err, 'Failed to send ACP prompt.');
       } finally {
         syncComposer(page);
         renderThread(page);

--- a/ui/public/acp-render.js
+++ b/ui/public/acp-render.js
@@ -32,6 +32,72 @@
     };
   }
 
+  function rebuildToolCallIndex(transcript) {
+    transcript.toolCallIndex = new Map();
+    transcript.messages.forEach((message, index) => {
+      if (message?.kind === 'tool' && message.toolCallId) {
+        transcript.toolCallIndex.set(message.toolCallId, index);
+      }
+    });
+    return transcript;
+  }
+
+  function serializeTranscript(transcript) {
+    return {
+      messages: Array.isArray(transcript?.messages)
+        ? transcript.messages.map((message) => ({
+            id: message.id || '',
+            kind: message.kind || 'system',
+            title: message.title || '',
+            status: message.status || '',
+            tone: message.tone || '',
+            meta: message.meta || '',
+            blocks: Array.isArray(message.blocks) ? message.blocks : [],
+            streaming: Boolean(message.streaming),
+            toolCallId: message.toolCallId || '',
+          }))
+        : [],
+      availableCommands: Array.isArray(transcript?.availableCommands) ? transcript.availableCommands : [],
+      currentMode: typeof transcript?.currentMode === 'string' ? transcript.currentMode : '',
+      usage:
+        transcript?.usage && typeof transcript.usage === 'object'
+          ? {
+              label: typeof transcript.usage.label === 'string' ? transcript.usage.label : '',
+              used: typeof transcript.usage.used === 'number' ? transcript.usage.used : null,
+              size: typeof transcript.usage.size === 'number' ? transcript.usage.size : null,
+            }
+          : null,
+    };
+  }
+
+  function hydrateTranscript(payload) {
+    const transcript = createTranscript();
+    transcript.messages = Array.isArray(payload?.messages)
+      ? payload.messages.map((message) => ({
+          id: message?.id || createId(message?.kind || 'message'),
+          kind: message?.kind || 'system',
+          title: message?.title || '',
+          status: message?.status || '',
+          tone: message?.tone || '',
+          meta: message?.meta || '',
+          blocks: Array.isArray(message?.blocks) ? message.blocks : [],
+          streaming: Boolean(message?.streaming),
+          toolCallId: message?.toolCallId || '',
+        }))
+      : [];
+    transcript.availableCommands = Array.isArray(payload?.availableCommands) ? payload.availableCommands : [];
+    transcript.currentMode = typeof payload?.currentMode === 'string' ? payload.currentMode : '';
+    transcript.usage =
+      payload?.usage && typeof payload.usage === 'object'
+        ? {
+            label: typeof payload.usage.label === 'string' ? payload.usage.label : '',
+            used: typeof payload.usage.used === 'number' ? payload.usage.used : null,
+            size: typeof payload.usage.size === 'number' ? payload.usage.size : null,
+          }
+        : null;
+    return rebuildToolCallIndex(transcript);
+  }
+
   function stringifyDetails(value) {
     if (value === undefined || value === null || value === '') return '';
     if (typeof value === 'string') return value;
@@ -410,12 +476,26 @@
     }));
   }
 
+  function isTranscriptBearingUpdate(update) {
+    const kind = update?.sessionUpdate || '';
+    return ![
+      '',
+      'available_commands_update',
+      'current_mode_update',
+      'usage_update',
+      'session_info_update',
+    ].includes(kind);
+  }
+
   global.SpritzACPRender = {
     buildCommandItems,
     createTranscript,
     applySessionUpdate,
     finalizeStreaming,
     getPreviewText,
+    hydrateTranscript,
+    isTranscriptBearingUpdate,
     renderMessage,
+    serializeTranscript,
   };
 })(window);

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -28,6 +28,7 @@ const launchConfig = config.launch || {};
 const launchQueryParams = parseTemplateMap(launchConfig.queryParams);
 const authReturnToPlaceholder = '__SPRITZ_RETURN_TO__';
 const noticeEl = document.getElementById('notice');
+const toastRegionEl = document.getElementById('toast-region');
 const listEl = document.getElementById('list');
 const refreshBtn = document.getElementById('refresh');
 const form = document.getElementById('create-form');
@@ -574,6 +575,44 @@ function showNotice(message, kind = 'error') {
   noticeEl.hidden = false;
   noticeEl.textContent = message;
   noticeEl.dataset.kind = kind;
+}
+
+function clearNotice() {
+  showNotice('');
+}
+
+function showToast(message, kind = 'error', options = {}) {
+  if (!toastRegionEl || !message) return;
+  const toast = document.createElement('div');
+  toast.className = 'toast';
+  toast.dataset.kind = kind;
+
+  const copy = document.createElement('div');
+  copy.className = 'toast-copy';
+  copy.textContent = message;
+
+  const dismiss = document.createElement('button');
+  dismiss.type = 'button';
+  dismiss.className = 'toast-dismiss';
+  dismiss.textContent = 'Dismiss';
+
+  let timeoutId = null;
+  const removeToast = () => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+    if (typeof toast.remove === 'function') {
+      toast.remove();
+    }
+  };
+
+  dismiss.addEventListener('click', removeToast);
+  toast.append(copy, dismiss);
+  toastRegionEl.appendChild(toast);
+
+  const durationMs = Number(options.durationMs) > 0 ? Number(options.durationMs) : kind === 'error' ? 5200 : 3600;
+  timeoutId = setTimeout(removeToast, durationMs);
 }
 
 function getStorage() {
@@ -1352,6 +1391,8 @@ function renderACPPage(name) {
       getAuthToken,
       request,
       showNotice,
+      clearNotice,
+      showToast,
       buildOpenUrl,
       cleanupTerminal,
       shellEl,

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -18,6 +18,7 @@
         </div>
       </header>
       <div id="notice" class="notice" hidden></div>
+      <div id="toast-region" class="toast-region" aria-live="polite" aria-atomic="true"></div>
 
       <section class="card">
         <h2>Create</h2>

--- a/ui/public/styles.css
+++ b/ui/public/styles.css
@@ -65,6 +65,49 @@ header p {
   color: #1c3f8a;
 }
 
+.toast-region {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  pointer-events: none;
+  max-width: min(420px, calc(100vw - 32px));
+}
+
+.toast {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 90, 90, 0.28);
+  background: rgba(29, 37, 46, 0.94);
+  color: #f5f7fa;
+  box-shadow: 0 18px 40px rgba(12, 18, 28, 0.24);
+  pointer-events: auto;
+}
+
+.toast[data-kind="info"] {
+  border-color: rgba(88, 138, 255, 0.34);
+}
+
+.toast-copy {
+  flex: 1;
+  line-height: 1.45;
+}
+
+.toast-dismiss {
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: rgba(245, 247, 250, 0.84);
+  font: inherit;
+  cursor: pointer;
+}
+
 .card {
   background: white;
   border-radius: 20px;


### PR DESCRIPTION
## Summary
- replace ACP chat banner errors with transient toasts and suppress benign client disposal noise
- restore ACP conversation transcripts from browser session cache when revisiting a conversation URL
- keep transcript cache keyed by the Spritz conversation id used in the route, while preserving ACP session ids as backend session state

## Testing
- node --test ui/public/acp-page-cache.test.mjs ui/public/acp-page-notice.test.mjs ui/public/acp-page-layout.test.mjs ui/public/acp-render.test.mjs ui/public/app-chat-route.test.mjs ui/public/preset-panel.test.mjs
- node --check ui/public/acp-render.js && node --check ui/public/acp-page.js && node --check ui/public/app.js
- git diff --check