### PR TITLE
fix(ui): rebind ACP conversations before sending

### DIFF
--- a/ui/public/acp-client.js
+++ b/ui/public/acp-client.js
@@ -265,6 +265,23 @@
 
     return {
       start,
+      getConversationId() {
+        return conversation?.metadata?.name || '';
+      },
+      getSessionId() {
+        return sessionId || '';
+      },
+      matchesConversation(targetConversation) {
+        const targetConversationId = targetConversation?.metadata?.name || '';
+        if (targetConversationId && targetConversationId !== (conversation?.metadata?.name || '')) {
+          return false;
+        }
+        const expectedSessionId = targetConversation?.spec?.sessionId || '';
+        if (expectedSessionId && sessionId && expectedSessionId !== sessionId) {
+          return false;
+        }
+        return true;
+      },
       isReady() {
         return Boolean(ws && ws.readyState === WebSocket.OPEN && ready && bootstrapComplete);
       },

--- a/ui/public/acp-page-session-binding.test.mjs
+++ b/ui/public/acp-page-session-binding.test.mjs
@@ -1,0 +1,201 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import vm from 'node:vm';
+
+function createElement(tagName) {
+  const listeners = new Map();
+  return {
+    tagName,
+    hidden: false,
+    disabled: false,
+    textContent: '',
+    value: '',
+    className: '',
+    children: [],
+    dataset: {},
+    style: {},
+    append(...items) {
+      this.children.push(...items);
+    },
+    appendChild(item) {
+      this.children.push(item);
+    },
+    remove() {
+      this.removed = true;
+    },
+    addEventListener(name, handler) {
+      listeners.set(name, handler);
+    },
+    setAttribute(name, value) {
+      this[name] = value;
+    },
+    querySelector() {
+      return null;
+    },
+    contains() {
+      return false;
+    },
+    click() {
+      if (this.disabled) return;
+      const handler = listeners.get('click');
+      if (handler) handler({ preventDefault() {} });
+    },
+    keydown(event) {
+      const handler = listeners.get('keydown');
+      if (handler) handler(event);
+    },
+  };
+}
+
+function walk(node, predicate) {
+  if (!node) return null;
+  if (predicate(node)) return node;
+  for (const child of node.children || []) {
+    const match = walk(child, predicate);
+    if (match) return match;
+  }
+  return null;
+}
+
+function loadModules(createACPClient) {
+  const document = { createElement };
+  const window = {
+    document,
+    location: {
+      hash: '#chat/young-crest/conv-1',
+      assign() {},
+      replace() {},
+      origin: 'https://example.test',
+    },
+    open() {},
+    setTimeout,
+    clearTimeout,
+    SpritzACPClient: {
+      createACPClient,
+      extractACPText(value) {
+        return typeof value?.text === 'string' ? value.text : '';
+      },
+    },
+  };
+  window.window = window;
+  const context = vm.createContext({ window, document, console, setTimeout, clearTimeout, URL, URLSearchParams });
+  context.globalThis = context.window;
+  vm.runInContext(fs.readFileSync('/Users/onur/repos/spritz/ui/public/acp-render.js', 'utf8'), context, {
+    filename: 'acp-render.js',
+  });
+  vm.runInContext(fs.readFileSync('/Users/onur/repos/spritz/ui/public/acp-page.js', 'utf8'), context, {
+    filename: 'acp-page.js',
+  });
+  return window;
+}
+
+test('ACP page rebinds the selected conversation before sending on a stale client', async () => {
+  const startedConversations = [];
+  const sentPrompts = [];
+  let clientCount = 0;
+  const toastMessages = [];
+
+  const window = loadModules(({ conversation }) => {
+    clientCount += 1;
+    const clientIndex = clientCount;
+    const stale = clientIndex === 1;
+    return {
+      start: async () => {
+        startedConversations.push(conversation?.metadata?.name || '');
+      },
+      isReady: () => true,
+      getConversationId: () => (stale ? 'stale-conv' : conversation?.metadata?.name || ''),
+      getSessionId: () => (stale ? 'session-stale' : conversation?.spec?.sessionId || ''),
+      matchesConversation(targetConversation) {
+        return (
+          this.getConversationId() === (targetConversation?.metadata?.name || '') &&
+          this.getSessionId() === (targetConversation?.spec?.sessionId || '')
+        );
+      },
+      async sendPrompt(text) {
+        sentPrompts.push({
+          clientIndex,
+          conversationId: conversation?.metadata?.name || '',
+          text,
+        });
+        return { stopReason: 'end_turn' };
+      },
+      cancelPrompt() {},
+      dispose() {},
+    };
+  });
+
+  const shellEl = createElement('main');
+  const createSection = createElement('section');
+  const listSection = createElement('section');
+
+  window.SpritzACPPage.renderACPPage('young-crest', 'conv-1', {
+    activePage: null,
+    apiBaseUrl: '',
+    authBearerTokenParam: 'token',
+    getAuthToken() {
+      return '';
+    },
+    async request(path) {
+      if (path === '/acp/agents') {
+        return {
+          items: [
+            {
+              spritz: {
+                metadata: { name: 'young-crest' },
+                status: {
+                  acp: { agentInfo: { title: 'OpenClaw ACP Gateway', version: '2026.3.8' } },
+                  url: 'https://example.test/w/young-crest/',
+                },
+              },
+            },
+          ],
+        };
+      }
+      if (path.startsWith('/acp/conversations?')) {
+        return {
+          items: [
+            {
+              metadata: { name: 'conv-1' },
+              spec: { title: 'Test conversation', sessionId: 'session-fresh' },
+              status: { updatedAt: '2026-03-10T08:00:00Z' },
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected path ${path}`);
+    },
+    showToast(message) {
+      toastMessages.push(message);
+    },
+    showNotice() {},
+    clearNotice() {},
+    buildOpenUrl(url) {
+      return url;
+    },
+    cleanupTerminal() {},
+    shellEl,
+    createSection,
+    listSection,
+    setHeaderCopy() {},
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const composer = walk(shellEl, (node) => node.tagName === 'textarea');
+  const sendButton = walk(shellEl, (node) => node.tagName === 'button' && node.textContent === 'Send');
+
+  assert.ok(composer);
+  assert.ok(sendButton);
+
+  composer.value = 'test 3';
+  sendButton.click();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.deepEqual(startedConversations, ['conv-1', 'conv-1']);
+  assert.deepEqual(sentPrompts, [{ clientIndex: 2, conversationId: 'conv-1', text: 'test 3' }]);
+  assert.deepEqual(toastMessages, []);
+});

--- a/ui/public/acp-page.js
+++ b/ui/public/acp-page.js
@@ -517,8 +517,34 @@
     page.statusEl.textContent = text || '';
   }
 
+  function selectedConversationClientMatches(page) {
+    return Boolean(
+      page.client &&
+        page.selectedConversation &&
+        typeof page.client.matchesConversation === 'function' &&
+        page.client.matchesConversation(page.selectedConversation),
+    );
+  }
+
+  async function ensureSelectedConversationClient(page) {
+    if (!page.selectedConversation) return false;
+    if (selectedConversationClientMatches(page)) {
+      return true;
+    }
+    if (!page.selectedConversationId) {
+      return false;
+    }
+    setStatus(page, 'Reconnecting conversation…');
+    await selectConversation(page, page.selectedConversationId);
+    return selectedConversationClientMatches(page);
+  }
+
   function syncComposer(page) {
-    const disabled = !page.client || !page.client.isReady() || !page.selectedConversation;
+    const disabled =
+      !page.client ||
+      !page.client.isReady() ||
+      !page.selectedConversation ||
+      !selectedConversationClientMatches(page);
     if (page.composerEl) page.composerEl.disabled = disabled || page.promptInFlight;
     if (page.sendBtn) page.sendBtn.disabled = disabled || page.promptInFlight;
     if (page.cancelBtn) page.cancelBtn.disabled = !page.promptInFlight;
@@ -577,7 +603,7 @@
     setStatus(page, 'Disconnected. Reconnecting…');
   }
 
-  async function connectSelectedConversation(page) {
+  async function connectSelectedConversation(page, options = {}) {
     if (!page.selectedAgent || !page.selectedConversation) {
       resetConversationRuntime(page);
       renderThread(page);
@@ -654,6 +680,14 @@
     });
     syncComposer(page);
     await page.client.start();
+    if (!selectedConversationClientMatches(page)) {
+      if (options.allowAutoRebind === false) {
+        throw new Error('ACP client bound to the wrong conversation.');
+      }
+      resetConversationRuntime(page);
+      await connectSelectedConversation(page, { allowAutoRebind: false });
+      return;
+    }
     if (page.cacheHydratedTranscript && !page.cacheReplacedByReplay) {
       page.transcript = ACPRender.createTranscript();
       renderConversationList(page);
@@ -934,6 +968,13 @@
     sendButton.addEventListener('click', async () => {
       const text = composerInput.value.trim();
       if (!text || !page.client || !page.selectedConversation) return;
+      const rebound = await ensureSelectedConversationClient(page);
+      if (!rebound || !page.client) {
+        reportACPError(page, new Error('Conversation is reconnecting. Try again.'), 'Conversation is reconnecting. Try again.', 'info');
+        syncComposer(page);
+        renderThread(page);
+        return;
+      }
       composerInput.value = '';
       ACPRender.applySessionUpdate(page.transcript, {
         sessionUpdate: 'user_message_chunk',


### PR DESCRIPTION
## Summary
- make ACP clients report which conversation and session they are bound to
- auto-rebind a conversation if the selected thread and active ACP client drift apart
- add a regression test that ensures prompts cannot be sent on a stale ACP client

## Testing
- node --test ui/public/acp-client.test.mjs ui/public/acp-page-cache.test.mjs ui/public/acp-page-notice.test.mjs ui/public/acp-page-layout.test.mjs ui/public/acp-page-session-binding.test.mjs ui/public/acp-render.test.mjs ui/public/app-chat-route.test.mjs ui/public/preset-panel.test.mjs
- node --check ui/public/acp-client.js
- node --check ui/public/acp-page.js
- git diff --check