### PR TITLE
fix(claude-code): preserve ACP session state across reconnects

### DIFF
--- a/images/examples/claude-code/acp-server.mjs
+++ b/images/examples/claude-code/acp-server.mjs
@@ -175,6 +175,99 @@ function closeChild(child, timerRef) {
   }, DEFAULTS.shutdownTimeoutMs);
 }
 
+/**
+ * Owns the long-lived claude-agent-acp child process for the workspace.
+ * The runtime survives websocket reconnects so ACP session ids remain valid
+ * between Spritz bootstrap and the browser chat connection.
+ */
+class ACPRuntime {
+  constructor(config, env, logger) {
+    this.config = config;
+    this.env = env;
+    this.logger = logger;
+    this.child = null;
+    this.killTimer = { current: null };
+    this.socket = null;
+  }
+
+  ensureStarted() {
+    if (this.child && this.child.exitCode === null && !this.child.killed) {
+      return;
+    }
+    const child = spawn(this.config.adapterBin, this.config.adapterArgs, {
+      cwd: this.config.workdir,
+      env: this.env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    child.stdout.on(
+      "data",
+      createLineForwarder((line) => {
+        if (this.socket?.readyState === WEBSOCKET_OPEN) {
+          this.socket.send(line);
+        }
+      }),
+    );
+    child.stderr.on(
+      "data",
+      createLineForwarder((line) => this.logger.error?.(`[claude-code-acp] ${line}`)),
+    );
+    child.on("error", (error) => {
+      this.logger.error?.(`claude-agent-acp failed to start: ${String(error)}`);
+      this.closeSocket(1011, "claude-agent-acp failed to start");
+      this.child = null;
+    });
+    child.on("exit", (code, signal) => {
+      if (this.killTimer.current) {
+        clearTimeout(this.killTimer.current);
+      }
+      this.child = null;
+      const status = signal ? `signal ${signal}` : `exit code ${code ?? 0}`;
+      this.logger.warn?.(`claude-agent-acp exited with ${status}`);
+      this.closeSocket(1011, `claude-agent-acp exited with ${status}`);
+    });
+    this.child = child;
+  }
+
+  closeSocket(code, reason) {
+    if (this.socket?.readyState === WEBSOCKET_OPEN) {
+      this.socket.close(code, reason);
+    }
+    this.socket = null;
+  }
+
+  attach(socket) {
+    if (this.socket && this.socket.readyState === WEBSOCKET_OPEN) {
+      socket.close(1013, "another ACP client is already attached");
+      return;
+    }
+    this.ensureStarted();
+    this.socket = socket;
+    socket.on("message", (data) => {
+      if (this.child?.stdin && !this.child.stdin.destroyed) {
+        this.child.stdin.write(ensureLine(data));
+      }
+    });
+    socket.on("close", () => {
+      if (this.socket === socket) {
+        this.socket = null;
+      }
+    });
+    socket.on("error", (error) => {
+      this.logger.warn?.(`claude-code ACP websocket error: ${String(error)}`);
+      if (this.socket === socket) {
+        this.socket = null;
+      }
+    });
+  }
+
+  stop() {
+    this.closeSocket(1001, "server shutting down");
+    if (this.child) {
+      closeChild(this.child, this.killTimer);
+    }
+  }
+}
+
 async function main(env = process.env, logger = console) {
   const config = buildConfig(env);
   const wsModule = await import(pathToFileURL(path.join(config.wsRoot, "index.js")).href);
@@ -184,6 +277,7 @@ async function main(env = process.env, logger = console) {
     throw new Error("Failed to load WebSocketServer from ws");
   }
 
+  const runtime = new ACPRuntime(config, env, logger);
   const server = http.createServer((req, res) => {
     const pathname = new URL(req.url ?? "/", "http://spritz-acp.local").pathname;
     if (req.method === "GET" && pathname === config.healthPath) {
@@ -219,60 +313,7 @@ async function main(env = process.env, logger = console) {
       socket.close(1011, `missing required env: ${missingEnv.join(", ")}`);
       return;
     }
-    const child = spawn(config.adapterBin, config.adapterArgs, {
-      cwd: config.workdir,
-      env,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-    const killTimer = { current: null };
-    let closed = false;
-
-    const closeSocket = (code, reason) => {
-      if (closed) {
-        return;
-      }
-      closed = true;
-      if (socket.readyState === WEBSOCKET_OPEN) {
-        socket.close(code, reason);
-      }
-      closeChild(child, killTimer);
-    };
-
-    child.stdout.on(
-      "data",
-      createLineForwarder((line) => {
-        if (socket.readyState !== WEBSOCKET_OPEN) {
-          closeChild(child, killTimer);
-          return;
-        }
-        socket.send(line);
-      }),
-    );
-    child.stderr.on("data", createLineForwarder((line) => logger.error?.(`[claude-code-acp] ${line}`)));
-    child.on("error", (error) => {
-      logger.error?.(`claude-agent-acp failed to start: ${String(error)}`);
-      closeSocket(1011, "claude-agent-acp failed to start");
-    });
-    child.on("exit", (code, signal) => {
-      if (killTimer.current) {
-        clearTimeout(killTimer.current);
-      }
-      if (!closed) {
-        const status = signal ? `signal ${signal}` : `exit code ${code ?? 0}`;
-        logger.warn?.(`claude-agent-acp exited with ${status}`);
-        closeSocket(1011, `claude-agent-acp exited with ${status}`);
-      }
-    });
-    socket.on("message", (data) => {
-      if (!child.stdin.destroyed) {
-        child.stdin.write(ensureLine(data));
-      }
-    });
-    socket.on("close", () => closeSocket(1000, "client closed"));
-    socket.on("error", (error) => {
-      logger.warn?.(`claude-code ACP websocket error: ${String(error)}`);
-      closeSocket(1011, "client websocket error");
-    });
+    runtime.attach(socket);
   });
 
   server.on("upgrade", (request, socket, head) => {
@@ -290,11 +331,29 @@ async function main(env = process.env, logger = console) {
   server.listen(port, host, () => {
     logger.log?.(`spritz-claude-code-acp-server listening on ${host}:${port}${config.acpPath}`);
   });
+  let shuttingDown = false;
+  const shutdown = () => {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
+    runtime.stop();
+    server.close(() => {
+      process.exit(0);
+    });
+    setTimeout(() => process.exit(1), DEFAULTS.shutdownTimeoutMs).unref();
+  };
+  process.once("SIGTERM", shutdown);
+  process.once("SIGINT", shutdown);
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+const entrypoint = process.argv[1];
+
+if (entrypoint && import.meta.url === pathToFileURL(entrypoint).href) {
   main().catch((error) => {
     console.error(error instanceof Error ? error.stack || error.message : String(error));
     process.exit(1);
   });
 }
+
+export { ACPRuntime, buildConfig, main };

--- a/images/examples/claude-code/acp-server.test.mjs
+++ b/images/examples/claude-code/acp-server.test.mjs
@@ -4,9 +4,106 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
+import { ACPRuntime } from "./acp-server.mjs";
 
 function once(child, event) {
   return new Promise((resolve) => child.once(event, resolve));
+}
+
+function onceEvent(target, event, timeoutMs = 5000) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`timed out waiting for ${event}`));
+    }, timeoutMs);
+    const cleanup = () => {
+      clearTimeout(timer);
+      target.removeEventListener?.(event, onEvent);
+      target.removeEventListener?.("error", onError);
+    };
+    const onEvent = (value) => {
+      cleanup();
+      resolve(value);
+    };
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+    target.addEventListener?.(event, onEvent, { once: true });
+    target.addEventListener?.("error", onError, { once: true });
+  });
+}
+
+async function openSocket(url) {
+  const socket = new WebSocket(url);
+  await onceEvent(socket, "open");
+  return socket;
+}
+
+async function sendRPC(socket, payload) {
+  socket.send(JSON.stringify(payload));
+  const event = await onceEvent(socket, "message");
+  return JSON.parse(String(event.data));
+}
+
+function waitFor(predicate, timeoutMs = 5000) {
+  const start = Date.now();
+  return new Promise((resolve, reject) => {
+    const tick = () => {
+      const value = predicate();
+      if (value) {
+        resolve(value);
+        return;
+      }
+      if (Date.now() - start >= timeoutMs) {
+        reject(new Error("timed out waiting for condition"));
+        return;
+      }
+      setTimeout(tick, 10);
+    };
+    tick();
+  });
+}
+
+class FakeSocket {
+  constructor() {
+    this.handlers = new Map();
+    this.readyState = 1;
+    this.sent = [];
+  }
+
+  on(event, handler) {
+    this.handlers.set(event, handler);
+  }
+
+  send(payload) {
+    this.sent.push(String(payload));
+  }
+
+  close(_code, _reason) {
+    if (this.readyState !== 1) {
+      return;
+    }
+    this.readyState = 3;
+    const handler = this.handlers.get("close");
+    if (handler) {
+      handler();
+    }
+  }
+
+  emit(event, payload) {
+    const handler = this.handlers.get(event);
+    if (handler) {
+      handler(payload);
+    }
+  }
+}
+
+async function sendRuntimeRPC(socket, payload) {
+  const count = socket.sent.length;
+  socket.emit("message", JSON.stringify(payload));
+  const line = await waitFor(() => socket.sent.length > count ? socket.sent.at(-1) : null);
+  return JSON.parse(line);
 }
 
 test("health and metadata endpoints stay available with a fake ws module", async () => {
@@ -49,4 +146,97 @@ test("health and metadata endpoints stay available with a fake ws module", async
 
   child.kill("SIGTERM");
   await once(child, "exit");
+});
+
+test("session/load works after reconnecting to the same ACP server", async (t) => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "spritz-claude-code-runtime-"));
+  const adapterPath = path.join(tempRoot, "mock-adapter.mjs");
+  fs.writeFileSync(
+    adapterPath,
+    [
+      "const sessions = new Set();",
+      "process.stdin.setEncoding('utf8');",
+      "let pending = '';",
+      "function send(message) { process.stdout.write(JSON.stringify(message) + '\\n'); }",
+      "function handle(message) {",
+      "  if (message.method === 'initialize') {",
+      "    send({ id: message.id, jsonrpc: '2.0', result: { protocolVersion: 1, agentCapabilities: { loadSession: true, promptCapabilities: {} }, agentInfo: { name: 'mock', title: 'Mock', version: '1.0.0' } } });",
+      "    return;",
+      "  }",
+      "  if (message.method === 'session/new') {",
+      "    const sessionId = 'session-1';",
+      "    sessions.add(sessionId);",
+      "    send({ id: message.id, jsonrpc: '2.0', result: { sessionId } });",
+      "    return;",
+      "  }",
+      "  if (message.method === 'session/load') {",
+      "    if (!sessions.has(message.params?.sessionId)) {",
+      "      send({ id: message.id, jsonrpc: '2.0', error: { code: -32002, message: `Resource not found: ${message.params?.sessionId}` } });",
+      "      return;",
+      "    }",
+      "    send({ id: message.id, jsonrpc: '2.0', result: { sessionId: message.params.sessionId } });",
+      "    return;",
+      "  }",
+      "  send({ id: message.id, jsonrpc: '2.0', result: {} });",
+      "}",
+      "process.stdin.on('data', (chunk) => {",
+      "  pending += chunk;",
+      "  let newline = pending.indexOf('\\n');",
+      "  while (newline !== -1) {",
+      "    const line = pending.slice(0, newline).trim();",
+      "    pending = pending.slice(newline + 1);",
+      "    if (line) { handle(JSON.parse(line)); }",
+      "    newline = pending.indexOf('\\n');",
+      "  }",
+      "});",
+    ].join("\n"),
+  );
+  const runtime = new ACPRuntime(
+    {
+      adapterBin: "node",
+      adapterArgs: [adapterPath],
+      workdir: tempRoot,
+    },
+    {
+      ...process.env,
+      ANTHROPIC_API_KEY: "test-key",
+    },
+    console,
+  );
+  t.after(() => {
+    runtime.stop();
+  });
+
+  const firstSocket = new FakeSocket();
+  runtime.attach(firstSocket);
+  await sendRuntimeRPC(firstSocket, { id: "init-1", jsonrpc: "2.0", method: "initialize", params: {} });
+  const created = await sendRuntimeRPC(firstSocket, {
+    id: "new-1",
+    jsonrpc: "2.0",
+    method: "session/new",
+    params: { cwd: "/workspace", mcpServers: [] },
+  });
+  assert.equal(created.result.sessionId, "session-1");
+  firstSocket.close();
+
+  const secondSocket = new FakeSocket();
+  runtime.attach(secondSocket);
+  await sendRuntimeRPC(secondSocket, { id: "init-2", jsonrpc: "2.0", method: "initialize", params: {} });
+  const loaded = await sendRuntimeRPC(secondSocket, {
+    id: "load-1",
+    jsonrpc: "2.0",
+    method: "session/load",
+    params: { cwd: "/workspace", mcpServers: [], sessionId: "session-1" },
+  });
+  assert.deepEqual(loaded, {
+    id: "load-1",
+    jsonrpc: "2.0",
+    result: { sessionId: "session-1" },
+  });
+  secondSocket.close();
+
+  runtime.stop();
+  if (runtime.child) {
+    await once(runtime.child, "exit");
+  }
 });


### PR DESCRIPTION
## Summary
- keep the Claude Code ACP adapter process alive across websocket reconnects
- add a regression test that exercises session/new on one connection and session/load on the next
- make the example server shut down cleanly on SIGTERM/SIGINT

## Testing
- node --test /Users/onur/repos/spritz/images/examples/claude-code/acp-server.test.mjs /Users/onur/repos/spritz/images/examples/claude-code/image-contract.test.mjs
- node --check /Users/onur/repos/spritz/images/examples/claude-code/acp-server.mjs
- bash -n /Users/onur/repos/spritz/images/examples/claude-code/entrypoint.sh
- git diff --check