### PR TITLE
fix(acp): lazy-start the openclaw gateway

### DIFF
--- a/images/examples/openclaw/acp-wrapper.mjs
+++ b/images/examples/openclaw/acp-wrapper.mjs
@@ -238,12 +238,48 @@ export function resolveBridgeFallbackSessionKey(sessionId, env = process.env) {
 }
 
 /**
+ * Lazily starts the OpenClaw gateway connection only when ACP session methods
+ * actually need it. This prevents initialize-only ACP probes from opening and
+ * then abruptly tearing down gateway webchat sessions.
+ */
+export function createLazyGatewayController(gateway, hooks = {}) {
+  let ensureReadyPromise = null;
+  let stopped = false;
+
+  return {
+    async ensureReady() {
+      if (stopped) {
+        throw new Error("Gateway controller has already been stopped.");
+      }
+      if (!ensureReadyPromise) {
+        gateway.start();
+        ensureReadyPromise = Promise.resolve()
+          .then(() => hooks.waitUntilReady?.())
+          .catch((error) => {
+            throw error;
+          });
+      }
+      return ensureReadyPromise;
+    },
+    stop() {
+      if (stopped) {
+        return;
+      }
+      stopped = true;
+      hooks.onStop?.();
+      gateway.stop();
+    },
+  };
+}
+
+/**
  * Extends OpenClaw's ACP gateway agent so the default ACP session flow maps to
  * normal agent-scoped gateway sessions instead of ACP runtime session keys.
  */
-export function createSpritzAcpGatewayAgentClass(AcpGatewayAgent, env = process.env) {
+export function createSpritzAcpGatewayAgentClass(AcpGatewayAgent, env = process.env, hooks = {}) {
   return class SpritzOpenclawAcpGatewayAgent extends AcpGatewayAgent {
     async newSession(params) {
+      await hooks.ensureGatewayReady?.();
       if (params.mcpServers.length > 0) {
         this.log(`ignoring ${params.mcpServers.length} MCP servers`);
       }
@@ -261,6 +297,7 @@ export function createSpritzAcpGatewayAgentClass(AcpGatewayAgent, env = process.
     }
 
     async loadSession(params) {
+      await hooks.ensureGatewayReady?.();
       if (params.mcpServers.length > 0) {
         this.log(`ignoring ${params.mcpServers.length} MCP servers`);
       }
@@ -555,32 +592,31 @@ async function serveSpritzOpenclawAcp(opts = {}, env = process.env) {
     },
   });
 
+  const gatewayController = createLazyGatewayController(gateway, {
+    waitUntilReady: () => gatewayReady,
+    onStop: () => {
+      resolveGatewayReady();
+      onClosed();
+    },
+  });
+
   const shutdown = () => {
     if (stopped) {
       return;
     }
     stopped = true;
-    resolveGatewayReady();
-    gateway.stop();
-    onClosed();
+    gatewayController.stop();
   };
 
   process.once("SIGINT", shutdown);
   process.once("SIGTERM", shutdown);
 
-  gateway.start();
-  await gatewayReady.catch((error) => {
-    shutdown();
-    throw error;
-  });
-  if (stopped) {
-    return closed;
-  }
-
   const input = Writable.toWeb(process.stdout);
   const output = Readable.toWeb(process.stdin);
   const stream = ndJsonStream(input, output);
-  const SpritzAcpGatewayAgent = createSpritzAcpGatewayAgentClass(AcpGatewayAgent, env);
+  const SpritzAcpGatewayAgent = createSpritzAcpGatewayAgentClass(AcpGatewayAgent, env, {
+    ensureGatewayReady: () => gatewayController.ensureReady(),
+  });
 
   new AgentSideConnection((connectionInstance) => {
     agent = new SpritzAcpGatewayAgent(connectionInstance, gateway, opts);

--- a/images/examples/openclaw/acp-wrapper.test.mjs
+++ b/images/examples/openclaw/acp-wrapper.test.mjs
@@ -8,6 +8,7 @@ import {
   buildGatewayClientOptions,
   buildHistoryReplayUpdates,
   buildBridgeFallbackSessionKey,
+  createLazyGatewayController,
   createSpritzAcpGatewayAgentClass,
   loadOpenclawCompat,
   parseArgs,
@@ -315,6 +316,90 @@ test('loadSession replays persisted session transcript before returning', async 
   assert.equal(agent.connection.updates[1].update.content.text, 'history reply');
   assert.deepEqual(agent.rateLimits, ['loadSession']);
   assert.deepEqual(agent.sentAvailableCommands, ['123e4567-e89b-42d3-a456-426614174000']);
+});
+
+test('Spritz ACP gateway agent ensures the gateway is ready before session lifecycle calls', async () => {
+  class FakeBaseAgent {
+    constructor() {
+      this.sessionStore = {
+        entries: new Map(),
+        createSession: ({ sessionId, sessionKey, cwd }) => {
+          const session = { sessionId, sessionKey, cwd };
+          this.sessionStore.entries.set(sessionId, session);
+          return session;
+        },
+        hasSession: () => false,
+      };
+      this.sentAvailableCommands = [];
+      this.connection = {
+        async sessionUpdate() {},
+      };
+      this.gateway = {
+        async request() {
+          return { messages: [] };
+        },
+      };
+    }
+
+    log() {}
+    enforceSessionCreateRateLimit() {}
+    async sendAvailableCommands(sessionId) {
+      this.sentAvailableCommands.push(sessionId);
+    }
+  }
+
+  const ensureGatewayReadyCalls = [];
+  const SpritzAgent = createSpritzAcpGatewayAgentClass(
+    FakeBaseAgent,
+    {},
+    {
+      async ensureGatewayReady() {
+        ensureGatewayReadyCalls.push('ready');
+      },
+    },
+  );
+  const agent = new SpritzAgent();
+
+  const created = await agent.newSession({
+    cwd: '/home/dev',
+    mcpServers: [],
+  });
+  await agent.loadSession({
+    sessionId: created.sessionId,
+    cwd: '/home/dev',
+    mcpServers: [],
+  });
+
+  assert.deepEqual(ensureGatewayReadyCalls, ['ready', 'ready']);
+});
+
+test('lazy gateway controller defers gateway start until the first session lifecycle call', async () => {
+  const events = [];
+  const controller = createLazyGatewayController(
+    {
+      start() {
+        events.push('start');
+      },
+      stop() {
+        events.push('stop');
+      },
+    },
+    {
+      async waitUntilReady() {
+        events.push('wait');
+      },
+      onStop() {
+        events.push('onStop');
+      },
+    },
+  );
+
+  assert.deepEqual(events, []);
+  await controller.ensureReady();
+  await controller.ensureReady();
+  controller.stop();
+
+  assert.deepEqual(events, ['start', 'wait', 'onStop', 'stop']);
 });
 
 test('loadOpenclawCompat loads the generated stable compat module from the package root', async () => {


### PR DESCRIPTION
## Summary
- defer OpenClaw gateway startup until ACP session lifecycle calls actually need it
- keep initialize-only ACP probes from opening and abruptly killing a webchat gateway connection
- add regression coverage for lazy gateway startup and session lifecycle readiness

## Validation
- node --test images/examples/openclaw/acp-wrapper.test.mjs
- node --check images/examples/openclaw/acp-wrapper.mjs
- git diff --check