### PR TITLE
fix(ui): keep ACP chat panes within the viewport

### DIFF
--- a/ui/public/acp-layout-css.test.mjs
+++ b/ui/public/acp-layout-css.test.mjs
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const styles = fs.readFileSync('/Users/onur/repos/spritz/ui/public/styles.css', 'utf8');
+
+function getRule(selector) {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = styles.match(new RegExp(`${escapedSelector}\\s*\\{([\\s\\S]*?)\\n\\}`, 'm'));
+  assert.ok(match, `expected CSS rule for ${selector}`);
+  return match[1];
+}
+
+function assertDecl(rule, declaration, selector) {
+  assert.match(
+    rule,
+    new RegExp(`(^|\\n)\\s*${declaration.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*;`, 'm'),
+    `expected "${declaration}" in ${selector}`,
+  );
+}
+
+test('ACP chat shell uses viewport-bound layout with internal scrolling', () => {
+  const chatShell = getRule('.shell[data-view="chat"]');
+  assertDecl(chatShell, 'display: flex', '.shell[data-view="chat"]');
+  assertDecl(chatShell, 'flex-direction: column', '.shell[data-view="chat"]');
+  assertDecl(chatShell, 'height: 100dvh', '.shell[data-view="chat"]');
+  assertDecl(chatShell, 'overflow: hidden', '.shell[data-view="chat"]');
+
+  const acpShell = getRule('.acp-shell');
+  assertDecl(acpShell, 'flex: 1', '.acp-shell');
+  assertDecl(acpShell, 'min-height: 0', '.acp-shell');
+
+  const sidebar = getRule('.acp-sidebar');
+  assertDecl(sidebar, 'min-height: 0', '.acp-sidebar');
+  assertDecl(sidebar, 'overflow: hidden', '.acp-sidebar');
+
+  const threadList = getRule('.acp-thread-list');
+  assertDecl(threadList, 'min-height: 0', '.acp-thread-list');
+  assertDecl(threadList, 'overflow: auto', '.acp-thread-list');
+
+  const main = getRule('.acp-main');
+  assertDecl(main, 'min-height: 0', '.acp-main');
+  assertDecl(main, 'overflow: hidden', '.acp-main');
+
+  const mainBody = getRule('.acp-main-body');
+  assertDecl(mainBody, 'min-height: 0', '.acp-main-body');
+  assertDecl(mainBody, 'overflow: auto', '.acp-main-body');
+});

--- a/ui/public/styles.css
+++ b/ui/public/styles.css
@@ -238,9 +238,15 @@ button.ghost {
 }
 
 .shell[data-view="chat"] {
+  display: flex;
+  flex-direction: column;
   max-width: none;
-  min-height: 100vh;
+  height: 100dvh;
+  min-height: 100dvh;
   padding: 20px;
+  box-sizing: border-box;
+  overflow: hidden;
+  gap: 12px;
 }
 
 .shell[data-view="chat"] > header {
@@ -253,9 +259,10 @@ button.ghost {
 }
 
 .acp-shell {
+  flex: 1;
   display: grid;
   grid-template-columns: 320px minmax(0, 1fr);
-  min-height: calc(100vh - 40px);
+  min-height: 0;
   padding: 0;
   overflow: hidden;
 }
@@ -265,7 +272,8 @@ button.ghost {
   flex-direction: column;
   border-right: 1px solid #e5e8ec;
   background: rgba(247, 247, 248, 0.96);
-  min-height: calc(100vh - 40px);
+  min-height: 0;
+  overflow: hidden;
 }
 
 .acp-sidebar-top {
@@ -275,6 +283,7 @@ button.ghost {
   padding: 20px;
   border-bottom: 1px solid #e5e8ec;
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(247, 247, 248, 0.94));
+  flex-shrink: 0;
 }
 
 .acp-sidebar-nav {
@@ -313,11 +322,13 @@ button.ghost {
 
 .acp-thread-list {
   flex: 1;
+  min-height: 0;
   overflow: auto;
   padding: 12px;
   display: flex;
   flex-direction: column;
   gap: 8px;
+  overscroll-behavior: contain;
 }
 
 .acp-thread-item {
@@ -392,13 +403,15 @@ button.ghost {
   display: flex;
   flex-direction: column;
   min-width: 0;
-  min-height: calc(100vh - 40px);
+  min-height: 0;
+  overflow: hidden;
   background:
     radial-gradient(circle at top left, rgba(120, 177, 255, 0.08), transparent 28%),
     linear-gradient(180deg, #f7f8fa 0%, #eef1f5 100%);
 }
 
 .acp-main-header {
+  flex-shrink: 0;
   padding: 20px 24px 16px;
   border-bottom: 1px solid rgba(229, 232, 236, 0.9);
   background: rgba(255, 255, 255, 0.82);
@@ -438,8 +451,10 @@ button.ghost {
 
 .acp-main-body {
   flex: 1;
+  min-height: 0;
   overflow: auto;
   padding: 28px 24px 12px;
+  overscroll-behavior: contain;
 }
 
 .acp-stream {
@@ -655,6 +670,7 @@ button.ghost {
 }
 
 .acp-main-footer {
+  flex-shrink: 0;
   border-top: 1px solid rgba(229, 232, 236, 0.9);
   background: rgba(255, 255, 255, 0.92);
 }
@@ -776,18 +792,19 @@ button.ghost {
 
   .acp-shell {
     grid-template-columns: 1fr;
-    min-height: 100vh;
+    height: 100%;
+    min-height: 0;
     border-radius: 0;
   }
 
   .acp-sidebar {
-    min-height: auto;
+    min-height: 0;
     border-right: 0;
     border-bottom: 1px solid #e5e8ec;
   }
 
   .acp-main {
-    min-height: auto;
+    min-height: 0;
   }
 
   .acp-main-header-top,


### PR DESCRIPTION
## Summary
- bind the ACP chat shell to the viewport instead of letting the page grow
- make the sidebar rail and main transcript pane scroll internally
- add a CSS regression test for the viewport layout contract

## Testing
- node --test /Users/onur/repos/spritz/ui/public/acp-layout-css.test.mjs /Users/onur/repos/spritz/ui/public/acp-page-layout.test.mjs /Users/onur/repos/spritz/ui/public/acp-page-notice.test.mjs /Users/onur/repos/spritz/ui/public/acp-page-cache.test.mjs /Users/onur/repos/spritz/ui/public/acp-page-session-binding.test.mjs /Users/onur/repos/spritz/ui/public/app-chat-route.test.mjs /Users/onur/repos/spritz/ui/public/preset-panel.test.mjs /Users/onur/repos/spritz/ui/public/acp-render.test.mjs /Users/onur/repos/spritz/ui/public/acp-client.test.mjs
- agent-browser local harness against current UI files (document does not scroll; sidebar and main pane do)