### PR TITLE
fix(acp): suppress html error pages in chat

### DIFF
--- a/ui/public/acp-page-cache.test.mjs
+++ b/ui/public/acp-page-cache.test.mjs
@@ -460,3 +460,108 @@ test('ACP page clears cached transcript when backend replay returns no transcrip
   assert.doesNotMatch(text, /Cached assistant reply\./);
   assert.match(text, /Conversation is ready\. Send a message to begin\./);
 });
+
+test('ACP page drops cached HTML error documents during transcript restore', async () => {
+  const cacheKey = 'spritz:acp:transcript:conv-1';
+  const window = loadModules({
+    [cacheKey]: JSON.stringify({
+      version: 1,
+      conversationId: 'conv-1',
+      transcript: {
+        messages: [
+          {
+            id: 'assistant-html',
+            kind: 'assistant',
+            title: '',
+            status: '',
+            tone: '',
+            meta: '',
+            blocks: [
+              {
+                type: 'text',
+                text:
+                  '<!DOCTYPE html><html><head><title>textcortex.com | 502: Bad gateway</title></head><body>' +
+                  '<span>staging.spritz.textcortex.com</span><span>Cloudflare</span></body></html>',
+              },
+            ],
+            streaming: false,
+            toolCallId: '',
+          },
+        ],
+        availableCommands: [],
+        currentMode: '',
+        usage: null,
+      },
+    }),
+  });
+
+  const shellEl = createElement('main');
+  const createSection = createElement('section');
+  const listSection = createElement('section');
+
+  window.SpritzACPPage.renderACPPage('young-crest', 'conv-1', {
+    activePage: null,
+    apiBaseUrl: '',
+    authBearerTokenParam: 'token',
+    getAuthToken() {
+      return '';
+    },
+    async request(path) {
+      if (path === '/acp/agents') {
+        return {
+          items: [
+            {
+              spritz: {
+                metadata: { name: 'young-crest' },
+                status: {
+                  acp: { agentInfo: { title: 'OpenClaw ACP Gateway', version: '2026.3.8' } },
+                },
+              },
+            },
+          ],
+        };
+      }
+      if (path.startsWith('/acp/conversations?')) {
+        return {
+          items: [
+            {
+              metadata: { name: 'conv-1' },
+              spec: { title: 'Replay conversation', sessionId: 'sess-1', cwd: '/home/dev' },
+              status: { updatedAt: '2026-03-10T06:00:00Z' },
+            },
+          ],
+        };
+      }
+      if (path === '/acp/conversations/conv-1/bootstrap') {
+        return {
+          conversation: {
+            metadata: { name: 'conv-1' },
+            spec: { title: 'Replay conversation', sessionId: 'sess-1', cwd: '/home/dev' },
+            status: { bindingState: 'active', boundSessionId: 'sess-1', updatedAt: '2026-03-10T06:00:00Z' },
+          },
+          effectiveSessionId: 'sess-1',
+          bindingState: 'active',
+          replaced: false,
+        };
+      }
+      throw new Error(`unexpected path ${path}`);
+    },
+    showNotice() {},
+    buildOpenUrl(url) {
+      return url;
+    },
+    cleanupTerminal() {},
+    shellEl,
+    createSection,
+    listSection,
+    setHeaderCopy() {},
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const text = collectText(shellEl);
+  assert.doesNotMatch(text, /<!DOCTYPE html>/);
+  assert.doesNotMatch(text, /Cloudflare/);
+  assert.match(text, /Conversation is ready\. Send a message to begin\./);
+});

--- a/ui/public/acp-page-notice.test.mjs
+++ b/ui/public/acp-page-notice.test.mjs
@@ -34,6 +34,13 @@ function createElement(tagName) {
   };
 }
 
+function collectText(node) {
+  if (!node) return '';
+  const own = typeof node.textContent === 'string' ? node.textContent : '';
+  const childText = Array.isArray(node.children) ? node.children.map((child) => collectText(child)).join(' ') : '';
+  return `${own} ${childText}`.replace(/\s+/g, ' ').trim();
+}
+
 function loadModules(createACPClient) {
   const document = { createElement };
   const window = {
@@ -371,4 +378,105 @@ test('ACP page surfaces HTML tool failures as toasts without dumping raw markup'
   assert.match(toastMessages[0], /502/i);
   assert.match(toastMessages[0], /staging\.spritz\.textcortex\.com/i);
   assert.equal(toastMessages[0].includes('<!DOCTYPE html>'), false);
+});
+
+test('ACP page surfaces HTML assistant failures as toasts without restoring markup into chat', async () => {
+  const toastMessages = [];
+  const window = loadModules(({ onUpdate, conversation }) => ({
+    start: async () => {
+      onUpdate({
+        sessionUpdate: 'agent_message_chunk',
+        content: {
+          type: 'text',
+          text:
+            '<!DOCTYPE html><html><head><title>textcortex.com | 502: Bad gateway</title></head><body>' +
+            '<span class="code-label">Error code 502</span><span>staging.spritz.textcortex.com</span>' +
+            '<span>Cloudflare</span><p>The web server reported a bad gateway error.</p></body></html>',
+        },
+      });
+    },
+    isReady: () => true,
+    getConversationId: () => conversation?.metadata?.name || '',
+    getSessionId: () => conversation?.spec?.sessionId || '',
+    matchesConversation(targetConversation) {
+      return (
+        this.getConversationId() === (targetConversation?.metadata?.name || '') &&
+        this.getSessionId() === (targetConversation?.spec?.sessionId || '')
+      );
+    },
+    cancelPrompt() {},
+    dispose() {},
+  }));
+  const shellEl = createElement('main');
+  const createSection = createElement('section');
+  const listSection = createElement('section');
+
+  window.SpritzACPPage.renderACPPage('young-crest', 'conv-1', {
+    activePage: null,
+    apiBaseUrl: '',
+    authBearerTokenParam: 'token',
+    getAuthToken() {
+      return '';
+    },
+    async request(path) {
+      if (path === '/acp/agents') {
+        return {
+          items: [
+            {
+              spritz: {
+                metadata: { name: 'young-crest' },
+                status: {
+                  acp: { agentInfo: { title: 'OpenClaw ACP Gateway', version: '2026.3.8' } },
+                },
+              },
+            },
+          ],
+        };
+      }
+      if (path.startsWith('/acp/conversations?')) {
+        return {
+          items: [
+            {
+              metadata: { name: 'conv-1' },
+              spec: { title: 'Test conversation', sessionId: 'sess-1', cwd: '/home/dev' },
+              status: { updatedAt: '2026-03-10T05:44:00Z' },
+            },
+          ],
+        };
+      }
+      if (path === '/acp/conversations/conv-1/bootstrap') {
+        return {
+          conversation: {
+            metadata: { name: 'conv-1' },
+            spec: { title: 'Test conversation', sessionId: 'sess-1', cwd: '/home/dev' },
+            status: { bindingState: 'active', boundSessionId: 'sess-1', updatedAt: '2026-03-10T05:44:00Z' },
+          },
+          effectiveSessionId: 'sess-1',
+          bindingState: 'active',
+          replaced: false,
+        };
+      }
+      throw new Error(`unexpected path ${path}`);
+    },
+    showNotice() {},
+    showToast(message) {
+      toastMessages.push(message);
+    },
+    buildOpenUrl(url) {
+      return url;
+    },
+    cleanupTerminal() {},
+    shellEl,
+    createSection,
+    listSection,
+    setHeaderCopy() {},
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(toastMessages.length, 1);
+  assert.match(toastMessages[0], /502/i);
+  assert.equal(toastMessages[0].includes('<!DOCTYPE html>'), false);
+  assert.doesNotMatch(collectText(shellEl), /<!DOCTYPE html>/);
 });

--- a/ui/public/acp-render.js
+++ b/ui/public/acp-render.js
@@ -73,17 +73,9 @@
   function hydrateTranscript(payload) {
     const transcript = createTranscript();
     transcript.messages = Array.isArray(payload?.messages)
-      ? payload.messages.map((message) => ({
-          id: message?.id || createId(message?.kind || 'message'),
-          kind: message?.kind || 'system',
-          title: message?.title || '',
-          status: message?.status || '',
-          tone: message?.tone || '',
-          meta: message?.meta || '',
-          blocks: Array.isArray(message?.blocks) ? message.blocks : [],
-          streaming: Boolean(message?.streaming),
-          toolCallId: message?.toolCallId || '',
-        }))
+      ? payload.messages
+          .map((message) => sanitizeHydratedMessage(message))
+          .filter(Boolean)
       : [];
     transcript.availableCommands = Array.isArray(payload?.availableCommands) ? payload.availableCommands : [];
     transcript.currentMode = typeof payload?.currentMode === 'string' ? payload.currentMode : '';
@@ -202,6 +194,62 @@
       text,
       open: true,
       isError: false,
+    };
+  }
+
+  function sanitizeHydratedBlock(kind, block) {
+    if (!block || typeof block !== 'object') return null;
+    if (block.type === 'text') {
+      const htmlError = detectHtmlErrorDocument(block.text);
+      if (htmlError) {
+        return kind === 'tool'
+          ? { ...block, type: 'details', title: 'Result', text: htmlError.text, open: false }
+          : null;
+      }
+      return { ...block, text: String(block.text || '') };
+    }
+    if (block.type === 'details') {
+      const htmlError = detectHtmlErrorDocument(block.text);
+      if (htmlError) {
+        return { ...block, text: htmlError.text, open: false };
+      }
+      return { ...block, text: String(block.text || '') };
+    }
+    return block;
+  }
+
+  function sanitizeHydratedMessage(message) {
+    const kind = message?.kind || 'system';
+    const hadHtmlError = Array.isArray(message?.blocks)
+      ? message.blocks.some((block) => {
+          if (!block || typeof block !== 'object') return false;
+          const value = block.type === 'text' || block.type === 'details' ? block.text : '';
+          return Boolean(detectHtmlErrorDocument(value));
+        })
+      : false;
+    const blocks = Array.isArray(message?.blocks)
+      ? message.blocks.map((block) => sanitizeHydratedBlock(kind, block)).filter(Boolean)
+      : [];
+    if (!blocks.length && (kind === 'assistant' || kind === 'user')) {
+      return null;
+    }
+    return {
+      id: message?.id || createId(kind || 'message'),
+      kind,
+      title: message?.title || '',
+      status:
+        kind === 'tool' && hadHtmlError && (!message?.status || message.status === 'completed')
+          ? 'failed'
+          : message?.status || '',
+      tone:
+        kind === 'tool' && hadHtmlError
+          ? 'danger'
+          : message?.tone || '',
+      meta: message?.meta || '',
+      blocks,
+      streaming: Boolean(message?.streaming),
+      toolCallId: message?.toolCallId || '',
+      historyMessageId: message?.historyMessageId || '',
     };
   }
 
@@ -358,28 +406,48 @@
     const kind = update?.sessionUpdate || 'unknown';
     const historical = Boolean(options.historical);
     if (kind === 'user_message_chunk') {
+      const text = extractACPText(update.content);
+      const htmlError = detectHtmlErrorDocument(text);
+      if (htmlError) {
+        return {
+          toast: {
+            kind: 'error',
+            message: htmlError.text,
+          },
+        };
+      }
       if (historical) {
         appendHistoricalText(
           transcript,
           'user',
-          extractACPText(update.content),
+          text,
           update.historyMessageId || update.messageId,
         );
       } else {
-        appendStreamingText(transcript, 'user', extractACPText(update.content));
+        appendStreamingText(transcript, 'user', text);
       }
       return null;
     }
     if (kind === 'agent_message_chunk') {
+      const text = extractACPText(update.content);
+      const htmlError = detectHtmlErrorDocument(text);
+      if (htmlError) {
+        return {
+          toast: {
+            kind: 'error',
+            message: htmlError.text,
+          },
+        };
+      }
       if (historical) {
         appendHistoricalText(
           transcript,
           'assistant',
-          extractACPText(update.content),
+          text,
           update.historyMessageId || update.messageId,
         );
       } else {
-        appendStreamingText(transcript, 'assistant', extractACPText(update.content));
+        appendStreamingText(transcript, 'assistant', text);
       }
       return null;
     }

--- a/ui/public/acp-render.test.mjs
+++ b/ui/public/acp-render.test.mjs
@@ -124,6 +124,27 @@ test('ACP render adapter summarizes HTML error pages in tool results', () => {
   assert.equal(resultBlock.text.includes('<!DOCTYPE html>'), false);
 });
 
+test('ACP render adapter drops HTML error pages from assistant text updates', () => {
+  const ACPRender = loadRenderModule();
+  const transcript = ACPRender.createTranscript();
+
+  const result = ACPRender.applySessionUpdate(transcript, {
+    sessionUpdate: 'agent_message_chunk',
+    content: {
+      type: 'text',
+      text:
+        '<!DOCTYPE html><html><head><title>textcortex.com | 502: Bad gateway</title></head><body>' +
+        '<span class="code-label">Error code 502</span><span>staging.spritz.textcortex.com</span>' +
+        '<span>Cloudflare</span></body></html>',
+    },
+  });
+
+  assert.equal(transcript.messages.length, 0);
+  assert.equal(result?.toast?.kind, 'error');
+  assert.match(result?.toast?.message || '', /502/i);
+  assert.equal((result?.toast?.message || '').includes('<!DOCTYPE html>'), false);
+});
+
 test('ACP render adapter treats bootstrap replay chunks as historical messages', () => {
   const ACPRender = loadRenderModule();
   const transcript = ACPRender.createTranscript();


### PR DESCRIPTION
## Summary
- stop ACP assistant text updates from rendering raw HTML error documents into chat
- drop cached HTML error documents during transcript restore so refresh cannot bring them back
- add regression coverage for live updates, cache restore, and toast behavior

## Testing
- node --test /Users/onur/repos/spritz/ui/public/acp-render.test.mjs /Users/onur/repos/spritz/ui/public/acp-page-cache.test.mjs /Users/onur/repos/spritz/ui/public/acp-page-notice.test.mjs /Users/onur/repos/spritz/ui/public/acp-page-layout.test.mjs /Users/onur/repos/spritz/ui/public/app-chat-route.test.mjs /Users/onur/repos/spritz/ui/public/preset-panel.test.mjs
- node --check /Users/onur/repos/spritz/ui/public/acp-render.js
- node --check /Users/onur/repos/spritz/ui/public/acp-page.js
- git -C /Users/onur/repos/spritz diff --check
- agent-browser --session primary open file:///tmp/spritz-acp-html-sanitize-harness.html
- agent-browser --session primary get text "#out"