### PR TITLE
fix(acp): keep claude sessions stable before first prompt

### DIFF
--- a/images/examples/claude-code/acp-server.mjs
+++ b/images/examples/claude-code/acp-server.mjs
@@ -275,6 +275,7 @@ class ACPRuntime {
     this.initialized = false;
     this.initializing = null;
     this.initializeResult = null;
+    this.sessions = new Map();
   }
 
   ensureStarted() {
@@ -326,6 +327,7 @@ class ACPRuntime {
       this.initialized = false;
       this.initializing = null;
       this.initializeResult = null;
+      this.sessions.clear();
     });
     child.on("exit", (code, signal) => {
       if (this.killTimer.current) {
@@ -335,6 +337,7 @@ class ACPRuntime {
       this.initialized = false;
       this.initializing = null;
       this.initializeResult = null;
+      this.sessions.clear();
       this.rejectInternalRequests({
         code: -32000,
         message: signal ? `signal ${signal}` : `exit code ${code ?? 0}`,
@@ -369,6 +372,69 @@ class ACPRuntime {
         ),
       );
     });
+  }
+
+  normalizeRPCError(error) {
+    if (error && typeof error === "object" && Number.isInteger(error.code) && typeof error.message === "string") {
+      return {
+        code: error.code,
+        message: error.message,
+        ...(error.data !== undefined ? { data: error.data } : {}),
+      };
+    }
+    return {
+      code: -32000,
+      message: error instanceof Error ? error.message : String(error || "ACP request failed."),
+    };
+  }
+
+  sendRPCResponse(socket, id, body) {
+    if (socket.readyState !== WEBSOCKET_OPEN) {
+      return;
+    }
+    socket.send(JSON.stringify({ jsonrpc: "2.0", id, ...body }));
+  }
+
+  rememberSession(result, { replayable = false } = {}) {
+    const sessionId = String(result?.sessionId || "").trim();
+    if (!sessionId) {
+      return;
+    }
+    this.sessions.set(sessionId, {
+      sessionId,
+      replayable,
+      modes: cloneACPValue(result?.modes),
+      models: cloneACPValue(result?.models),
+      configOptions: cloneACPValue(result?.configOptions),
+    });
+  }
+
+  markSessionReplayable(sessionId) {
+    const key = String(sessionId || "").trim();
+    if (!key) {
+      return;
+    }
+    const cached = this.sessions.get(key);
+    if (!cached) {
+      return;
+    }
+    cached.replayable = true;
+  }
+
+  cachedLoadResult(sessionId) {
+    const key = String(sessionId || "").trim();
+    if (!key) {
+      return null;
+    }
+    const cached = this.sessions.get(key);
+    if (!cached || cached.replayable) {
+      return null;
+    }
+    return {
+      modes: cloneACPValue(cached.modes) || {},
+      models: cloneACPValue(cached.models) || {},
+      configOptions: cloneACPValue(cached.configOptions) || [],
+    };
   }
 
   async ensureInitialized(request) {
@@ -406,23 +472,42 @@ class ACPRuntime {
     this.ensureStarted();
     this.socket = socket;
     socket.on("message", async (data) => {
+      let payload = null;
       try {
-        const payload = parseACPMessage(Buffer.isBuffer(data) ? data.toString("utf8") : String(data));
+        payload = parseACPMessage(Buffer.isBuffer(data) ? data.toString("utf8") : String(data));
         if (payload.invalid) {
           socket.close(1002, "invalid ACP JSON");
           return;
         }
         if (payload.method === "initialize" && payload.id !== undefined) {
           const result = await this.ensureInitialized(payload.params);
-          if (socket.readyState === WEBSOCKET_OPEN) {
-            socket.send(
-              JSON.stringify({
-                jsonrpc: "2.0",
-                id: payload.id,
-                result,
-              }),
-            );
+          this.sendRPCResponse(socket, payload.id, { result });
+          return;
+        }
+        if (payload.method === "session/new" && payload.id !== undefined) {
+          await this.ensureInitialized();
+          const result = await this.requestChild("session/new", payload.params);
+          this.rememberSession(result, { replayable: false });
+          this.sendRPCResponse(socket, payload.id, { result });
+          return;
+        }
+        if (payload.method === "session/load" && payload.id !== undefined) {
+          await this.ensureInitialized();
+          const cached = this.cachedLoadResult(payload.params?.sessionId);
+          if (cached) {
+            this.sendRPCResponse(socket, payload.id, { result: cached });
+            return;
           }
+          const result = await this.requestChild("session/load", payload.params);
+          this.markSessionReplayable(payload.params?.sessionId);
+          this.sendRPCResponse(socket, payload.id, { result });
+          return;
+        }
+        if (payload.method === "session/prompt" && payload.id !== undefined) {
+          await this.ensureInitialized();
+          const result = await this.requestChild("session/prompt", payload.params);
+          this.markSessionReplayable(payload.params?.sessionId);
+          this.sendRPCResponse(socket, payload.id, { result });
           return;
         }
         await this.ensureInitialized();
@@ -430,6 +515,10 @@ class ACPRuntime {
           this.child.stdin.write(ensureLine(JSON.stringify(payload)));
         }
       } catch (error) {
+        if (payload?.id !== undefined) {
+          this.sendRPCResponse(socket, payload.id, { error: this.normalizeRPCError(error) });
+          return;
+        }
         this.logger.error?.(`claude-code ACP bridge error: ${String(error?.message || error)}`);
         socket.close(1011, "claude-code ACP bridge error");
       }

--- a/images/examples/claude-code/acp-server.test.mjs
+++ b/images/examples/claude-code/acp-server.test.mjs
@@ -243,7 +243,11 @@ test("session/load works after reconnecting to the same ACP server", async (t) =
   assert.deepEqual(loaded, {
     id: "load-1",
     jsonrpc: "2.0",
-    result: { sessionId: "session-1" },
+    result: {
+      modes: {},
+      models: {},
+      configOptions: [],
+    },
   });
   secondSocket.close();
 
@@ -251,6 +255,122 @@ test("session/load works after reconnecting to the same ACP server", async (t) =
   if (runtime.child) {
     await once(runtime.child, "exit");
   }
+});
+
+test("session/load reuses a freshly created session before the first prompt", async (t) => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "spritz-claude-code-runtime-"));
+  const adapterPath = path.join(tempRoot, "mock-adapter.mjs");
+  fs.writeFileSync(
+    adapterPath,
+    [
+      "let prompted = false;",
+      "process.stdin.setEncoding('utf8');",
+      "let pending = '';",
+      "function send(message) { process.stdout.write(JSON.stringify(message) + '\\n'); }",
+      "function handle(message) {",
+      "  if (message.method === 'initialize') {",
+      "    send({ id: message.id, jsonrpc: '2.0', result: { protocolVersion: 1, agentCapabilities: { loadSession: true, promptCapabilities: {} }, agentInfo: { name: 'mock', title: 'Mock', version: '1.0.0' } } });",
+      "    return;",
+      "  }",
+      "  if (message.method === 'session/new') {",
+      "    send({ id: message.id, jsonrpc: '2.0', result: { sessionId: 'session-1', modes: { currentModeId: 'default' }, models: { currentModelId: 'default' }, configOptions: [{ id: 'mode', currentValue: 'default' }] } });",
+      "    return;",
+      "  }",
+      "  if (message.method === 'session/load') {",
+      "    if (!prompted) {",
+      "      send({ id: message.id, jsonrpc: '2.0', error: { code: -32002, message: `Resource not found: ${message.params?.sessionId}` } });",
+      "      return;",
+      "    }",
+      "    send({ id: message.id, jsonrpc: '2.0', result: { modes: { currentModeId: 'default' }, models: { currentModelId: 'default' }, configOptions: [{ id: 'mode', currentValue: 'default' }] } });",
+      "    return;",
+      "  }",
+      "  if (message.method === 'session/prompt') {",
+      "    prompted = true;",
+      "    send({ id: message.id, jsonrpc: '2.0', result: { stopReason: 'end_turn' } });",
+      "    return;",
+      "  }",
+      "  send({ id: message.id, jsonrpc: '2.0', result: {} });",
+      "}",
+      "process.stdin.on('data', (chunk) => {",
+      "  pending += chunk;",
+      "  let newline = pending.indexOf('\\n');",
+      "  while (newline !== -1) {",
+      "    const line = pending.slice(0, newline).trim();",
+      "    pending = pending.slice(newline + 1);",
+      "    if (line) { handle(JSON.parse(line)); }",
+      "    newline = pending.indexOf('\\n');",
+      "  }",
+      "});",
+    ].join("\n"),
+  );
+  const runtime = new ACPRuntime(
+    {
+      adapterBin: "node",
+      adapterArgs: [adapterPath],
+      workdir: tempRoot,
+      metadata: {
+        protocolVersion: 1,
+        agentCapabilities: { loadSession: true, promptCapabilities: {} },
+        agentInfo: { name: "mock", title: "Mock", version: "1.0.0" },
+        authMethods: [],
+      },
+    },
+    {
+      ...process.env,
+      ANTHROPIC_API_KEY: "test-key",
+    },
+    console,
+  );
+  t.after(() => {
+    runtime.stop();
+  });
+
+  const firstSocket = new FakeSocket();
+  runtime.attach(firstSocket);
+  await sendRuntimeRPC(firstSocket, { id: "init-1", jsonrpc: "2.0", method: "initialize", params: {} });
+  const created = await sendRuntimeRPC(firstSocket, {
+    id: "new-1",
+    jsonrpc: "2.0",
+    method: "session/new",
+    params: { cwd: "/workspace", mcpServers: [] },
+  });
+  assert.equal(created.result.sessionId, "session-1");
+  firstSocket.close();
+
+  const secondSocket = new FakeSocket();
+  runtime.attach(secondSocket);
+  await sendRuntimeRPC(secondSocket, { id: "init-2", jsonrpc: "2.0", method: "initialize", params: {} });
+  const loaded = await sendRuntimeRPC(secondSocket, {
+    id: "load-1",
+    jsonrpc: "2.0",
+    method: "session/load",
+    params: { cwd: "/workspace", mcpServers: [], sessionId: "session-1" },
+  });
+  assert.deepEqual(loaded, {
+    id: "load-1",
+    jsonrpc: "2.0",
+    result: {
+      modes: { currentModeId: "default" },
+      models: { currentModelId: "default" },
+      configOptions: [{ id: "mode", currentValue: "default" }],
+    },
+  });
+
+  const prompted = await sendRuntimeRPC(secondSocket, {
+    id: "prompt-1",
+    jsonrpc: "2.0",
+    method: "session/prompt",
+    params: {
+      sessionId: "session-1",
+      prompt: [{ type: "text", text: "hello" }],
+    },
+  });
+  assert.deepEqual(prompted, {
+    id: "prompt-1",
+    jsonrpc: "2.0",
+    result: { stopReason: "end_turn" },
+  });
+  secondSocket.close();
 });
 
 test("a new ACP client handoff replaces the previous attached socket", async (t) => {

--- a/ui/public/acp-page-notice.test.mjs
+++ b/ui/public/acp-page-notice.test.mjs
@@ -266,6 +266,92 @@ test('ACP page surfaces real startup errors as toasts', async () => {
   assert.deepEqual(toastMessages, ['Failed to connect to ACP gateway.']);
 });
 
+test('ACP page sanitizes raw HTML bootstrap failures before showing a toast', async () => {
+  const toastMessages = [];
+  const window = loadModules(({ conversation }) => ({
+    start: async () => {},
+    isReady: () => false,
+    getConversationId: () => conversation?.metadata?.name || '',
+    getSessionId: () => conversation?.spec?.sessionId || '',
+    matchesConversation(targetConversation) {
+      return (
+        this.getConversationId() === (targetConversation?.metadata?.name || '') &&
+        this.getSessionId() === (targetConversation?.spec?.sessionId || '')
+      );
+    },
+    cancelPrompt() {},
+    dispose() {},
+  }));
+  const shellEl = createElement('main');
+  const createSection = createElement('section');
+  const listSection = createElement('section');
+  const htmlError =
+    '<!DOCTYPE html><html><head><title>textcortex.com | 502: Bad gateway</title></head><body>' +
+    '<span class="code-label">Error code 502</span><span>staging.spritz.textcortex.com</span>' +
+    '<span>Cloudflare</span><p>The web server reported a bad gateway error.</p></body></html>';
+
+  window.SpritzACPPage.renderACPPage('young-crest', 'conv-1', {
+    activePage: null,
+    apiBaseUrl: '',
+    authBearerTokenParam: 'token',
+    getAuthToken() {
+      return '';
+    },
+    async request(path) {
+      if (path === '/acp/agents') {
+        return {
+          items: [
+            {
+              spritz: {
+                metadata: { name: 'young-crest' },
+                status: {
+                  acp: { agentInfo: { title: 'OpenClaw ACP Gateway', version: '2026.3.8' } },
+                },
+              },
+            },
+          ],
+        };
+      }
+      if (path.startsWith('/acp/conversations?')) {
+        return {
+          items: [
+            {
+              metadata: { name: 'conv-1' },
+              spec: { title: 'Test conversation', sessionId: 'sess-1', cwd: '/home/dev' },
+              status: { updatedAt: '2026-03-10T05:44:00Z' },
+            },
+          ],
+        };
+      }
+      if (path === '/acp/conversations/conv-1/bootstrap') {
+        throw new Error(htmlError);
+      }
+      throw new Error(`unexpected path ${path}`);
+    },
+    showNotice() {},
+    clearNotice() {},
+    showToast(message) {
+      toastMessages.push(message);
+    },
+    buildOpenUrl(url) {
+      return url;
+    },
+    cleanupTerminal() {},
+    shellEl,
+    createSection,
+    listSection,
+    setHeaderCopy() {},
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(toastMessages.length, 1);
+  assert.match(toastMessages[0], /HTTP 502/i);
+  assert.match(toastMessages[0], /staging\.spritz\.textcortex\.com/i);
+  assert.equal(toastMessages[0].includes('<!DOCTYPE html>'), false);
+});
+
 test('ACP page surfaces HTML tool failures as toasts without dumping raw markup', async () => {
   const toastMessages = [];
   const window = loadModules(({ conversation, onUpdate, onReadyChange }) => ({

--- a/ui/public/acp-page.js
+++ b/ui/public/acp-page.js
@@ -123,14 +123,22 @@
     }
   }
 
+  function normalizeACPToastMessage(message) {
+    const raw = String(message || '').trim();
+    if (!raw) return '';
+    const htmlError = ACPRender.detectHtmlErrorDocument?.(raw);
+    return htmlError?.text || raw;
+  }
+
   function showACPToast(page, message, kind = 'error') {
-    if (!message) return;
+    const normalized = normalizeACPToastMessage(message);
+    if (!normalized) return;
     if (typeof page.deps.showToast === 'function') {
-      page.deps.showToast(message, kind);
+      page.deps.showToast(normalized, kind);
       return;
     }
     if (typeof page.deps.showNotice === 'function') {
-      page.deps.showNotice(message, kind);
+      page.deps.showNotice(normalized, kind);
     }
   }
 


### PR DESCRIPTION
## Summary
- make the Claude ACP adapter treat freshly created sessions as reconnectable before the first prompt
- sanitize raw HTML bootstrap failures before ACP chat shows them to the user
- add regressions for both behaviors

## Testing
- node --test images/examples/claude-code/acp-server.test.mjs
- node --test ui/public/acp-page-notice.test.mjs ui/public/acp-page-session-binding.test.mjs ui/public/acp-render.test.mjs
- node --check images/examples/claude-code/acp-server.mjs && node --check ui/public/acp-page.js
- git diff --check