### PR TITLE
refactor(acp): cut over transcript cache namespace

### DIFF
--- a/ui/public/acp-page-cache.test.mjs
+++ b/ui/public/acp-page-cache.test.mjs
@@ -66,6 +66,11 @@ function collectText(node) {
   return `${own} ${childText}`.replace(/\s+/g, ' ').trim();
 }
 
+const CURRENT_CACHE_KEY = 'spritz:acp:thread:conv-1';
+const CURRENT_CACHE_INDEX_KEY = 'spritz:acp:thread:index';
+const PRE_CUTOVER_CACHE_KEY = 'spritz:acp:transcript:conv-1';
+const PRE_CUTOVER_CACHE_INDEX_KEY = 'spritz:acp:transcript:index';
+
 function loadModules(storageSeed = {}, createACPClient = null) {
   const document = { createElement };
   const window = {
@@ -115,12 +120,10 @@ function loadModules(storageSeed = {}, createACPClient = null) {
 }
 
 test('ACP page restores cached transcript when revisiting a conversation', async () => {
-  const cacheKey = 'spritz:acp:transcript:conv-1';
   let releaseStart = () => {};
   const window = loadModules(
     {
-      [cacheKey]: JSON.stringify({
-        version: 2,
+      [CURRENT_CACHE_KEY]: JSON.stringify({
         conversationId: 'conv-1',
         transcript: {
           messages: [
@@ -232,12 +235,10 @@ test('ACP page restores cached transcript when revisiting a conversation', async
 });
 
 test('ACP page ignores stale cached transcript versions after cache cutover', async () => {
-  const cacheKey = 'spritz:acp:transcript:conv-1';
   let releaseStart = () => {};
   const window = loadModules(
     {
-      [cacheKey]: JSON.stringify({
-        version: 1,
+      [PRE_CUTOVER_CACHE_KEY]: JSON.stringify({
         conversationId: 'conv-1',
         transcript: {
           messages: [
@@ -258,6 +259,7 @@ test('ACP page ignores stale cached transcript versions after cache cutover', as
           usage: null,
         },
       }),
+      [PRE_CUTOVER_CACHE_INDEX_KEY]: JSON.stringify(['conv-1']),
     },
     ({ conversation }) => ({
       start: async () => {
@@ -345,16 +347,15 @@ test('ACP page ignores stale cached transcript versions after cache cutover', as
   await new Promise((resolve) => setTimeout(resolve, 0));
 
   assert.doesNotMatch(collectText(shellEl), /Stale cached assistant reply\./);
-  assert.equal(window.sessionStorage.getItem(cacheKey), null);
+  assert.equal(window.sessionStorage.getItem(PRE_CUTOVER_CACHE_KEY), null);
+  assert.equal(window.sessionStorage.getItem(PRE_CUTOVER_CACHE_INDEX_KEY), null);
   releaseStart();
 });
 
 test('ACP page replaces cached transcript with backend replay during bootstrap', async () => {
-  const cacheKey = 'spritz:acp:transcript:conv-1';
   const window = loadModules(
     {
-      [cacheKey]: JSON.stringify({
-        version: 2,
+      [CURRENT_CACHE_KEY]: JSON.stringify({
         conversationId: 'conv-1',
         transcript: {
           messages: [
@@ -467,11 +468,9 @@ test('ACP page replaces cached transcript with backend replay during bootstrap',
 });
 
 test('ACP page clears cached transcript when backend replay returns no transcript updates', async () => {
-  const cacheKey = 'spritz:acp:transcript:conv-1';
   const window = loadModules(
     {
-      [cacheKey]: JSON.stringify({
-        version: 2,
+      [CURRENT_CACHE_KEY]: JSON.stringify({
         conversationId: 'conv-1',
         transcript: {
           messages: [
@@ -580,10 +579,8 @@ test('ACP page clears cached transcript when backend replay returns no transcrip
 });
 
 test('ACP page drops cached HTML error documents during transcript restore', async () => {
-  const cacheKey = 'spritz:acp:transcript:conv-1';
   const window = loadModules({
-    [cacheKey]: JSON.stringify({
-      version: 1,
+    [CURRENT_CACHE_KEY]: JSON.stringify({
       conversationId: 'conv-1',
       transcript: {
         messages: [

--- a/ui/public/acp-page.js
+++ b/ui/public/acp-page.js
@@ -1,10 +1,11 @@
 (function (global) {
   const { createACPClient } = global.SpritzACPClient;
   const ACPRender = global.SpritzACPRender;
-  const ACP_TRANSCRIPT_CACHE_VERSION = 2;
-  const ACP_TRANSCRIPT_CACHE_PREFIX = 'spritz:acp:transcript:';
-  const ACP_TRANSCRIPT_CACHE_INDEX_KEY = 'spritz:acp:transcript:index';
+  const ACP_TRANSCRIPT_CACHE_PREFIX = 'spritz:acp:thread:';
+  const ACP_TRANSCRIPT_CACHE_INDEX_KEY = 'spritz:acp:thread:index';
   const ACP_TRANSCRIPT_CACHE_LIMIT = 25;
+  const PRE_CUTOVER_ACP_TRANSCRIPT_CACHE_PREFIX = 'spritz:acp:transcript:';
+  const PRE_CUTOVER_ACP_TRANSCRIPT_CACHE_INDEX_KEY = 'spritz:acp:transcript:index';
 
   function chatPagePath(name = '', conversationId = '') {
     if (!name) return '#chat';
@@ -142,14 +143,7 @@
   }
 
   function readTranscriptCacheIndex(storage) {
-    if (!storage) return [];
-    try {
-      const raw = storage.getItem(ACP_TRANSCRIPT_CACHE_INDEX_KEY);
-      const parsed = raw ? JSON.parse(raw) : [];
-      return Array.isArray(parsed) ? parsed.filter((item) => typeof item === 'string' && item) : [];
-    } catch {
-      return [];
-    }
+    return readTranscriptCacheIndexFromKey(storage, ACP_TRANSCRIPT_CACHE_INDEX_KEY);
   }
 
   function writeTranscriptCacheIndex(storage, ids) {
@@ -165,12 +159,38 @@
     return `${ACP_TRANSCRIPT_CACHE_PREFIX}${conversationId}`;
   }
 
+  function purgePreCutoverTranscriptCache(storage) {
+    if (!storage) return;
+    try {
+      const priorIndex = readTranscriptCacheIndexFromKey(storage, PRE_CUTOVER_ACP_TRANSCRIPT_CACHE_INDEX_KEY);
+      priorIndex.forEach((conversationId) => {
+        storage.removeItem(`${PRE_CUTOVER_ACP_TRANSCRIPT_CACHE_PREFIX}${conversationId}`);
+      });
+      storage.removeItem(PRE_CUTOVER_ACP_TRANSCRIPT_CACHE_INDEX_KEY);
+    } catch {
+      // ignore storage errors
+    }
+  }
+
+  function readTranscriptCacheIndexFromKey(storage, key) {
+    if (!storage) return [];
+    try {
+      const raw = storage.getItem(key);
+      const parsed = raw ? JSON.parse(raw) : [];
+      return Array.isArray(parsed) ? parsed.filter((item) => typeof item === 'string' && item) : [];
+    } catch {
+      return [];
+    }
+  }
+
   function clearCachedConversationRecord(conversationId) {
     const normalizedId = String(conversationId || '').trim();
     if (!normalizedId) return;
     const storage = safeSessionStorage();
     if (!storage) return;
+    purgePreCutoverTranscriptCache(storage);
     try {
+      storage.removeItem(`${PRE_CUTOVER_ACP_TRANSCRIPT_CACHE_PREFIX}${normalizedId}`);
       storage.removeItem(conversationTranscriptCacheKey(normalizedId));
       writeTranscriptCacheIndex(
         storage,
@@ -186,11 +206,13 @@
     if (!normalizedId) return null;
     const storage = safeSessionStorage();
     if (!storage) return null;
+    purgePreCutoverTranscriptCache(storage);
     try {
+      storage.removeItem(`${PRE_CUTOVER_ACP_TRANSCRIPT_CACHE_PREFIX}${normalizedId}`);
       const raw = storage.getItem(conversationTranscriptCacheKey(normalizedId));
       if (!raw) return null;
       const parsed = JSON.parse(raw);
-      if (parsed?.version !== ACP_TRANSCRIPT_CACHE_VERSION || typeof parsed !== 'object') {
+      if (!parsed || typeof parsed !== 'object') {
         clearCachedConversationRecord(normalizedId);
         return null;
       }
@@ -205,10 +227,10 @@
     if (!conversationId) return;
     const storage = safeSessionStorage();
     if (!storage) return;
+    purgePreCutoverTranscriptCache(storage);
 
     const preview = ACPRender.getPreviewText(page.transcript);
     const payload = {
-      version: ACP_TRANSCRIPT_CACHE_VERSION,
       conversationId,
       spritzName: page.selectedName || '',
       sessionId: page.selectedConversation?.spec?.sessionId || '',
@@ -217,6 +239,7 @@
       transcript: ACPRender.serializeTranscript(page.transcript),
     };
     try {
+      storage.removeItem(`${PRE_CUTOVER_ACP_TRANSCRIPT_CACHE_PREFIX}${conversationId}`);
       storage.setItem(conversationTranscriptCacheKey(conversationId), JSON.stringify(payload));
       const nextIndex = [conversationId, ...readTranscriptCacheIndex(storage).filter((item) => item !== conversationId)];
       const prunedIndex = nextIndex.slice(0, ACP_TRANSCRIPT_CACHE_LIMIT);


### PR DESCRIPTION
## Summary
- remove ACP transcript cache versioning entirely
- cut over to a single current cache namespace and purge the pre-cutover namespace
- keep the HTML error sanitization in the render path

## Testing
- node --test ui/public/acp-render.test.mjs ui/public/acp-page-cache.test.mjs ui/public/acp-page-notice.test.mjs ui/public/acp-page-layout.test.mjs ui/public/app-chat-route.test.mjs ui/public/preset-panel.test.mjs
- node --check ui/public/acp-render.js
- node --check ui/public/acp-page.js
- git diff --check
- agent-browser harness verifying old namespace purge and no version field in new cache payload