### PR TITLE
fix(acp): compact html tool failures in chat

### DIFF
--- a/ui/public/acp-page-notice.test.mjs
+++ b/ui/public/acp-page-notice.test.mjs
@@ -258,3 +258,117 @@ test('ACP page surfaces real startup errors as toasts', async () => {
   assert.deepEqual(noticeMessages.filter(Boolean), []);
   assert.deepEqual(toastMessages, ['Failed to connect to ACP gateway.']);
 });
+
+test('ACP page surfaces HTML tool failures as toasts without dumping raw markup', async () => {
+  const toastMessages = [];
+  const window = loadModules(({ conversation, onUpdate, onReadyChange }) => ({
+    async start() {
+      if (typeof onReadyChange === 'function') {
+        onReadyChange(true);
+      }
+      setTimeout(() => {
+        if (typeof onUpdate !== 'function') return;
+        onUpdate({
+          sessionUpdate: 'tool_call',
+          toolCallId: 'tool-502',
+          title: 'Fetch workspace',
+          status: 'completed',
+          rawInput: { url: 'https://staging.spritz.textcortex.com/' },
+        });
+        onUpdate({
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'tool-502',
+          status: 'completed',
+          rawOutput:
+            '<!DOCTYPE html><html><head><title>textcortex.com | 502: Bad gateway</title></head><body>' +
+            '<span class="code-label">Error code 502</span><span>staging.spritz.textcortex.com</span>' +
+            '<span>Cloudflare</span><p>The web server reported a bad gateway error.</p></body></html>',
+        });
+      }, 0);
+    },
+    isReady: () => true,
+    getConversationId: () => conversation?.metadata?.name || '',
+    getSessionId: () => conversation?.spec?.sessionId || '',
+    matchesConversation(targetConversation) {
+      return (
+        this.getConversationId() === (targetConversation?.metadata?.name || '') &&
+        this.getSessionId() === (targetConversation?.spec?.sessionId || '')
+      );
+    },
+    dispose() {},
+    cancelPrompt() {},
+  }));
+  const shellEl = createElement('main');
+  const createSection = createElement('section');
+  const listSection = createElement('section');
+
+  window.SpritzACPPage.renderACPPage('young-crest', 'conv-1', {
+    activePage: null,
+    apiBaseUrl: '',
+    authBearerTokenParam: 'token',
+    getAuthToken() {
+      return '';
+    },
+    async request(path) {
+      if (path === '/acp/agents') {
+        return {
+          items: [
+            {
+              spritz: {
+                metadata: { name: 'young-crest' },
+                status: {
+                  acp: { agentInfo: { title: 'OpenClaw ACP Gateway', version: '2026.3.8' } },
+                },
+              },
+            },
+          ],
+        };
+      }
+      if (path.startsWith('/acp/conversations?')) {
+        return {
+          items: [
+            {
+              metadata: { name: 'conv-1' },
+              spec: { title: 'Test conversation', sessionId: 'sess-1', cwd: '/home/dev' },
+              status: { updatedAt: '2026-03-10T05:44:00Z' },
+            },
+          ],
+        };
+      }
+      if (path === '/acp/conversations/conv-1/bootstrap') {
+        return {
+          conversation: {
+            metadata: { name: 'conv-1' },
+            spec: { title: 'Test conversation', sessionId: 'sess-1', cwd: '/home/dev' },
+            status: { bindingState: 'active', boundSessionId: 'sess-1', updatedAt: '2026-03-10T05:44:00Z' },
+          },
+          effectiveSessionId: 'sess-1',
+          bindingState: 'active',
+          replaced: false,
+        };
+      }
+      throw new Error(`unexpected path ${path}`);
+    },
+    showNotice() {},
+    clearNotice() {},
+    showToast(message) {
+      toastMessages.push(message);
+    },
+    buildOpenUrl(url) {
+      return url;
+    },
+    cleanupTerminal() {},
+    shellEl,
+    createSection,
+    listSection,
+    setHeaderCopy() {},
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(toastMessages.length, 1);
+  assert.match(toastMessages[0], /502/i);
+  assert.match(toastMessages[0], /staging\.spritz\.textcortex\.com/i);
+  assert.equal(toastMessages[0].includes('<!DOCTYPE html>'), false);
+});

--- a/ui/public/acp-page.js
+++ b/ui/public/acp-page.js
@@ -644,6 +644,9 @@
     const result = ACPRender.applySessionUpdate(page.transcript, update, {
       historical: !page.bootstrapComplete,
     });
+    if (result?.toast?.message) {
+      showACPToast(page, result.toast.message, result.toast.kind || 'error');
+    }
     if (result?.conversationTitle) {
       patchSelectedConversation(page, { title: result.conversationTitle }).catch(() => {});
     }

--- a/ui/public/acp-render.js
+++ b/ui/public/acp-render.js
@@ -115,6 +115,96 @@
     return `${normalized.slice(0, maxLength - 1)}…`;
   }
 
+  function decodeHtmlEntities(text) {
+    return String(text || '')
+      .replace(/&nbsp;/gi, ' ')
+      .replace(/&amp;/gi, '&')
+      .replace(/&lt;/gi, '<')
+      .replace(/&gt;/gi, '>')
+      .replace(/&quot;/gi, '"')
+      .replace(/&#39;/gi, "'");
+  }
+
+  function stripHtmlTags(text) {
+    return decodeHtmlEntities(
+      String(text || '')
+        .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+        .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+        .replace(/<[^>]+>/g, ' '),
+    )
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  function extractHtmlTagText(html, tagName) {
+    const match = String(html || '').match(new RegExp(`<${tagName}[^>]*>([\\s\\S]*?)<\\/${tagName}>`, 'i'));
+    return match ? stripHtmlTags(match[1]) : '';
+  }
+
+  function detectHtmlErrorDocument(text) {
+    const raw = String(text || '').trim();
+    if (!raw) return null;
+    if (!/^\s*<(?:!doctype\s+html|html\b)/i.test(raw)) {
+      return null;
+    }
+
+    const title = extractHtmlTagText(raw, 'title');
+    const flattened = stripHtmlTags(raw);
+    const codeMatch =
+      flattened.match(/\berror code\s+(\d{3})\b/i) ||
+      title.match(/\b(\d{3})\b/);
+    const hostMatches = [...flattened.matchAll(/\b([a-z0-9.-]+\.[a-z]{2,})\b/gi)].map((match) => match[1]);
+    const host =
+      hostMatches
+        .sort((left, right) => right.length - left.length)
+        .find((value) => !/^cloudflare\.com$/i.test(value)) || '';
+    const providerMatch = flattened.match(/\b(Cloudflare|Vercel|Netlify|nginx|Apache)\b/i);
+    const summaryMatch =
+      flattened.match(/\bThe web server reported [^.]+\./i) ||
+      flattened.match(/\bThis page isn[’']t working[^.]*\./i) ||
+      flattened.match(/\bBad gateway\b/i);
+
+    const parts = [];
+    if (codeMatch?.[1]) {
+      parts.push(`HTTP ${codeMatch[1]}`);
+    }
+    if (title) {
+      parts.push(title);
+    } else if (summaryMatch?.[0]) {
+      parts.push(summaryMatch[0]);
+    } else {
+      parts.push('HTML error response');
+    }
+    if (host) {
+      parts.push(host);
+    }
+    if (providerMatch?.[1]) {
+      parts.push(providerMatch[1]);
+    }
+
+    return {
+      text: parts.join(' · '),
+      open: false,
+      isError: true,
+    };
+  }
+
+  function normalizeToolResultText(rawOutput) {
+    const text = stringifyDetails(rawOutput);
+    if (!text) {
+      return { text: '', open: true, isError: false };
+    }
+    const htmlError = detectHtmlErrorDocument(text);
+    if (htmlError) {
+      return htmlError;
+    }
+    return {
+      text,
+      open: true,
+      isError: false,
+    };
+  }
+
   function pushMessage(transcript, message) {
     transcript.messages.push({
       id: message.id || createId(message.kind || 'message'),
@@ -190,7 +280,8 @@
   function buildToolBlocks(update, existing) {
     const blocks = [];
     const inputText = stringifyDetails(update.rawInput);
-    const resultText = stringifyDetails(update.rawOutput);
+    const normalizedResult = normalizeToolResultText(update.rawOutput);
+    const resultText = normalizedResult.text;
     if (inputText) {
       blocks.push({ type: 'details', title: 'Input', text: inputText, open: false });
     } else if (existing) {
@@ -198,27 +289,35 @@
       if (priorInput) blocks.push(priorInput);
     }
     if (resultText) {
-      blocks.push({ type: 'details', title: 'Result', text: resultText, open: true });
+      blocks.push({ type: 'details', title: 'Result', text: resultText, open: normalizedResult.open });
     } else if (existing) {
       const priorResult = existing.blocks.find((block) => block.type === 'details' && block.title === 'Result');
       if (priorResult) blocks.push(priorResult);
     }
-    return blocks;
+    return {
+      blocks,
+      isError: normalizedResult.isError,
+      summary: normalizedResult.isError ? normalizedResult.text : '',
+    };
   }
 
   function upsertToolCall(transcript, update) {
     const toolCallId = update.toolCallId || createId('tool');
     const existingIndex = transcript.toolCallIndex.get(toolCallId);
     const existing = existingIndex !== undefined ? transcript.messages[existingIndex] : null;
+    const normalizedBlocks = buildToolBlocks(update, existing);
     const title = update.title || existing?.title || 'Tool call';
-    const status = update.status || existing?.status || 'pending';
+    const status =
+      normalizedBlocks.isError && (!update.status || update.status === 'completed')
+        ? 'failed'
+        : update.status || existing?.status || 'pending';
     const next = {
       kind: 'tool',
       title,
       status,
       tone: status === 'completed' ? 'success' : status === 'failed' ? 'danger' : 'info',
       meta: update.kind || existing?.meta || '',
-      blocks: buildToolBlocks(update, existing),
+      blocks: normalizedBlocks.blocks,
       toolCallId,
     };
 
@@ -227,11 +326,12 @@
         ...existing,
         ...next,
       };
-      return;
+      return normalizedBlocks;
     }
 
     transcript.toolCallIndex.set(toolCallId, transcript.messages.length);
     pushMessage(transcript, next);
+    return normalizedBlocks;
   }
 
   function createUsageBlocks(update) {
@@ -284,7 +384,15 @@
       return null;
     }
     if (kind === 'tool_call' || kind === 'tool_call_update') {
-      upsertToolCall(transcript, update);
+      const toolResult = upsertToolCall(transcript, update);
+      if (!historical && toolResult?.isError && toolResult.summary) {
+        return {
+          toast: {
+            kind: 'error',
+            message: toolResult.summary,
+          },
+        };
+      }
       return null;
     }
     if (kind === 'available_commands_update') {

--- a/ui/public/acp-render.test.mjs
+++ b/ui/public/acp-render.test.mjs
@@ -90,6 +90,40 @@ test('ACP render adapter keeps commands out of transcript and upserts tool cards
   assert.equal(toolCard.blocks.some((block) => block.type === 'details' && block.title === 'Result'), true);
 });
 
+test('ACP render adapter summarizes HTML error pages in tool results', () => {
+  const ACPRender = loadRenderModule();
+  const transcript = ACPRender.createTranscript();
+
+  ACPRender.applySessionUpdate(transcript, {
+    sessionUpdate: 'tool_call',
+    toolCallId: 'tool-502',
+    title: 'Fetch workspace',
+    status: 'completed',
+    rawInput: { url: 'https://staging.spritz.textcortex.com/' },
+  });
+
+  ACPRender.applySessionUpdate(transcript, {
+    sessionUpdate: 'tool_call_update',
+    toolCallId: 'tool-502',
+    status: 'completed',
+    rawOutput:
+      '<!DOCTYPE html><html><head><title>textcortex.com | 502: Bad gateway</title></head><body>' +
+      '<span class="code-label">Error code 502</span><span>staging.spritz.textcortex.com</span>' +
+      '<span>Cloudflare</span><p>The web server reported a bad gateway error.</p></body></html>',
+  });
+
+  assert.equal(transcript.messages.length, 1);
+  const toolCard = transcript.messages[0];
+  const resultBlock = toolCard.blocks.find((block) => block.type === 'details' && block.title === 'Result');
+  assert.ok(resultBlock);
+  assert.equal(resultBlock.open, false);
+  assert.match(resultBlock.text, /502/i);
+  assert.match(resultBlock.text, /staging\.spritz\.textcortex\.com/i);
+  assert.match(resultBlock.text, /cloudflare/i);
+  assert.match(resultBlock.text, /bad gateway/i);
+  assert.equal(resultBlock.text.includes('<!DOCTYPE html>'), false);
+});
+
 test('ACP render adapter treats bootstrap replay chunks as historical messages', () => {
   const ACPRender = loadRenderModule();
   const transcript = ACPRender.createTranscript();


### PR DESCRIPTION
This fixes ACP chat rendering when a tool or upstream request returns an HTML error document.

Instead of dumping the full HTML page into the transcript, the UI now marks the tool call as failed, shows a compact summary, and raises a toast for live updates. Tests cover both transcript rendering and the live ACP page notice path, and I verified the rendered output with agent-browser using the real ACP render bundle.