### PR TITLE
fix(acp): cut over stale transcript cache

### DIFF
--- a/ui/public/acp-page-cache.test.mjs
+++ b/ui/public/acp-page-cache.test.mjs
@@ -120,7 +120,7 @@ test('ACP page restores cached transcript when revisiting a conversation', async
   const window = loadModules(
     {
       [cacheKey]: JSON.stringify({
-        version: 1,
+        version: 2,
         conversationId: 'conv-1',
         transcript: {
           messages: [
@@ -231,12 +231,130 @@ test('ACP page restores cached transcript when revisiting a conversation', async
   releaseStart();
 });
 
+test('ACP page ignores stale cached transcript versions after cache cutover', async () => {
+  const cacheKey = 'spritz:acp:transcript:conv-1';
+  let releaseStart = () => {};
+  const window = loadModules(
+    {
+      [cacheKey]: JSON.stringify({
+        version: 1,
+        conversationId: 'conv-1',
+        transcript: {
+          messages: [
+            {
+              id: 'assistant-1',
+              kind: 'assistant',
+              title: '',
+              status: '',
+              tone: '',
+              meta: '',
+              blocks: [{ type: 'text', text: 'Stale cached assistant reply.' }],
+              streaming: false,
+              toolCallId: '',
+            },
+          ],
+          availableCommands: [],
+          currentMode: '',
+          usage: null,
+        },
+      }),
+    },
+    ({ conversation }) => ({
+      start: async () => {
+        await new Promise((resolve) => {
+          releaseStart = resolve;
+        });
+      },
+      isReady: () => true,
+      getConversationId: () => conversation?.metadata?.name || '',
+      getSessionId: () => conversation?.spec?.sessionId || '',
+      matchesConversation(targetConversation) {
+        return (
+          this.getConversationId() === (targetConversation?.metadata?.name || '') &&
+          this.getSessionId() === (targetConversation?.spec?.sessionId || '')
+        );
+      },
+      cancelPrompt() {},
+      dispose() {},
+    }),
+  );
+
+  const shellEl = createElement('main');
+  const createSection = createElement('section');
+  const listSection = createElement('section');
+
+  window.SpritzACPPage.renderACPPage('young-crest', 'conv-1', {
+    activePage: null,
+    apiBaseUrl: '',
+    authBearerTokenParam: 'token',
+    getAuthToken() {
+      return '';
+    },
+    async request(path) {
+      if (path === '/acp/agents') {
+        return {
+          items: [
+            {
+              spritz: {
+                metadata: { name: 'young-crest' },
+                status: {
+                  acp: { agentInfo: { title: 'OpenClaw ACP Gateway', version: '2026.3.8' } },
+                },
+              },
+            },
+          ],
+        };
+      }
+      if (path.startsWith('/acp/conversations?')) {
+        return {
+          items: [
+            {
+              metadata: { name: 'conv-1' },
+              spec: { title: 'Cached conversation', sessionId: 'sess-1', cwd: '/home/dev' },
+              status: { updatedAt: '2026-03-10T06:00:00Z' },
+            },
+          ],
+        };
+      }
+      if (path === '/acp/conversations/conv-1/bootstrap') {
+        return {
+          conversation: {
+            metadata: { name: 'conv-1' },
+            spec: { title: 'Cached conversation', sessionId: 'sess-1', cwd: '/home/dev' },
+            status: { bindingState: 'active', boundSessionId: 'sess-1', updatedAt: '2026-03-10T06:00:00Z' },
+          },
+          effectiveSessionId: 'sess-1',
+          bindingState: 'active',
+          replaced: false,
+        };
+      }
+      throw new Error(`unexpected path ${path}`);
+    },
+    showNotice() {},
+    buildOpenUrl(url) {
+      return url;
+    },
+    cleanupTerminal() {},
+    shellEl,
+    createSection,
+    listSection,
+    setHeaderCopy() {},
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.doesNotMatch(collectText(shellEl), /Stale cached assistant reply\./);
+  assert.equal(window.sessionStorage.getItem(cacheKey), null);
+  releaseStart();
+});
+
 test('ACP page replaces cached transcript with backend replay during bootstrap', async () => {
   const cacheKey = 'spritz:acp:transcript:conv-1';
   const window = loadModules(
     {
       [cacheKey]: JSON.stringify({
-        version: 1,
+        version: 2,
         conversationId: 'conv-1',
         transcript: {
           messages: [
@@ -353,7 +471,7 @@ test('ACP page clears cached transcript when backend replay returns no transcrip
   const window = loadModules(
     {
       [cacheKey]: JSON.stringify({
-        version: 1,
+        version: 2,
         conversationId: 'conv-1',
         transcript: {
           messages: [

--- a/ui/public/acp-page.js
+++ b/ui/public/acp-page.js
@@ -1,7 +1,7 @@
 (function (global) {
   const { createACPClient } = global.SpritzACPClient;
   const ACPRender = global.SpritzACPRender;
-  const ACP_TRANSCRIPT_CACHE_VERSION = 1;
+  const ACP_TRANSCRIPT_CACHE_VERSION = 2;
   const ACP_TRANSCRIPT_CACHE_PREFIX = 'spritz:acp:transcript:';
   const ACP_TRANSCRIPT_CACHE_INDEX_KEY = 'spritz:acp:transcript:index';
   const ACP_TRANSCRIPT_CACHE_LIMIT = 25;
@@ -191,6 +191,7 @@
       if (!raw) return null;
       const parsed = JSON.parse(raw);
       if (parsed?.version !== ACP_TRANSCRIPT_CACHE_VERSION || typeof parsed !== 'object') {
+        clearCachedConversationRecord(normalizedId);
         return null;
       }
       return parsed;

--- a/ui/public/acp-render.js
+++ b/ui/public/acp-render.js
@@ -573,9 +573,10 @@
   function renderBlock(block) {
     if (!block) return null;
     if (block.type === 'text') {
+      const htmlError = detectHtmlErrorDocument(block.text);
       const wrapper = document.createElement('div');
       wrapper.className = 'acp-block acp-block--text';
-      wrapper.appendChild(renderRichText(block.text || ''));
+      wrapper.appendChild(renderRichText(htmlError ? htmlError.text : block.text || ''));
       return wrapper;
     }
     if (block.type === 'plan') {
@@ -614,14 +615,15 @@
       return grid;
     }
     if (block.type === 'details') {
+      const htmlError = detectHtmlErrorDocument(block.text);
       const details = document.createElement('details');
       details.className = 'acp-details';
-      details.open = Boolean(block.open);
+      details.open = htmlError ? false : Boolean(block.open);
       const summary = document.createElement('summary');
       summary.textContent = block.title || 'Details';
       const pre = document.createElement('pre');
       pre.className = 'acp-details-body';
-      pre.textContent = block.text || '';
+      pre.textContent = htmlError ? htmlError.text : block.text || '';
       details.append(summary, pre);
       return details;
     }
@@ -678,9 +680,19 @@
       if (!message) continue;
       if (message.kind === 'assistant' || message.kind === 'user') {
         const textBlock = message.blocks.find((block) => block.type === 'text' && block.text);
-        if (textBlock) return excerpt(textBlock.text);
+        if (textBlock) {
+          const htmlError = detectHtmlErrorDocument(textBlock.text);
+          if (!htmlError) {
+            return excerpt(textBlock.text);
+          }
+        }
       }
       if (message.kind === 'tool') {
+        const resultBlock = message.blocks.find((block) => block.type === 'details' && block.title === 'Result' && block.text);
+        const htmlError = detectHtmlErrorDocument(resultBlock?.text);
+        if (htmlError) {
+          return excerpt(htmlError.text);
+        }
         return excerpt(`${message.title || 'Tool call'} · ${message.status || 'running'}`);
       }
     }

--- a/ui/public/acp-render.test.mjs
+++ b/ui/public/acp-render.test.mjs
@@ -24,6 +24,13 @@ function createElement(tagName) {
   };
 }
 
+function collectText(node) {
+  if (!node) return '';
+  const own = typeof node.textContent === 'string' ? node.textContent : '';
+  const childText = Array.isArray(node.children) ? node.children.map((child) => collectText(child)).join(' ') : '';
+  return `${own} ${childText}`.replace(/\s+/g, ' ').trim();
+}
+
 function loadRenderModule() {
   const document = { createElement };
   const window = {
@@ -143,6 +150,28 @@ test('ACP render adapter drops HTML error pages from assistant text updates', ()
   assert.equal(result?.toast?.kind, 'error');
   assert.match(result?.toast?.message || '', /502/i);
   assert.equal((result?.toast?.message || '').includes('<!DOCTYPE html>'), false);
+});
+
+test('ACP render adapter sanitizes raw HTML error pages at render time', () => {
+  const ACPRender = loadRenderModule();
+
+  const node = ACPRender.renderMessage({
+    kind: 'assistant',
+    blocks: [
+      {
+        type: 'text',
+        text:
+          '<!DOCTYPE html><html><head><title>textcortex.com | 502: Bad gateway</title></head><body>' +
+          '<span class="code-label">Error code 502</span><span>staging.spritz.textcortex.com</span>' +
+          '<span>Cloudflare</span></body></html>',
+      },
+    ],
+  });
+
+  const text = collectText(node);
+  assert.match(text, /502/i);
+  assert.match(text, /staging\.spritz\.textcortex\.com/i);
+  assert.equal(text.includes('<!DOCTYPE html>'), false);
 });
 
 test('ACP render adapter treats bootstrap replay chunks as historical messages', () => {


### PR DESCRIPTION
## Summary
- cut over ACP transcript browser cache to a new version and delete stale entries
- sanitize HTML error documents again at final render time and in preview generation
- add regression coverage for stale cache invalidation and render-time sanitization

## Testing
- node --test ui/public/acp-render.test.mjs ui/public/acp-page-cache.test.mjs ui/public/acp-page-notice.test.mjs ui/public/acp-page-layout.test.mjs ui/public/app-chat-route.test.mjs ui/public/preset-panel.test.mjs
- node --check ui/public/acp-render.js
- node --check ui/public/acp-page.js
- git diff --check
- agent-browser harness: stale version-1 cache is ignored and rewritten cleanly