### PR TITLE
fix(ui): gate ACP prompts on session bootstrap

### DIFF
--- a/ui/public/acp-client.js
+++ b/ui/public/acp-client.js
@@ -44,10 +44,22 @@
     const pending = new Map();
     let sessionId = conversation?.spec?.sessionId || '';
     let loadSessionSupported = false;
+    let bootstrapComplete = false;
 
     function createACPError(code, message) {
       const error = new Error(message);
       error.code = code;
+      return error;
+    }
+
+    function createRPCError(payload) {
+      const baseMessage = String(payload?.message || 'ACP request failed.');
+      const details =
+        typeof payload?.data?.details === 'string' && payload.data.details.trim()
+          ? payload.data.details.trim()
+          : '';
+      const error = createACPError('ACP_RPC_ERROR', details ? `${baseMessage}: ${details}` : baseMessage);
+      error.rpcError = payload || null;
       return error;
     }
 
@@ -92,6 +104,24 @@
       sendRaw({ jsonrpc: '2.0', method, params });
     }
 
+    function isMissingSessionError(error) {
+      const message = String(error?.message || '').toLowerCase();
+      return message.includes('session') && message.includes('not found');
+    }
+
+    async function createNewSession() {
+      onStatus('Creating session…');
+      const created = await requestRPC('session/new', {
+        cwd: conversation?.spec?.cwd || '/home/dev',
+        mcpServers: [],
+      });
+      sessionId = created?.sessionId || '';
+      if (sessionId && typeof onSessionId === 'function') {
+        await onSessionId(sessionId);
+      }
+      onStatus('Connected');
+    }
+
     async function bootstrapSession() {
       onStatus('Negotiating ACP…');
       const init = await requestRPC('initialize', {
@@ -105,25 +135,24 @@
       }
       if (sessionId && loadSessionSupported) {
         onStatus('Loading conversation…');
-        await requestRPC('session/load', {
-          sessionId,
-          cwd: conversation?.spec?.cwd || '/home/dev',
-          mcpServers: [],
-        });
-        onStatus('Connected');
-        return;
+        try {
+          await requestRPC('session/load', {
+            sessionId,
+            cwd: conversation?.spec?.cwd || '/home/dev',
+            mcpServers: [],
+          });
+          onStatus('Connected');
+          return;
+        } catch (error) {
+          if (!isMissingSessionError(error)) {
+            throw error;
+          }
+          sessionId = '';
+          onStatus('Stored session is unavailable. Creating a new session…');
+        }
       }
 
-      onStatus('Creating session…');
-      const created = await requestRPC('session/new', {
-        cwd: conversation?.spec?.cwd || '/home/dev',
-        mcpServers: [],
-      });
-      sessionId = created?.sessionId || '';
-      if (sessionId && typeof onSessionId === 'function') {
-        await onSessionId(sessionId);
-      }
-      onStatus('Connected');
+      await createNewSession();
     }
 
     function handleIncoming(message) {
@@ -136,7 +165,7 @@
           if (pendingRequest.method === 'session/prompt' && typeof onPromptStateChange === 'function') {
             onPromptStateChange(false);
           }
-          pendingRequest.reject(new Error(message.error.message || 'ACP request failed.'));
+          pendingRequest.reject(createRPCError(message.error));
           return;
         }
         pendingRequest.resolve(message.result);
@@ -176,6 +205,7 @@
     function start() {
       disposed = false;
       ready = false;
+      bootstrapComplete = false;
       if (typeof onReadyChange === 'function') {
         onReadyChange(false);
       }
@@ -183,13 +213,19 @@
         ws = new WebSocket(wsUrl);
         ws.onopen = async () => {
           try {
+            await bootstrapSession();
+            bootstrapComplete = true;
             ready = true;
             if (typeof onReadyChange === 'function') {
               onReadyChange(true);
             }
-            await bootstrapSession();
             resolve();
           } catch (err) {
+            bootstrapComplete = false;
+            ready = false;
+            if (typeof onReadyChange === 'function') {
+              onReadyChange(false);
+            }
             reject(err);
             try {
               ws.close();
@@ -215,6 +251,7 @@
         };
         ws.onclose = () => {
           ready = false;
+          bootstrapComplete = false;
           cleanupPending(createACPError('ACP_CONNECTION_CLOSED', 'ACP connection closed.'));
           if (typeof onReadyChange === 'function') {
             onReadyChange(false);
@@ -229,10 +266,10 @@
     return {
       start,
       isReady() {
-        return Boolean(ws && ws.readyState === WebSocket.OPEN && ready);
+        return Boolean(ws && ws.readyState === WebSocket.OPEN && ready && bootstrapComplete);
       },
       async sendPrompt(text) {
-        if (!sessionId) {
+        if (!sessionId || !this.isReady()) {
           throw new Error('ACP session is not ready yet.');
         }
         if (typeof onPromptStateChange === 'function') {
@@ -253,6 +290,7 @@
       dispose() {
         disposed = true;
         ready = false;
+        bootstrapComplete = false;
         cleanupPending(createACPError('ACP_CLIENT_DISPOSED', 'ACP client disposed.'));
         try {
           if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) {

--- a/ui/public/acp-client.test.mjs
+++ b/ui/public/acp-client.test.mjs
@@ -1,0 +1,197 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import vm from 'node:vm';
+
+function loadACPClientModule() {
+  const sockets = [];
+
+  class FakeWebSocket {
+    static OPEN = 1;
+    static CONNECTING = 0;
+    static CLOSED = 3;
+
+    constructor(url) {
+      this.url = url;
+      this.readyState = FakeWebSocket.CONNECTING;
+      this.sent = [];
+      this.onopen = null;
+      this.onmessage = null;
+      this.onclose = null;
+      this.onerror = null;
+      sockets.push(this);
+    }
+
+    send(payload) {
+      this.sent.push(JSON.parse(payload));
+    }
+
+    close() {
+      this.readyState = FakeWebSocket.CLOSED;
+      if (typeof this.onclose === 'function') {
+        this.onclose({});
+      }
+    }
+
+    open() {
+      this.readyState = FakeWebSocket.OPEN;
+      this.onopen?.();
+    }
+
+    receive(payload) {
+      this.onmessage?.({ data: JSON.stringify(payload) });
+    }
+  }
+
+  const window = {
+    WebSocket: FakeWebSocket,
+    TextDecoder,
+  };
+  window.window = window;
+
+  const context = vm.createContext({
+    window,
+    WebSocket: FakeWebSocket,
+    TextDecoder,
+    console,
+  });
+  context.globalThis = context.window;
+
+  vm.runInContext(fs.readFileSync('/Users/onur/repos/spritz/ui/public/acp-client.js', 'utf8'), context, {
+    filename: 'acp-client.js',
+  });
+
+  return {
+    createACPClient: window.SpritzACPClient.createACPClient,
+    sockets,
+  };
+}
+
+test('ACP client does not report ready or send prompts before bootstrap completes', async () => {
+  const { createACPClient, sockets } = loadACPClientModule();
+  const readyStates = [];
+
+  const client = createACPClient({
+    wsUrl: 'ws://example.test/acp',
+    conversation: {
+      spec: {
+        sessionId: 'session-existing',
+        cwd: '/home/dev',
+      },
+    },
+    onStatus() {},
+    onReadyChange(value) {
+      readyStates.push(value);
+    },
+  });
+
+  const startPromise = client.start();
+  const socket = sockets[0];
+  socket.open();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(client.isReady(), false);
+  const earlySend = client.sendPrompt('test 2').then(
+    () => 'resolved',
+    (error) => error.message,
+  );
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(socket.sent.length, 1);
+  assert.equal(socket.sent[0].method, 'initialize');
+  assert.equal(
+    await Promise.race([
+      earlySend,
+      new Promise((resolve) => setTimeout(() => resolve('pending'), 5)),
+    ]),
+    'ACP session is not ready yet.',
+  );
+
+  socket.receive({
+    jsonrpc: '2.0',
+    id: socket.sent[0].id,
+    result: {
+      agentCapabilities: {
+        loadSession: true,
+      },
+    },
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(socket.sent[1].method, 'session/load');
+  socket.receive({
+    jsonrpc: '2.0',
+    id: socket.sent[1].id,
+    result: {},
+  });
+
+  await startPromise;
+
+  assert.equal(client.isReady(), true);
+  assert.deepEqual(readyStates, [false, true]);
+  client.dispose();
+});
+
+test('ACP client recreates the session when session/load reports a missing session', async () => {
+  const { createACPClient, sockets } = loadACPClientModule();
+  const seenSessionIds = [];
+
+  const client = createACPClient({
+    wsUrl: 'ws://example.test/acp',
+    conversation: {
+      spec: {
+        sessionId: 'session-stale',
+        cwd: '/home/dev',
+      },
+    },
+    onStatus() {},
+    async onSessionId(sessionId) {
+      seenSessionIds.push(sessionId);
+    },
+  });
+
+  const startPromise = client.start();
+  const socket = sockets[0];
+  socket.open();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  socket.receive({
+    jsonrpc: '2.0',
+    id: socket.sent[0].id,
+    result: {
+      agentCapabilities: {
+        loadSession: true,
+      },
+    },
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(socket.sent[1].method, 'session/load');
+  socket.receive({
+    jsonrpc: '2.0',
+    id: socket.sent[1].id,
+    error: {
+      code: -32603,
+      message: 'Internal error',
+      data: {
+        details: 'Session session-stale not found',
+      },
+    },
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(socket.sent[2].method, 'session/new');
+  socket.receive({
+    jsonrpc: '2.0',
+    id: socket.sent[2].id,
+    result: {
+      sessionId: 'session-fresh',
+    },
+  });
+
+  await startPromise;
+
+  assert.equal(client.isReady(), true);
+  assert.deepEqual(seenSessionIds, ['session-fresh']);
+  client.dispose();
+});


### PR DESCRIPTION
## Summary
- keep the ACP client unavailable until initialize plus session load/new completes
- recover automatically when a stored ACP session id no longer exists upstream
- add regression coverage for the bootstrap race and stale-session fallback

## Testing
- node --test ui/public/acp-client.test.mjs ui/public/acp-page-cache.test.mjs ui/public/acp-page-notice.test.mjs ui/public/acp-page-layout.test.mjs ui/public/acp-render.test.mjs ui/public/app-chat-route.test.mjs ui/public/preset-panel.test.mjs
- node --check ui/public/acp-client.js ui/public/acp-page.js ui/public/acp-render.js ui/public/app.js