### PR TITLE
fix(acp): load ws via openclaw esm wrapper

### DIFF
--- a/images/examples/openclaw/acp-server.mjs
+++ b/images/examples/openclaw/acp-server.mjs
@@ -3,19 +3,18 @@
 import http from "node:http";
 import net from "node:net";
 import { PassThrough, Readable, Writable } from "node:stream";
-import { createRequire } from "node:module";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { pathToFileURL } from "node:url";
 
 import {
   buildGatewayClientOptions,
   buildSpritzOpenclawAcpMetadata,
   createLazyGatewayController,
   createSpritzAcpGatewayAgentClass,
+  importOpenclawDependency,
   loadAcpSdk,
   loadOpenclawCompat,
   parseArgs,
   readOpenclawPackageVersion,
-  resolveOpenclawPackageRoot,
   useTrustedProxyControlUiBridge,
 } from "./acp-wrapper.mjs";
 
@@ -156,18 +155,26 @@ function rewriteConnectFrameAsTrustedProxyControlUi(payload) {
   return Buffer.from(JSON.stringify(frame), "utf8");
 }
 
+export function resolveWSExports(wsModule) {
+  const WebSocket =
+    wsModule?.WebSocket ??
+    wsModule?.default?.WebSocket ??
+    wsModule?.default ??
+    wsModule;
+  const WebSocketServer =
+    wsModule?.WebSocketServer ??
+    wsModule?.default?.WebSocketServer;
+  return { WebSocket, WebSocketServer };
+}
+
 async function loadWSModule(env = process.env) {
-  const packageRoot = resolveOpenclawPackageRoot(env);
-  const requireFromOpenclaw = createRequire(`${packageRoot}/package.json`);
-  const resolvedPath = requireFromOpenclaw.resolve("ws");
-  return await import(pathToFileURL(resolvedPath).href);
+  return await importOpenclawDependency("ws/wrapper.mjs", env);
 }
 
 async function startGatewayProxy(params) {
   const { upstreamURL, headers, trustedProxyControlUi, env, logger } = params;
   const wsModule = await loadWSModule(env);
-  const WebSocket = wsModule.WebSocket ?? wsModule.default ?? wsModule;
-  const WebSocketServer = wsModule.WebSocketServer;
+  const { WebSocket, WebSocketServer } = resolveWSExports(wsModule);
   if (!WebSocket || !WebSocketServer) {
     throw new Error("Failed to load ws module for the Spritz OpenClaw gateway proxy.");
   }
@@ -582,7 +589,7 @@ export async function serveSpritzOpenclawAcpServer(env = process.env, logger = c
   const config = configFromEnv(env);
   const runtime = await createRuntime(config, env, logger);
   const wsModule = await loadWSModule(env);
-  const WebSocketServer = wsModule.WebSocketServer;
+  const { WebSocketServer } = resolveWSExports(wsModule);
   if (!WebSocketServer) {
     throw new Error("Failed to load WebSocketServer from ws.");
   }

--- a/images/examples/openclaw/acp-server.test.mjs
+++ b/images/examples/openclaw/acp-server.test.mjs
@@ -5,6 +5,7 @@ import http from "node:http";
 import {
   createACPRequestHandler,
   parseListenAddress,
+  resolveWSExports,
 } from "./acp-server.mjs";
 
 test("parseListenAddress supports IPv4 and bracketed IPv6", () => {
@@ -68,4 +69,22 @@ test("ACP request handler serves health and metadata without mutating runtime st
   assert.equal(upgradeRes.status, 426);
 
   await new Promise((resolve) => server.close(resolve));
+});
+
+test("resolveWSExports accepts ws modules that expose constructors via the default export", () => {
+  const WebSocket = class WebSocket {};
+  const WebSocketServer = class WebSocketServer {};
+
+  assert.deepEqual(
+    resolveWSExports({
+      default: {
+        WebSocket,
+        WebSocketServer,
+      },
+    }),
+    {
+      WebSocket,
+      WebSocketServer,
+    },
+  );
 });


### PR DESCRIPTION
## Summary
- load the OpenClaw ACP server websocket runtime from the package-owned ESM wrapper instead of the CommonJS entrypoint
- normalize websocket constructors so CommonJS default-export shapes still work
- add a regression test for the default-export case

## Testing
- node --test images/examples/openclaw/acp-server.test.mjs images/examples/openclaw/image-contract.test.mjs images/examples/openclaw/acp-wrapper.test.mjs
- node --check images/examples/openclaw/acp-server.mjs
- node --check images/examples/openclaw/acp-wrapper.mjs
- bash images/examples/openclaw/entrypoint_test.sh
- git diff --check