### PR TITLE
refactor(api): remove unused ACP gateway route

### DIFF
--- a/api/acp_gateway.go
+++ b/api/acp_gateway.go
@@ -8,48 +8,6 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-func (s *server) openACPConnection(c echo.Context) error {
-	if !s.acp.enabled {
-		return writeError(c, http.StatusNotFound, "acp disabled")
-	}
-	principal, ok := principalFromContext(c)
-	if s.auth.enabled() && (!ok || principal.ID == "") {
-		return writeError(c, http.StatusUnauthorized, "unauthenticated")
-	}
-	name := c.Param("name")
-	if name == "" {
-		return writeError(c, http.StatusBadRequest, "spritz name required")
-	}
-	namespace := s.requestNamespace(c)
-	if namespace == "" {
-		namespace = "default"
-	}
-
-	spritz, err := s.getAuthorizedACPReadySpritz(c.Request().Context(), principal, namespace, name)
-	if err != nil {
-		return s.writeACPResourceError(c, err)
-	}
-
-	upgrader := websocket.Upgrader{CheckOrigin: s.acp.allowOrigin}
-	browserConn, err := upgrader.Upgrade(c.Response(), c.Request(), nil)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		_ = browserConn.Close()
-	}()
-
-	workspaceConn, _, err := websocket.DefaultDialer.DialContext(c.Request().Context(), s.acpWorkspaceURL(spritz.Namespace, spritz.Name), nil)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		_ = workspaceConn.Close()
-	}()
-
-	return proxyWebSockets(browserConn, workspaceConn)
-}
-
 func (s *server) openACPConversationConnection(c echo.Context) error {
 	if !s.acp.enabled {
 		return writeError(c, http.StatusNotFound, "acp disabled")


### PR DESCRIPTION
## Summary
- remove the unused spritz-name ACP websocket handler
- keep the conversation-scoped ACP websocket path as the only live route

## Testing
- cd /Users/onur/repos/spritz/api && go test ./...