### PR TITLE
fix(acp): load ws from exported entrypoint

### DIFF
--- a/images/examples/openclaw/acp-server.mjs
+++ b/images/examples/openclaw/acp-server.mjs
@@ -168,7 +168,7 @@ export function resolveWSExports(wsModule) {
 }
 
 async function loadWSModule(env = process.env) {
-  return await importOpenclawDependency("ws/wrapper.mjs", env);
+  return await importOpenclawDependency("ws", env);
 }
 
 async function startGatewayProxy(params) {

--- a/images/examples/openclaw/acp-server.test.mjs
+++ b/images/examples/openclaw/acp-server.test.mjs
@@ -1,12 +1,17 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import http from "node:http";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import {
   createACPRequestHandler,
   parseListenAddress,
   resolveWSExports,
 } from "./acp-server.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 test("parseListenAddress supports IPv4 and bracketed IPv6", () => {
   assert.deepEqual(parseListenAddress("0.0.0.0:2529"), {
@@ -87,4 +92,11 @@ test("resolveWSExports accepts ws modules that expose constructors via the defau
       WebSocketServer,
     },
   );
+});
+
+test("ACP server loads ws from the exported package entrypoint", () => {
+  const source = fs.readFileSync(path.join(__dirname, "acp-server.mjs"), "utf8");
+
+  assert.match(source, /importOpenclawDependency\("ws", env\)/);
+  assert.doesNotMatch(source, /importOpenclawDependency\("ws\/wrapper\.mjs", env\)/);
 });


### PR DESCRIPTION
## Summary
- load the ACP server websocket runtime from the exported OpenClaw package entrypoint
- keep websocket constructor normalization for the CommonJS default-export shape
- add a regression test so non-exported subpaths cannot slip back in

## Testing
- node --test images/examples/openclaw/acp-server.test.mjs images/examples/openclaw/image-contract.test.mjs images/examples/openclaw/acp-wrapper.test.mjs
- node --check images/examples/openclaw/acp-server.mjs
- node --check images/examples/openclaw/acp-wrapper.mjs
- bash images/examples/openclaw/entrypoint_test.sh
- git diff --check