### PR TITLE
fix(acp): replay sessions from persisted transcript

### DIFF
--- a/images/examples/openclaw/acp-wrapper.mjs
+++ b/images/examples/openclaw/acp-wrapper.mjs
@@ -161,7 +161,7 @@ function buildHistoryToolResultUpdate(message, content) {
 }
 
 /**
- * Converts persisted OpenClaw chat history into ACP session updates so
+ * Converts persisted OpenClaw session transcript entries into ACP session updates so
  * `session/load` can reconstruct prior transcript state for any ACP client.
  */
 export function buildHistoryReplayUpdates(messages = []) {
@@ -223,32 +223,21 @@ export function buildHistoryReplayUpdates(messages = []) {
   return updates;
 }
 
-async function replayGatewayHistory(agent, session) {
+async function replayGatewayTranscript(agent, session) {
   if (!agent?.gateway?.request || !agent?.connection?.sessionUpdate) {
     return;
   }
 
-  const history = await agent.gateway.request("chat.history", {
-    sessionKey: session.sessionKey,
+  const transcript = await agent.gateway.request("sessions.get", {
+    key: session.sessionKey,
     limit: 1000,
   });
 
-  const updates = buildHistoryReplayUpdates(history?.messages);
+  const updates = buildHistoryReplayUpdates(transcript?.messages);
   for (const update of updates) {
     await agent.connection.sessionUpdate({
       sessionId: session.sessionId,
       update,
-    });
-  }
-
-  const thinkingLevel = typeof history?.thinkingLevel === "string" ? history.thinkingLevel.trim() : "";
-  if (thinkingLevel) {
-    await agent.connection.sessionUpdate({
-      sessionId: session.sessionId,
-      update: {
-        sessionUpdate: "current_mode_update",
-        mode: thinkingLevel,
-      },
     });
   }
 }
@@ -335,7 +324,7 @@ export function createSpritzAcpGatewayAgentClass(AcpGatewayAgent, env = process.
         cwd: params.cwd,
       });
       this.log(`loadSession: ${session.sessionId} -> ${session.sessionKey}`);
-      await replayGatewayHistory(this, session);
+      await replayGatewayTranscript(this, session);
       await this.sendAvailableCommands(session.sessionId);
       return {};
     }

--- a/images/examples/openclaw/acp-wrapper.test.mjs
+++ b/images/examples/openclaw/acp-wrapper.test.mjs
@@ -188,7 +188,7 @@ test('buildHistoryReplayUpdates converts gateway history into ACP replay updates
   assert.equal(updates[3].rawOutput, '/home/dev');
 });
 
-test('loadSession replays gateway history before returning', async () => {
+test('loadSession replays persisted session transcript before returning', async () => {
   class FakeBaseAgent {
     constructor() {
       this.logged = [];
@@ -202,9 +202,9 @@ test('loadSession replays gateway history before returning', async () => {
       };
       this.gateway = {
         async request(method, params) {
-          if (method === 'chat.history') {
+          if (method === 'sessions.get') {
             assert.deepEqual(params, {
-              sessionKey: 'agent:main:spritz-acp:123e4567-e89b-42d3-a456-426614174000',
+              key: 'agent:main:spritz-acp:123e4567-e89b-42d3-a456-426614174000',
               limit: 1000,
             });
             return {
@@ -212,7 +212,6 @@ test('loadSession replays gateway history before returning', async () => {
                 { role: 'user', content: [{ type: 'text', text: 'hello from history' }] },
                 { role: 'assistant', content: [{ type: 'text', text: 'history reply' }] },
               ],
-              thinkingLevel: 'high',
             };
           }
           throw new Error(`unexpected gateway method ${method}`);
@@ -255,14 +254,13 @@ test('loadSession replays gateway history before returning', async () => {
     mcpServers: [],
   });
 
-  assert.equal(agent.connection.updates.length, 3);
+  assert.equal(agent.connection.updates.length, 2);
   assert.deepEqual(
     agent.connection.updates.map((entry) => entry.update.sessionUpdate),
-    ['user_message_chunk', 'agent_message_chunk', 'current_mode_update'],
+    ['user_message_chunk', 'agent_message_chunk'],
   );
   assert.equal(agent.connection.updates[0].update.content.text, 'hello from history');
   assert.equal(agent.connection.updates[1].update.content.text, 'history reply');
-  assert.equal(agent.connection.updates[2].update.mode, 'high');
   assert.deepEqual(agent.rateLimits, ['loadSession']);
   assert.deepEqual(agent.sentAvailableCommands, ['123e4567-e89b-42d3-a456-426614174000']);
 });


### PR DESCRIPTION
## Summary
- replay ACP session restore from OpenClaw persisted session transcript instead of chat history
- align the image-owned ACP bridge with stock OpenClaw session replay behavior
- add a regression test for session/load to ensure replay comes from sessions.get

## Testing
- node --test images/examples/openclaw/acp-wrapper.test.mjs
- node --check images/examples/openclaw/acp-wrapper.mjs
- bash -n images/examples/openclaw/entrypoint.sh
- git diff --check