### PR TITLE
fix(acp): ship wrapper next to openclaw adapter

### DIFF
--- a/images/examples/openclaw/Dockerfile
+++ b/images/examples/openclaw/Dockerfile
@@ -64,7 +64,7 @@ WORKDIR /workspace
 COPY --chown=dev:dev examples/base/entrypoint.sh /usr/local/bin/spritz-entrypoint
 COPY --chown=dev:dev examples/openclaw/entrypoint.sh /usr/local/bin/spritz-openclaw-entrypoint
 COPY --chown=dev:dev --chmod=0755 examples/openclaw/acp-server.mjs /usr/local/bin/spritz-openclaw-acp-server
-COPY --chown=dev:dev --chmod=0755 examples/openclaw/acp-wrapper.mjs /usr/local/bin/spritz-openclaw-acp-wrapper
+COPY --chown=dev:dev --chmod=0755 examples/openclaw/acp-wrapper.mjs /usr/local/bin/acp-wrapper.mjs
 
 ENTRYPOINT ["/usr/local/bin/spritz-openclaw-entrypoint"]
 CMD ["sleep", "infinity"]

--- a/images/examples/openclaw/image-contract.test.mjs
+++ b/images/examples/openclaw/image-contract.test.mjs
@@ -39,6 +39,15 @@ test("openclaw image copies the ACP server into /usr/local/bin", () => {
   );
 });
 
+test("openclaw image copies the ACP wrapper next to the ACP server runtime path", () => {
+  const dockerfile = fs.readFileSync(dockerfilePath, "utf8");
+
+  assert.match(
+    dockerfile,
+    /COPY --chown=dev:dev --chmod=0755 examples\/openclaw\/acp-wrapper\.mjs \/usr\/local\/bin\/acp-wrapper\.mjs/,
+  );
+});
+
 test("openclaw entrypoint defaults the ACP server binary", () => {
   const entrypoint = fs.readFileSync(entrypointPath, "utf8");
 


### PR DESCRIPTION
## Summary
- ship the OpenClaw ACP wrapper at the runtime path imported by the long-lived ACP server
- add a regression test that locks the image contract to that runtime path

## Testing
- node --test images/examples/openclaw/image-contract.test.mjs images/examples/openclaw/acp-server.test.mjs images/examples/openclaw/acp-wrapper.test.mjs
- node --check images/examples/openclaw/acp-server.mjs
- node --check images/examples/openclaw/acp-wrapper.mjs
- bash images/examples/openclaw/entrypoint_test.sh
- git diff --check