### PR TITLE
fix(helm): allow spritz-api to update conversation status

### DIFF
--- a/helm/spritz/templates/api-rbac.yaml
+++ b/helm/spritz/templates/api-rbac.yaml
@@ -8,7 +8,7 @@ rules:
     resources: ["spritzes", "spritzconversations"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["spritz.sh"]
-    resources: ["spritzes/status"]
+    resources: ["spritzes/status", "spritzconversations/status"]
     verbs: ["get", "update", "patch"]
   - apiGroups: [""]
     resources: ["pods"]

--- a/scripts/verify-helm.sh
+++ b/scripts/verify-helm.sh
@@ -82,6 +82,7 @@ expect_contains "${auth_render}" "nginx.ingress.kubernetes.io/configuration-snip
 expect_contains "${auth_annotations_render}" "authonly: enabled" "auth ingress custom annotations in auth render"
 expect_contains "${acp_network_policy_render}" "kind: NetworkPolicy" "ACP network policy when enabled"
 expect_contains "${acp_network_policy_render}" "name: spritz-acp" "ACP network policy name when enabled"
+expect_contains "${default_render}" 'resources: ["spritzes/status", "spritzconversations/status"]' "status RBAC for spritz conversations"
 
 expect_failure \
   "api.auth.mode must be header or auto when authGateway.enabled=true" \


### PR DESCRIPTION
## Summary
- grant the spritz-api Role access to `spritzconversations/status`
- cover the chart with a regression check in `scripts/verify-helm.sh`

## Testing
- ./scripts/verify-helm.sh
- helm template spritz ./helm/spritz | rg -n 'spritzconversations/status|spritzes/status'