### PR TITLE
fix(claude-code): keep ACP runtime stable across reconnects

### DIFF
--- a/api/acp_bootstrap.go
+++ b/api/acp_bootstrap.go
@@ -114,11 +114,11 @@ func (c *acpBootstrapWorkspaceClient) close() error {
 	return c.conn.Close()
 }
 
-func (c *acpBootstrapWorkspaceClient) initialize(ctx context.Context, clientInfo acpBootstrapClientInfo) (*acpBootstrapInitializeResult, error) {
+func (c *acpBootstrapWorkspaceClient) initialize(ctx context.Context, clientInfo acpBootstrapClientInfo, clientCapabilities map[string]any) (*acpBootstrapInitializeResult, error) {
 	result := &acpBootstrapInitializeResult{}
 	if err := c.request(ctx, "initialize", acpBootstrapInitializeRequest{
 		ProtocolVersion:    1,
-		ClientCapabilities: map[string]any{},
+		ClientCapabilities: clientCapabilities,
 		ClientInfo:         clientInfo,
 	}, result, nil); err != nil {
 		return nil, err
@@ -335,7 +335,7 @@ func (s *server) bootstrapACPConversationBinding(ctx context.Context, conversati
 		_ = client.close()
 	}()
 
-	initResult, err := client.initialize(ctx, s.acp.clientInfo)
+	initResult, err := client.initialize(ctx, s.acp.clientInfo, s.acp.clientCapabilities)
 	if err != nil {
 		s.recordConversationBindingError(ctx, conversation.Namespace, conversation.Name, "", err)
 		return nil, err

--- a/api/acp_config.go
+++ b/api/acp_config.go
@@ -26,7 +26,23 @@ type acpConfig struct {
 	allowedOrigins       map[string]struct{}
 	workspaceURL         func(namespace, name string) string
 	clientInfo           acpBootstrapClientInfo
+	clientCapabilities   map[string]any
 	bootstrapDialTimeout time.Duration
+}
+
+func defaultACPClientCapabilities() map[string]any {
+	return map[string]any{
+		"auth": map[string]any{
+			"terminal": true,
+			"_meta": map[string]any{
+				"gateway": true,
+			},
+		},
+		"_meta": map[string]any{
+			"terminal-auth":  true,
+			"terminal_output": true,
+		},
+	}
 }
 
 func newACPConfig() acpConfig {
@@ -47,6 +63,7 @@ func newACPConfig() acpConfig {
 			Title:   envOrDefault("SPRITZ_ACP_CLIENT_TITLE", "Spritz ACP API"),
 			Version: envOrDefault("SPRITZ_ACP_CLIENT_VERSION", "1.0.0"),
 		},
+		clientCapabilities:   defaultACPClientCapabilities(),
 		bootstrapDialTimeout: parseDurationEnv("SPRITZ_ACP_BOOTSTRAP_DIAL_TIMEOUT", 5*time.Second),
 	}
 }

--- a/api/acp_test.go
+++ b/api/acp_test.go
@@ -49,6 +49,7 @@ func newACPTestServer(t *testing.T, objects ...client.Object) *server {
 			enabled:              true,
 			port:                 spritzv1.DefaultACPPort,
 			path:                 spritzv1.DefaultACPPath,
+			clientCapabilities:   defaultACPClientCapabilities(),
 			bootstrapDialTimeout: 5 * time.Second,
 		},
 	}
@@ -61,11 +62,12 @@ type fakeACPBootstrapServerOptions struct {
 }
 
 type fakeACPBootstrapServer struct {
-	url      string
-	server   *httptest.Server
-	mu       sync.Mutex
-	loadIDs  []string
-	newCalls int
+	url          string
+	server       *httptest.Server
+	mu           sync.Mutex
+	loadIDs      []string
+	newCalls     int
+	initRequests []acpBootstrapInitializeRequest
 }
 
 func newFakeACPBootstrapServer(t *testing.T, options fakeACPBootstrapServerOptions) *fakeACPBootstrapServer {
@@ -95,6 +97,13 @@ func newFakeACPBootstrapServer(t *testing.T, options fakeACPBootstrapServerOptio
 			}
 			switch message.Method {
 			case "initialize":
+				var params acpBootstrapInitializeRequest
+				if err := json.Unmarshal(message.Params, &params); err != nil {
+					t.Fatalf("failed to decode initialize params: %v", err)
+				}
+				fakeServer.mu.Lock()
+				fakeServer.initRequests = append(fakeServer.initRequests, params)
+				fakeServer.mu.Unlock()
 				if err := conn.WriteJSON(map[string]any{
 					"jsonrpc": "2.0",
 					"id":      message.ID,
@@ -673,5 +682,53 @@ func TestBootstrapACPConversationUsesDefaultNamespaceWhenRequestOmitsIt(t *testi
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestBootstrapACPConversationAdvertisesRichClientCapabilities(t *testing.T) {
+	spritz := readyACPSpritz("tidy-otter", "user-1")
+	conversation := conversationFor("tidy-otter-conv", "tidy-otter", "user-1", "Latest", metav1.Now())
+	conversation.Spec.SessionID = "session-existing"
+	fakeACP := newFakeACPBootstrapServer(t, fakeACPBootstrapServerOptions{})
+
+	s := newACPTestServer(t, spritz, conversation)
+	s.acp.workspaceURL = func(namespace, name string) string { return fakeACP.url }
+
+	e := echo.New()
+	secured := e.Group("", s.authMiddleware())
+	secured.POST("/api/acp/conversations/:id/bootstrap", s.bootstrapACPConversation)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/acp/conversations/"+conversation.Name+"/bootstrap", nil)
+	req.Header.Set("X-Spritz-User-Id", "user-1")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	fakeACP.mu.Lock()
+	defer fakeACP.mu.Unlock()
+	if len(fakeACP.initRequests) != 1 {
+		t.Fatalf("expected one initialize request, got %d", len(fakeACP.initRequests))
+	}
+	initRequest := fakeACP.initRequests[0]
+	authCapabilities, ok := initRequest.ClientCapabilities["auth"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected auth client capabilities, got %#v", initRequest.ClientCapabilities)
+	}
+	if authCapabilities["terminal"] != true {
+		t.Fatalf("expected terminal auth capability, got %#v", authCapabilities)
+	}
+	authMeta, ok := authCapabilities["_meta"].(map[string]any)
+	if !ok || authMeta["gateway"] != true {
+		t.Fatalf("expected gateway auth capability, got %#v", authCapabilities)
+	}
+	metaCapabilities, ok := initRequest.ClientCapabilities["_meta"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected _meta client capabilities, got %#v", initRequest.ClientCapabilities)
+	}
+	if metaCapabilities["terminal-auth"] != true || metaCapabilities["terminal_output"] != true {
+		t.Fatalf("expected terminal metadata capabilities, got %#v", metaCapabilities)
 	}
 }

--- a/images/examples/claude-code/acp-server.mjs
+++ b/images/examples/claude-code/acp-server.mjs
@@ -22,6 +22,18 @@ const DEFAULTS = {
 };
 
 const WEBSOCKET_OPEN = 1;
+const DEFAULT_CLIENT_CAPABILITIES = Object.freeze({
+  auth: {
+    terminal: true,
+    _meta: {
+      gateway: true,
+    },
+  },
+  _meta: {
+    "terminal-auth": true,
+    terminal_output: true,
+  },
+});
 
 function trimPath(value, fallback) {
   const next = typeof value === "string" ? value.trim() : "";
@@ -175,6 +187,63 @@ function parseACPMessage(line) {
   }
 }
 
+function cloneACPValue(value) {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
+function buildDefaultInitializeRequest(config) {
+  return {
+    protocolVersion: 1,
+    clientCapabilities: cloneACPValue(DEFAULT_CLIENT_CAPABILITIES),
+    clientInfo: {
+      name: config.metadata?.agentInfo?.name || DEFAULTS.agentName,
+      title: config.metadata?.agentInfo?.title || DEFAULTS.agentTitle,
+      version: config.metadata?.agentInfo?.version || "1.0.0",
+    },
+  };
+}
+
+function normalizeInitializeRequest(config, request) {
+  const fallback = buildDefaultInitializeRequest(config);
+  const params = request && typeof request === "object" ? request : {};
+  return {
+    protocolVersion: Number.isInteger(params.protocolVersion) ? params.protocolVersion : fallback.protocolVersion,
+    clientCapabilities:
+      params.clientCapabilities && typeof params.clientCapabilities === "object"
+        ? cloneACPValue(params.clientCapabilities)
+        : fallback.clientCapabilities,
+    clientInfo:
+      params.clientInfo && typeof params.clientInfo === "object"
+        ? {
+            name: String(params.clientInfo.name || fallback.clientInfo.name),
+            title: String(params.clientInfo.title || fallback.clientInfo.title),
+            version: String(params.clientInfo.version || fallback.clientInfo.version),
+          }
+        : fallback.clientInfo,
+  };
+}
+
+function normalizeInitializeResult(config, result) {
+  const fallback = config.metadata || {};
+  const payload = result && typeof result === "object" ? result : {};
+  return {
+    protocolVersion: Number.isInteger(payload.protocolVersion)
+      ? payload.protocolVersion
+      : fallback.protocolVersion || 1,
+    agentCapabilities:
+      payload.agentCapabilities && typeof payload.agentCapabilities === "object"
+        ? cloneACPValue(payload.agentCapabilities)
+        : cloneACPValue(fallback.agentCapabilities || {}),
+    agentInfo:
+      payload.agentInfo && typeof payload.agentInfo === "object"
+        ? cloneACPValue(payload.agentInfo)
+        : cloneACPValue(fallback.agentInfo || {}),
+    authMethods: Array.isArray(payload.authMethods)
+      ? cloneACPValue(payload.authMethods)
+      : cloneACPValue(fallback.authMethods || []),
+  };
+}
+
 function closeChild(child, timerRef) {
   if (child.exitCode !== null || child.killed) {
     return;
@@ -205,6 +274,7 @@ class ACPRuntime {
     this.internalPending = new Map();
     this.initialized = false;
     this.initializing = null;
+    this.initializeResult = null;
   }
 
   ensureStarted() {
@@ -255,6 +325,7 @@ class ACPRuntime {
       this.child = null;
       this.initialized = false;
       this.initializing = null;
+      this.initializeResult = null;
     });
     child.on("exit", (code, signal) => {
       if (this.killTimer.current) {
@@ -263,6 +334,7 @@ class ACPRuntime {
       this.child = null;
       this.initialized = false;
       this.initializing = null;
+      this.initializeResult = null;
       this.rejectInternalRequests({
         code: -32000,
         message: signal ? `signal ${signal}` : `exit code ${code ?? 0}`,
@@ -299,30 +371,25 @@ class ACPRuntime {
     });
   }
 
-  async ensureInitialized() {
+  async ensureInitialized(request) {
     if (this.initialized) {
-      return;
+      return this.initializeResult;
     }
     if (this.initializing) {
       await this.initializing;
-      return;
+      return this.initializeResult;
     }
-    this.initializing = this.requestChild("initialize", {
-      protocolVersion: 1,
-      clientCapabilities: {},
-      clientInfo: {
-        name: "spritz-claude-code-acp-server",
-        title: "Spritz Claude Code ACP Server",
-        version: "1.0.0",
-      },
-    })
-      .then(() => {
+    const initializeRequest = normalizeInitializeRequest(this.config, request);
+    this.initializing = this.requestChild("initialize", initializeRequest)
+      .then((result) => {
+        this.initializeResult = normalizeInitializeResult(this.config, result);
         this.initialized = true;
+        return this.initializeResult;
       })
       .finally(() => {
         this.initializing = null;
       });
-    await this.initializing;
+    return this.initializing;
   }
 
   closeSocket(code, reason) {
@@ -346,13 +413,13 @@ class ACPRuntime {
           return;
         }
         if (payload.method === "initialize" && payload.id !== undefined) {
-          await this.ensureInitialized();
+          const result = await this.ensureInitialized(payload.params);
           if (socket.readyState === WEBSOCKET_OPEN) {
             socket.send(
               JSON.stringify({
                 jsonrpc: "2.0",
                 id: payload.id,
-                result: this.config.metadata,
+                result,
               }),
             );
           }

--- a/images/examples/claude-code/acp-server.test.mjs
+++ b/images/examples/claude-code/acp-server.test.mjs
@@ -331,3 +331,107 @@ test("a new ACP client handoff replaces the previous attached socket", async (t)
     },
   });
 });
+
+test("initialize preserves adapter-negotiated auth methods across reconnects", async (t) => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "spritz-claude-code-runtime-"));
+  const adapterPath = path.join(tempRoot, "mock-adapter.mjs");
+  fs.writeFileSync(
+    adapterPath,
+    [
+      "process.stdin.setEncoding('utf8');",
+      "let pending = '';",
+      "function send(message) { process.stdout.write(JSON.stringify(message) + '\\n'); }",
+      "function handle(message) {",
+      "  if (message.method === 'initialize') {",
+      "    const supportsGatewayAuth = message.params?.clientCapabilities?.auth?._meta?.gateway === true;",
+      "    send({",
+      "      id: message.id,",
+      "      jsonrpc: '2.0',",
+      "      result: {",
+      "        protocolVersion: 1,",
+      "        agentCapabilities: { loadSession: true, promptCapabilities: {} },",
+      "        agentInfo: { name: 'mock', title: 'Mock', version: '1.0.0' },",
+      "        authMethods: supportsGatewayAuth ? [{ id: 'gateway', name: 'Gateway' }] : [],",
+      "      },",
+      "    });",
+      "    return;",
+      "  }",
+      "  send({ id: message.id, jsonrpc: '2.0', result: {} });",
+      "}",
+      "process.stdin.on('data', (chunk) => {",
+      "  pending += chunk;",
+      "  let newline = pending.indexOf('\\n');",
+      "  while (newline !== -1) {",
+      "    const line = pending.slice(0, newline).trim();",
+      "    pending = pending.slice(newline + 1);",
+      "    if (line) { handle(JSON.parse(line)); }",
+      "    newline = pending.indexOf('\\n');",
+      "  }",
+      "});",
+    ].join("\n"),
+  );
+  const runtime = new ACPRuntime(
+    {
+      adapterBin: "node",
+      adapterArgs: [adapterPath],
+      workdir: tempRoot,
+      metadata: {
+        protocolVersion: 1,
+        agentCapabilities: { loadSession: true, promptCapabilities: {} },
+        agentInfo: { name: "mock", title: "Mock", version: "1.0.0" },
+        authMethods: [],
+      },
+    },
+    {
+      ...process.env,
+      ANTHROPIC_API_KEY: "test-key",
+    },
+    console,
+  );
+  t.after(() => {
+    runtime.stop();
+  });
+
+  const firstSocket = new FakeSocket();
+  runtime.attach(firstSocket);
+  const firstInit = await sendRuntimeRPC(firstSocket, {
+    id: "init-1",
+    jsonrpc: "2.0",
+    method: "initialize",
+    params: {
+      protocolVersion: 1,
+      clientCapabilities: {
+        auth: {
+          _meta: {
+            gateway: true,
+          },
+        },
+      },
+      clientInfo: {
+        name: "client-a",
+        title: "Client A",
+        version: "1.0.0",
+      },
+    },
+  });
+  assert.deepEqual(firstInit.result.authMethods, [{ id: "gateway", name: "Gateway" }]);
+  firstSocket.close();
+
+  const secondSocket = new FakeSocket();
+  runtime.attach(secondSocket);
+  const secondInit = await sendRuntimeRPC(secondSocket, {
+    id: "init-2",
+    jsonrpc: "2.0",
+    method: "initialize",
+    params: {
+      protocolVersion: 1,
+      clientCapabilities: {},
+      clientInfo: {
+        name: "client-b",
+        title: "Client B",
+        version: "1.0.0",
+      },
+    },
+  });
+  assert.deepEqual(secondInit.result.authMethods, [{ id: "gateway", name: "Gateway" }]);
+});


### PR DESCRIPTION
## Summary
- keep one Claude ACP runtime initialized across reconnects instead of reinitializing the child on every downstream initialize
- replace the attached websocket cleanly instead of rejecting brief handoff overlap
- cover the reconnect/session-load regression and the websocket handoff behavior in tests

## Testing
- node --test /Users/onur/repos/spritz/images/examples/claude-code/acp-server.test.mjs /Users/onur/repos/spritz/images/examples/claude-code/image-contract.test.mjs
- node --check /Users/onur/repos/spritz/images/examples/claude-code/acp-server.mjs
- git diff --check