### PR TITLE
fix(claude-code): keep probe sockets from stealing chats

### DIFF
--- a/images/examples/claude-code/acp-server.mjs
+++ b/images/examples/claude-code/acp-server.mjs
@@ -465,12 +465,19 @@ class ACPRuntime {
     this.socket = null;
   }
 
-  attach(socket) {
-    if (this.socket && this.socket.readyState === WEBSOCKET_OPEN) {
-      this.socket.close(1001, "ACP client replaced");
+  claimSocket(socket) {
+    if (this.socket === socket) {
+      return;
     }
-    this.ensureStarted();
+    const previousSocket = this.socket;
     this.socket = socket;
+    if (previousSocket?.readyState === WEBSOCKET_OPEN) {
+      previousSocket.close(1001, "ACP client replaced");
+    }
+  }
+
+  attach(socket) {
+    this.ensureStarted();
     socket.on("message", async (data) => {
       let payload = null;
       try {
@@ -486,6 +493,7 @@ class ACPRuntime {
         }
         if (payload.method === "session/new" && payload.id !== undefined) {
           await this.ensureInitialized();
+          this.claimSocket(socket);
           const result = await this.requestChild("session/new", payload.params);
           this.rememberSession(result, { replayable: false });
           this.sendRPCResponse(socket, payload.id, { result });
@@ -493,6 +501,7 @@ class ACPRuntime {
         }
         if (payload.method === "session/load" && payload.id !== undefined) {
           await this.ensureInitialized();
+          this.claimSocket(socket);
           const cached = this.cachedLoadResult(payload.params?.sessionId);
           if (cached) {
             this.sendRPCResponse(socket, payload.id, { result: cached });
@@ -505,12 +514,14 @@ class ACPRuntime {
         }
         if (payload.method === "session/prompt" && payload.id !== undefined) {
           await this.ensureInitialized();
+          this.claimSocket(socket);
           const result = await this.requestChild("session/prompt", payload.params);
           this.markSessionReplayable(payload.params?.sessionId);
           this.sendRPCResponse(socket, payload.id, { result });
           return;
         }
         await this.ensureInitialized();
+        this.claimSocket(socket);
         if (this.child?.stdin && !this.child.stdin.destroyed) {
           this.child.stdin.write(ensureLine(JSON.stringify(payload)));
         }

--- a/images/examples/claude-code/acp-server.test.mjs
+++ b/images/examples/claude-code/acp-server.test.mjs
@@ -373,7 +373,7 @@ test("session/load reuses a freshly created session before the first prompt", as
   secondSocket.close();
 });
 
-test("a new ACP client handoff replaces the previous attached socket", async (t) => {
+test("an initialize-only probe does not replace the active ACP client", async (t) => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "spritz-claude-code-runtime-"));
   const adapterPath = path.join(tempRoot, "mock-adapter.mjs");
   fs.writeFileSync(
@@ -385,6 +385,14 @@ test("a new ACP client handoff replaces the previous attached socket", async (t)
       "function handle(message) {",
       "  if (message.method === 'initialize') {",
       "    send({ id: message.id, jsonrpc: '2.0', result: { protocolVersion: 1, agentCapabilities: { loadSession: true, promptCapabilities: {} }, agentInfo: { name: 'mock', title: 'Mock', version: '1.0.0' } } });",
+      "    return;",
+      "  }",
+      "  if (message.method === 'session/new') {",
+      "    send({ id: message.id, jsonrpc: '2.0', result: { sessionId: 'session-1' } });",
+      "    return;",
+      "  }",
+      "  if (message.method === 'session/prompt') {",
+      "    send({ id: message.id, jsonrpc: '2.0', result: { stopReason: 'end_turn' } });",
       "    return;",
       "  }",
       "  send({ id: message.id, jsonrpc: '2.0', result: {} });",
@@ -426,21 +434,26 @@ test("a new ACP client handoff replaces the previous attached socket", async (t)
   const firstSocket = new FakeSocket();
   runtime.attach(firstSocket);
   await sendRuntimeRPC(firstSocket, { id: "init-1", jsonrpc: "2.0", method: "initialize", params: {} });
+  await sendRuntimeRPC(firstSocket, {
+    id: "new-1",
+    jsonrpc: "2.0",
+    method: "session/new",
+    params: { cwd: "/workspace", mcpServers: [] },
+  });
 
   const secondSocket = new FakeSocket();
   runtime.attach(secondSocket);
-
-  assert.equal(firstSocket.readyState, 3);
-  assert.equal(firstSocket.closeCode, 1001);
-  assert.equal(firstSocket.closeReason, "ACP client replaced");
-
-  const initResponse = await sendRuntimeRPC(secondSocket, {
+  const secondInit = await sendRuntimeRPC(secondSocket, {
     id: "init-2",
     jsonrpc: "2.0",
     method: "initialize",
     params: {},
   });
-  assert.deepEqual(initResponse, {
+
+  assert.equal(firstSocket.readyState, 1);
+  assert.equal(firstSocket.closeCode, null);
+  assert.equal(firstSocket.closeReason, null);
+  assert.deepEqual(secondInit, {
     id: "init-2",
     jsonrpc: "2.0",
     result: {
@@ -450,6 +463,101 @@ test("a new ACP client handoff replaces the previous attached socket", async (t)
       authMethods: [],
     },
   });
+
+  const promptResponse = await sendRuntimeRPC(firstSocket, {
+    id: "prompt-1",
+    jsonrpc: "2.0",
+    method: "session/prompt",
+    params: {
+      sessionId: "session-1",
+      prompt: [{ type: "text", text: "hello" }],
+    },
+  });
+  assert.deepEqual(promptResponse, {
+    id: "prompt-1",
+    jsonrpc: "2.0",
+    result: { stopReason: "end_turn" },
+  });
+});
+
+test("real session traffic hands the runtime off to the new ACP client", async (t) => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "spritz-claude-code-runtime-"));
+  const adapterPath = path.join(tempRoot, "mock-adapter.mjs");
+  fs.writeFileSync(
+    adapterPath,
+    [
+      "process.stdin.setEncoding('utf8');",
+      "let pending = '';",
+      "function send(message) { process.stdout.write(JSON.stringify(message) + '\\n'); }",
+      "function handle(message) {",
+      "  if (message.method === 'initialize') {",
+      "    send({ id: message.id, jsonrpc: '2.0', result: { protocolVersion: 1, agentCapabilities: { loadSession: true, promptCapabilities: {} }, agentInfo: { name: 'mock', title: 'Mock', version: '1.0.0' } } });",
+      "    return;",
+      "  }",
+      "  if (message.method === 'session/new') {",
+      "    send({ id: message.id, jsonrpc: '2.0', result: { sessionId: 'session-1' } });",
+      "    return;",
+      "  }",
+      "  send({ id: message.id, jsonrpc: '2.0', result: {} });",
+      "}",
+      "process.stdin.on('data', (chunk) => {",
+      "  pending += chunk;",
+      "  let newline = pending.indexOf('\\n');",
+      "  while (newline !== -1) {",
+      "    const line = pending.slice(0, newline).trim();",
+      "    pending = pending.slice(newline + 1);",
+      "    if (line) { handle(JSON.parse(line)); }",
+      "    newline = pending.indexOf('\\n');",
+      "  }",
+      "});",
+    ].join("\n"),
+  );
+  const runtime = new ACPRuntime(
+    {
+      adapterBin: "node",
+      adapterArgs: [adapterPath],
+      workdir: tempRoot,
+      metadata: {
+        protocolVersion: 1,
+        agentCapabilities: { loadSession: true, promptCapabilities: {} },
+        agentInfo: { name: "mock", title: "Mock", version: "1.0.0" },
+        authMethods: [],
+      },
+    },
+    {
+      ...process.env,
+      ANTHROPIC_API_KEY: "test-key",
+    },
+    console,
+  );
+  t.after(() => {
+    runtime.stop();
+  });
+
+  const firstSocket = new FakeSocket();
+  runtime.attach(firstSocket);
+  await sendRuntimeRPC(firstSocket, { id: "init-1", jsonrpc: "2.0", method: "initialize", params: {} });
+  await sendRuntimeRPC(firstSocket, {
+    id: "new-1",
+    jsonrpc: "2.0",
+    method: "session/new",
+    params: { cwd: "/workspace", mcpServers: [] },
+  });
+
+  const secondSocket = new FakeSocket();
+  runtime.attach(secondSocket);
+  await sendRuntimeRPC(secondSocket, { id: "init-2", jsonrpc: "2.0", method: "initialize", params: {} });
+  await sendRuntimeRPC(secondSocket, {
+    id: "new-2",
+    jsonrpc: "2.0",
+    method: "session/new",
+    params: { cwd: "/workspace", mcpServers: [] },
+  });
+
+  assert.equal(firstSocket.readyState, 3);
+  assert.equal(firstSocket.closeCode, 1001);
+  assert.equal(firstSocket.closeReason, "ACP client replaced");
+  assert.equal(secondSocket.readyState, 1);
 });
 
 test("initialize preserves adapter-negotiated auth methods across reconnects", async (t) => {


### PR DESCRIPTION
## Summary
- keep initialize-only Claude ACP sockets from replacing the active chat connection
- hand the runtime off only when a new socket starts real session traffic
- add regressions for probe sockets and real client handoff

## Testing
- node --test /Users/onur/repos/spritz/images/examples/claude-code/acp-server.test.mjs /Users/onur/repos/spritz/images/examples/claude-code/image-contract.test.mjs
- node --check /Users/onur/repos/spritz/images/examples/claude-code/acp-server.mjs
- git diff --check
