### PR TITLE
feat(images): add Claude Code ACP example image

### DIFF
--- a/images/examples/claude-code/Dockerfile
+++ b/images/examples/claude-code/Dockerfile
@@ -1,0 +1,47 @@
+FROM node:22-bookworm-slim
+
+# Example Spritz image with Claude Code and a long-lived ACP bridge.
+# Build with context at images/ so shared scripts are available:
+#   docker build -f examples/claude-code/Dockerfile .
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+ARG CLAUDE_CODE_VERSION=2.1.72
+ARG CLAUDE_AGENT_ACP_VERSION=0.21.0
+ARG WS_VERSION=8.18.3
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    bash \
+    ca-certificates \
+    curl \
+    git \
+    nano \
+    openssh-client \
+    ripgrep \
+    vim \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g \
+    "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+    "@zed-industries/claude-agent-acp@${CLAUDE_AGENT_ACP_VERSION}" \
+    "ws@${WS_VERSION}" \
+  && test -x /usr/local/bin/claude \
+  && test -x /usr/local/bin/claude-agent-acp \
+  && test -f /usr/local/lib/node_modules/ws/index.js
+
+RUN useradd -m -s /bin/bash dev \
+  && mkdir -p /home/dev/.claude /home/dev/.config \
+  && chown -R dev:dev /home/dev/.claude /home/dev/.config
+
+ENV XDG_CONFIG_HOME=/home/dev/.config
+
+USER dev
+WORKDIR /workspace
+
+COPY --chown=dev:dev --chmod=0755 examples/base/entrypoint.sh /usr/local/bin/spritz-entrypoint
+COPY --chown=dev:dev --chmod=0755 examples/claude-code/entrypoint.sh /usr/local/bin/spritz-claude-code-entrypoint
+COPY --chown=dev:dev --chmod=0755 examples/claude-code/acp-server.mjs /usr/local/bin/spritz-claude-code-acp-server
+
+ENTRYPOINT ["/usr/local/bin/spritz-claude-code-entrypoint"]
+CMD ["sleep", "infinity"]

--- a/images/examples/claude-code/README.md
+++ b/images/examples/claude-code/README.md
@@ -1,0 +1,31 @@
+# Claude Code Example Image
+
+Example Spritz workspace image that starts Claude Code plus a workspace-local ACP websocket server on
+port `2529`.
+
+It stays generic:
+
+- no bundled secrets
+- no environment-specific domains or IDs
+- no TextCortex-specific wiring
+
+Build from `images/`:
+
+```bash
+docker build -f examples/claude-code/Dockerfile -t spritz-claude-code:latest .
+```
+
+Runtime contract:
+
+- websocket ACP on `0.0.0.0:2529`
+- health on `/healthz`
+- metadata on `/.well-known/spritz-acp`
+- adapter bin defaults to `claude-agent-acp`
+- required auth env defaults to `ANTHROPIC_API_KEY`
+
+Main overrides:
+
+- `SPRITZ_CLAUDE_CODE_ACP_ENABLED`
+- `SPRITZ_CLAUDE_CODE_ACP_BIN`
+- `SPRITZ_CLAUDE_CODE_ACP_ARGS_JSON`
+- `SPRITZ_CLAUDE_CODE_REQUIRED_ENV`

--- a/images/examples/claude-code/acp-server.mjs
+++ b/images/examples/claude-code/acp-server.mjs
@@ -1,0 +1,300 @@
+#!/usr/bin/env node
+
+import { spawn, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import http from "node:http";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const DEFAULTS = {
+  listenAddr: "0.0.0.0:2529",
+  acpPath: "/",
+  healthPath: "/healthz",
+  metadataPath: "/.well-known/spritz-acp",
+  wsRoot: "/usr/local/lib/node_modules/ws",
+  adapterBin: "claude-agent-acp",
+  agentPackageRoot: "/usr/local/lib/node_modules/@zed-industries/claude-agent-acp",
+  agentName: "claude-agent-acp",
+  agentTitle: "Claude Code ACP Gateway",
+  workdir: "/workspace",
+  requiredEnv: ["ANTHROPIC_API_KEY"],
+  shutdownTimeoutMs: 5_000,
+};
+
+const WEBSOCKET_OPEN = 1;
+
+function trimPath(value, fallback) {
+  const next = typeof value === "string" ? value.trim() : "";
+  if (!next) {
+    return fallback;
+  }
+  return next.startsWith("/") ? next : `/${next}`;
+}
+
+function parseListenAddr(value) {
+  const raw = String(value || "").trim();
+  if (!raw) {
+    throw new Error("SPRITZ_CLAUDE_CODE_ACP_LISTEN_ADDR is required");
+  }
+  if (raw.startsWith("[")) {
+    const closing = raw.indexOf("]");
+    if (closing === -1 || raw[closing + 1] !== ":") {
+      throw new Error(`invalid listen address: ${raw}`);
+    }
+    return {
+      host: raw.slice(1, closing),
+      port: Number.parseInt(raw.slice(closing + 2), 10),
+    };
+  }
+  const separator = raw.lastIndexOf(":");
+  if (separator === -1) {
+    throw new Error(`invalid listen address: ${raw}`);
+  }
+  return {
+    host: raw.slice(0, separator),
+    port: Number.parseInt(raw.slice(separator + 1), 10),
+  };
+}
+
+function parseArgsJSON(value) {
+  if (typeof value !== "string" || value.trim() === "") {
+    return [];
+  }
+  const parsed = JSON.parse(value);
+  if (!Array.isArray(parsed) || parsed.some((item) => typeof item !== "string")) {
+    throw new Error("SPRITZ_CLAUDE_CODE_ACP_ARGS_JSON must be a JSON array of strings");
+  }
+  return parsed.map((item) => item.trim()).filter(Boolean);
+}
+
+function parseRequiredEnv(value) {
+  if (typeof value !== "string" || value.trim() === "") {
+    return [...DEFAULTS.requiredEnv];
+  }
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function resolveMissingEnv(requiredEnv, env) {
+  return requiredEnv.filter((name) => !String(env[name] || "").trim());
+}
+
+function commandExists(bin, env) {
+  const result = spawnSync("/bin/sh", ["-lc", "command -v \"$0\" >/dev/null 2>&1", bin], {
+    env,
+    stdio: "ignore",
+  });
+  return result.status === 0;
+}
+
+function readVersion(packageRoot) {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(packageRoot, "package.json"), "utf8"));
+    return typeof pkg.version === "string" && pkg.version.trim() ? pkg.version.trim() : "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+function buildConfig(env) {
+  const agentPackageRoot =
+    env.SPRITZ_CLAUDE_CODE_AGENT_PACKAGE_ROOT || DEFAULTS.agentPackageRoot;
+  return {
+    listenAddr: env.SPRITZ_CLAUDE_CODE_ACP_LISTEN_ADDR || DEFAULTS.listenAddr,
+    acpPath: trimPath(env.SPRITZ_CLAUDE_CODE_ACP_PATH, DEFAULTS.acpPath),
+    healthPath: trimPath(env.SPRITZ_CLAUDE_CODE_ACP_HEALTH_PATH, DEFAULTS.healthPath),
+    metadataPath: trimPath(env.SPRITZ_CLAUDE_CODE_ACP_METADATA_PATH, DEFAULTS.metadataPath),
+    wsRoot: env.SPRITZ_CLAUDE_CODE_WS_PACKAGE_ROOT || DEFAULTS.wsRoot,
+    adapterBin: env.SPRITZ_CLAUDE_CODE_ACP_BIN || DEFAULTS.adapterBin,
+    adapterArgs: parseArgsJSON(env.SPRITZ_CLAUDE_CODE_ACP_ARGS_JSON),
+    requiredEnv: parseRequiredEnv(env.SPRITZ_CLAUDE_CODE_REQUIRED_ENV),
+    workdir: env.SPRITZ_CLAUDE_CODE_WORKDIR || DEFAULTS.workdir,
+    metadata: {
+      protocolVersion: 1,
+      agentCapabilities: {
+        loadSession: true,
+        promptCapabilities: {
+          image: true,
+          embeddedContext: true,
+        },
+        mcpCapabilities: {
+          http: true,
+          sse: true,
+        },
+      },
+      agentInfo: {
+        name: env.SPRITZ_CLAUDE_CODE_AGENT_NAME || DEFAULTS.agentName,
+        title: env.SPRITZ_CLAUDE_CODE_AGENT_TITLE || DEFAULTS.agentTitle,
+        version: env.SPRITZ_CLAUDE_CODE_AGENT_VERSION || readVersion(agentPackageRoot),
+      },
+      authMethods: [],
+    },
+  };
+}
+
+function writeJSON(res, status, body) {
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+function createLineForwarder(onLine) {
+  let pending = "";
+  return (chunk) => {
+    pending += chunk.toString("utf8");
+    let newline = pending.indexOf("\n");
+    while (newline !== -1) {
+      const line = pending.slice(0, newline).replace(/\r$/, "");
+      pending = pending.slice(newline + 1);
+      if (line.trim()) {
+        onLine(line);
+      }
+      newline = pending.indexOf("\n");
+    }
+  };
+}
+
+function ensureLine(data) {
+  const payload = Buffer.isBuffer(data) ? data : Buffer.from(data);
+  return payload[payload.length - 1] === 0x0a
+    ? payload
+    : Buffer.concat([payload, Buffer.from("\n")]);
+}
+
+function closeChild(child, timerRef) {
+  if (child.exitCode !== null || child.killed) {
+    return;
+  }
+  child.stdin.end();
+  child.kill("SIGTERM");
+  timerRef.current = setTimeout(() => {
+    if (child.exitCode === null && !child.killed) {
+      child.kill("SIGKILL");
+    }
+  }, DEFAULTS.shutdownTimeoutMs);
+}
+
+async function main(env = process.env, logger = console) {
+  const config = buildConfig(env);
+  const wsModule = await import(pathToFileURL(path.join(config.wsRoot, "index.js")).href);
+  const WebSocketServer =
+    wsModule?.WebSocketServer ?? wsModule?.default?.WebSocketServer ?? wsModule?.default;
+  if (!WebSocketServer) {
+    throw new Error("Failed to load WebSocketServer from ws");
+  }
+
+  const server = http.createServer((req, res) => {
+    const pathname = new URL(req.url ?? "/", "http://spritz-acp.local").pathname;
+    if (req.method === "GET" && pathname === config.healthPath) {
+      const missingEnv = resolveMissingEnv(config.requiredEnv, env);
+      if (missingEnv.length > 0) {
+        writeJSON(res, 503, { ok: false, error: `missing required env: ${missingEnv.join(", ")}` });
+        return;
+      }
+      if (!commandExists(config.adapterBin, env)) {
+        writeJSON(res, 503, { ok: false, error: `command not found: ${config.adapterBin}` });
+        return;
+      }
+      writeJSON(res, 200, { ok: true });
+      return;
+    }
+    if (req.method === "GET" && pathname === config.metadataPath) {
+      writeJSON(res, 200, config.metadata);
+      return;
+    }
+    if (req.method === "GET" && pathname === config.acpPath) {
+      res.writeHead(426, { "content-type": "text/plain; charset=utf-8" });
+      res.end("upgrade required");
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+
+  const wss = new WebSocketServer({ noServer: true });
+  wss.on("connection", (socket) => {
+    const missingEnv = resolveMissingEnv(config.requiredEnv, env);
+    if (missingEnv.length > 0) {
+      socket.close(1011, `missing required env: ${missingEnv.join(", ")}`);
+      return;
+    }
+    const child = spawn(config.adapterBin, config.adapterArgs, {
+      cwd: config.workdir,
+      env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const killTimer = { current: null };
+    let closed = false;
+
+    const closeSocket = (code, reason) => {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      if (socket.readyState === WEBSOCKET_OPEN) {
+        socket.close(code, reason);
+      }
+      closeChild(child, killTimer);
+    };
+
+    child.stdout.on(
+      "data",
+      createLineForwarder((line) => {
+        if (socket.readyState !== WEBSOCKET_OPEN) {
+          closeChild(child, killTimer);
+          return;
+        }
+        socket.send(line);
+      }),
+    );
+    child.stderr.on("data", createLineForwarder((line) => logger.error?.(`[claude-code-acp] ${line}`)));
+    child.on("error", (error) => {
+      logger.error?.(`claude-agent-acp failed to start: ${String(error)}`);
+      closeSocket(1011, "claude-agent-acp failed to start");
+    });
+    child.on("exit", (code, signal) => {
+      if (killTimer.current) {
+        clearTimeout(killTimer.current);
+      }
+      if (!closed) {
+        const status = signal ? `signal ${signal}` : `exit code ${code ?? 0}`;
+        logger.warn?.(`claude-agent-acp exited with ${status}`);
+        closeSocket(1011, `claude-agent-acp exited with ${status}`);
+      }
+    });
+    socket.on("message", (data) => {
+      if (!child.stdin.destroyed) {
+        child.stdin.write(ensureLine(data));
+      }
+    });
+    socket.on("close", () => closeSocket(1000, "client closed"));
+    socket.on("error", (error) => {
+      logger.warn?.(`claude-code ACP websocket error: ${String(error)}`);
+      closeSocket(1011, "client websocket error");
+    });
+  });
+
+  server.on("upgrade", (request, socket, head) => {
+    const pathname = new URL(request.url ?? "/", "http://spritz-acp.local").pathname;
+    if (pathname !== config.acpPath) {
+      socket.destroy();
+      return;
+    }
+    wss.handleUpgrade(request, socket, head, (websocket) => {
+      wss.emit("connection", websocket, request);
+    });
+  });
+
+  const { host, port } = parseListenAddr(config.listenAddr);
+  server.listen(port, host, () => {
+    logger.log?.(`spritz-claude-code-acp-server listening on ${host}:${port}${config.acpPath}`);
+  });
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.stack || error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/images/examples/claude-code/acp-server.test.mjs
+++ b/images/examples/claude-code/acp-server.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import test from "node:test";
+
+function once(child, event) {
+  return new Promise((resolve) => child.once(event, resolve));
+}
+
+test("health and metadata endpoints stay available with a fake ws module", async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "spritz-claude-code-test-"));
+  const wsRoot = path.join(tempRoot, "ws");
+  fs.mkdirSync(wsRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(wsRoot, "index.js"),
+    "export class WebSocketServer { constructor() {} on() {} handleUpgrade(_req, _socket, _head, callback) { callback({ readyState: 1, on() {}, send() {}, close() {} }); } }\n",
+  );
+  const packageRoot = path.join(tempRoot, "claude-agent-acp");
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(path.join(packageRoot, "package.json"), JSON.stringify({ version: "0.21.0" }));
+  const child = spawn("node", ["images/examples/claude-code/acp-server.mjs"], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      ANTHROPIC_API_KEY: "test-key",
+      SPRITZ_CLAUDE_CODE_ACP_LISTEN_ADDR: "127.0.0.1:32531",
+      SPRITZ_CLAUDE_CODE_WS_PACKAGE_ROOT: wsRoot,
+      SPRITZ_CLAUDE_CODE_AGENT_PACKAGE_ROOT: packageRoot,
+      SPRITZ_CLAUDE_CODE_ACP_BIN: "node",
+      SPRITZ_CLAUDE_CODE_ACP_ARGS_JSON: "[]",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  await once(child.stdout, "data");
+
+  const [healthRes, metadataRes, acpRes] = await Promise.all([
+    fetch("http://127.0.0.1:32531/healthz"),
+    fetch("http://127.0.0.1:32531/.well-known/spritz-acp"),
+    fetch("http://127.0.0.1:32531/"),
+  ]);
+
+  assert.equal(healthRes.status, 200);
+  assert.deepEqual(await healthRes.json(), { ok: true });
+  assert.equal(metadataRes.status, 200);
+  assert.equal((await metadataRes.json()).agentInfo.title, "Claude Code ACP Gateway");
+  assert.equal(acpRes.status, 426);
+
+  child.kill("SIGTERM");
+  await once(child, "exit");
+});

--- a/images/examples/claude-code/entrypoint.sh
+++ b/images/examples/claude-code/entrypoint.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+acp_enabled="${SPRITZ_CLAUDE_CODE_ACP_ENABLED:-true}"
+acp_bind="${SPRITZ_CLAUDE_CODE_ACP_BIND:-0.0.0.0}"
+acp_port="${SPRITZ_CLAUDE_CODE_ACP_PORT:-2529}"
+acp_path="${SPRITZ_CLAUDE_CODE_ACP_PATH:-/}"
+server_bin="${SPRITZ_CLAUDE_CODE_SERVER_BIN:-/usr/local/bin/spritz-claude-code-acp-server}"
+spritz_entrypoint_bin="${SPRITZ_CLAUDE_CODE_MAIN_ENTRYPOINT:-/usr/local/bin/spritz-entrypoint}"
+
+lower_acp_enabled="$(printf '%s' "${acp_enabled}" | tr '[:upper:]' '[:lower:]')"
+if [[ "${lower_acp_enabled}" == "false" || "${lower_acp_enabled}" == "0" || "${lower_acp_enabled}" == "no" || "${lower_acp_enabled}" == "off" ]]; then
+  exec "${spritz_entrypoint_bin}" "$@"
+fi
+
+export SPRITZ_CLAUDE_CODE_ACP_LISTEN_ADDR="${SPRITZ_CLAUDE_CODE_ACP_LISTEN_ADDR:-${acp_bind}:${acp_port}}"
+export SPRITZ_CLAUDE_CODE_ACP_PATH="${SPRITZ_CLAUDE_CODE_ACP_PATH:-${acp_path}}"
+export SPRITZ_CLAUDE_CODE_ACP_HEALTH_PATH="${SPRITZ_CLAUDE_CODE_ACP_HEALTH_PATH:-/healthz}"
+export SPRITZ_CLAUDE_CODE_ACP_METADATA_PATH="${SPRITZ_CLAUDE_CODE_ACP_METADATA_PATH:-/.well-known/spritz-acp}"
+export SPRITZ_CLAUDE_CODE_ACP_BIN="${SPRITZ_CLAUDE_CODE_ACP_BIN:-claude-agent-acp}"
+export SPRITZ_CLAUDE_CODE_ACP_ARGS_JSON="${SPRITZ_CLAUDE_CODE_ACP_ARGS_JSON:-[]}"
+export SPRITZ_CLAUDE_CODE_REQUIRED_ENV="${SPRITZ_CLAUDE_CODE_REQUIRED_ENV:-ANTHROPIC_API_KEY}"
+export SPRITZ_CLAUDE_CODE_WORKDIR="${SPRITZ_CLAUDE_CODE_WORKDIR:-/workspace}"
+export SPRITZ_CLAUDE_CODE_AGENT_NAME="${SPRITZ_CLAUDE_CODE_AGENT_NAME:-claude-agent-acp}"
+export SPRITZ_CLAUDE_CODE_AGENT_TITLE="${SPRITZ_CLAUDE_CODE_AGENT_TITLE:-Claude Code ACP Gateway}"
+
+"${server_bin}" &
+server_pid=$!
+
+"${spritz_entrypoint_bin}" "$@" &
+main_pid=$!
+
+cleanup() {
+  kill "${main_pid}" "${server_pid}" 2>/dev/null || true
+}
+
+trap cleanup INT TERM
+
+wait -n "${main_pid}" "${server_pid}"
+status=$?
+
+cleanup
+wait "${main_pid}" 2>/dev/null || true
+wait "${server_pid}" 2>/dev/null || true
+
+exit "${status}"

--- a/images/examples/claude-code/image-contract.test.mjs
+++ b/images/examples/claude-code/image-contract.test.mjs
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+test("Dockerfile marks the Claude Code entrypoints executable", () => {
+  const dockerfile = fs.readFileSync(new URL("./Dockerfile", import.meta.url), "utf8");
+  assert.match(
+    dockerfile,
+    /COPY --chown=dev:dev --chmod=0755 examples\/base\/entrypoint\.sh \/usr\/local\/bin\/spritz-entrypoint/,
+  );
+  assert.match(
+    dockerfile,
+    /COPY --chown=dev:dev --chmod=0755 examples\/claude-code\/entrypoint\.sh \/usr\/local\/bin\/spritz-claude-code-entrypoint/,
+  );
+});


### PR DESCRIPTION
## Summary
- add a generic Claude Code example workspace image that exposes ACP on port 2529
- start a workspace-local ACP websocket bridge via `claude-agent-acp` so Spritz can talk to Claude Code directly
- document the runtime contract and cover the image with focused tests

## Validation
- `node --test images/examples/claude-code/acp-server.test.mjs images/examples/claude-code/image-contract.test.mjs`
- `node --check images/examples/claude-code/acp-server.mjs`
- `bash -n images/examples/claude-code/entrypoint.sh`
- `npx -y @simpledoc/simpledoc check`
- `docker build -f examples/claude-code/Dockerfile -t spritz-claude-code-test:local .`
- real container smoke on port `2529` with a mocked ACP child:
  - `GET /healthz` -> `{"ok":true}`
  - `GET /.well-known/spritz-acp` -> Claude Code ACP metadata
  - websocket ACP `initialize` / `session/new` / `session/prompt` -> `claude-smoke-ok`
- `docker exec spritz-claude-code-smoke sh -lc 'claude --version && claude-agent-acp --help >/tmp/claude-agent-help.txt && head -n 2 /tmp/claude-agent-help.txt'