### PR TITLE
feat(api): prefix generated spritz names by image

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -190,6 +190,7 @@ func (s *server) registerRoutes(e *echo.Echo) {
 	internal.PUT("/shared-mounts/owner/:owner/:mount/latest", s.putSharedMountLatest)
 	secured := group.Group("", s.authMiddleware())
 	secured.GET("/spritzes", s.listSpritzes)
+	secured.POST("/spritzes/suggest-name", s.suggestSpritzName)
 	secured.POST("/spritzes", s.createSpritz)
 	secured.GET("/spritzes/:name", s.getSpritz)
 	secured.DELETE("/spritzes/:name", s.deleteSpritz)
@@ -214,11 +215,59 @@ func (s *server) handleHealthz(c echo.Context) error {
 
 type createRequest struct {
 	Name        string              `json:"name"`
+	NamePrefix  string              `json:"namePrefix,omitempty"`
 	Namespace   string              `json:"namespace,omitempty"`
 	Spec        spritzv1.SpritzSpec `json:"spec"`
 	UserConfig  json.RawMessage     `json:"userConfig,omitempty"`
 	Labels      map[string]string   `json:"labels,omitempty"`
 	Annotations map[string]string   `json:"annotations,omitempty"`
+}
+
+type suggestNameRequest struct {
+	Namespace  string `json:"namespace,omitempty"`
+	Image      string `json:"image,omitempty"`
+	NamePrefix string `json:"namePrefix,omitempty"`
+}
+
+func (s *server) resolveSpritzNamespace(requested string) (string, error) {
+	namespace := requested
+	if s.namespace != "" {
+		if namespace != "" && namespace != s.namespace {
+			return "", fmt.Errorf("namespace mismatch")
+		}
+		namespace = s.namespace
+	}
+	if namespace == "" {
+		namespace = "default"
+	}
+	return namespace, nil
+}
+
+func (s *server) suggestSpritzName(c echo.Context) error {
+	principal, ok := principalFromContext(c)
+	if s.auth.enabled() && (!ok || principal.ID == "") {
+		return writeError(c, http.StatusUnauthorized, "unauthenticated")
+	}
+
+	var body suggestNameRequest
+	if err := c.Bind(&body); err != nil {
+		return writeError(c, http.StatusBadRequest, "invalid json")
+	}
+	body.Image = strings.TrimSpace(body.Image)
+	if body.Image == "" {
+		return writeError(c, http.StatusBadRequest, "image is required")
+	}
+
+	namespace, err := s.resolveSpritzNamespace(body.Namespace)
+	if err != nil {
+		return writeError(c, http.StatusForbidden, err.Error())
+	}
+	namePrefix := resolveSpritzNamePrefix(body.NamePrefix, body.Image)
+	generator, err := s.newSpritzNameGenerator(c.Request().Context(), namespace, namePrefix)
+	if err != nil {
+		return writeError(c, http.StatusInternalServerError, "failed to generate spritz name")
+	}
+	return writeJSON(c, http.StatusOK, map[string]string{"name": generator()})
 }
 
 func (s *server) createSpritz(c echo.Context) error {
@@ -270,21 +319,16 @@ func (s *server) createSpritz(c echo.Context) error {
 		body.Spec.SharedMounts = normalized
 	}
 
-	namespace := body.Namespace
-	if s.namespace != "" {
-		if namespace != "" && namespace != s.namespace {
-			return writeError(c, http.StatusForbidden, "namespace mismatch")
-		}
-		namespace = s.namespace
-	}
-	if namespace == "" {
-		namespace = "default"
+	namespace, err := s.resolveSpritzNamespace(body.Namespace)
+	if err != nil {
+		return writeError(c, http.StatusForbidden, err.Error())
 	}
 
 	nameProvided := body.Name != ""
 	var nameGenerator func() string
 	if !nameProvided {
-		generator, err := s.newSpritzNameGenerator(c.Request().Context(), namespace)
+		namePrefix := resolveSpritzNamePrefix(body.NamePrefix, body.Spec.Image)
+		generator, err := s.newSpritzNameGenerator(c.Request().Context(), namespace, namePrefix)
 		if err != nil {
 			return writeError(c, http.StatusInternalServerError, "failed to generate spritz name")
 		}

--- a/api/main_create_owner_test.go
+++ b/api/main_create_owner_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/labstack/echo/v4"
@@ -99,5 +100,75 @@ func TestCreateSpritzRejectsOwnerIDMismatchForNonAdmin(t *testing.T) {
 
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("expected status 403, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestSuggestSpritzNameUsesPrefixFromRequest(t *testing.T) {
+	s := newCreateSpritzTestServer(t)
+	e := echo.New()
+	secured := e.Group("", s.authMiddleware())
+	secured.POST("/api/spritzes/suggest-name", s.suggestSpritzName)
+
+	body := []byte(`{"image":"example.com/spritz-openclaw:latest","namePrefix":"openclaw"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/spritzes/suggest-name", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	req.Header.Set("X-Spritz-User-Id", "user-1")
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to decode response json: %v", err)
+	}
+	data, ok := payload["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected data object in response, got %#v", payload["data"])
+	}
+	name, _ := data["name"].(string)
+	if name == "" {
+		t.Fatal("expected generated name")
+	}
+	if !strings.HasPrefix(name, "openclaw-") {
+		t.Fatalf("expected name prefix %q, got %q", "openclaw-", name)
+	}
+}
+
+func TestCreateSpritzGeneratesPrefixedNameFromImage(t *testing.T) {
+	s := newCreateSpritzTestServer(t)
+	e := echo.New()
+	secured := e.Group("", s.authMiddleware())
+	secured.POST("/api/spritzes", s.createSpritz)
+
+	body := []byte(`{"spec":{"image":"example.com/spritz-claude-code:latest"}}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/spritzes", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	req.Header.Set("X-Spritz-User-Id", "user-1")
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to decode response json: %v", err)
+	}
+	data, ok := payload["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected data object in response, got %#v", payload["data"])
+	}
+	name, _ := data["metadata"].(map[string]any)["name"].(string)
+	if name == "" {
+		t.Fatal("expected generated metadata.name")
+	}
+	if !strings.HasPrefix(name, "claude-code-") {
+		t.Fatalf("expected generated name to start with %q, got %q", "claude-code-", name)
 	}
 }

--- a/api/random_name.go
+++ b/api/random_name.go
@@ -135,6 +135,60 @@ func randomIndex(max int) int {
 	return int(n.Int64())
 }
 
+func sanitizeSpritzNameToken(value string) string {
+	raw := strings.ToLower(strings.TrimSpace(value))
+	if raw == "" {
+		return ""
+	}
+	var out strings.Builder
+	lastDash := false
+	for _, r := range raw {
+		switch {
+		case r >= 'a' && r <= 'z':
+			out.WriteRune(r)
+			lastDash = false
+		case r >= '0' && r <= '9':
+			out.WriteRune(r)
+			lastDash = false
+		default:
+			if out.Len() == 0 || lastDash {
+				continue
+			}
+			out.WriteByte('-')
+			lastDash = true
+		}
+	}
+	return strings.Trim(out.String(), "-")
+}
+
+func deriveSpritzNamePrefixFromImage(image string) string {
+	raw := strings.TrimSpace(image)
+	if raw == "" {
+		return ""
+	}
+	if idx := strings.LastIndex(raw, "/"); idx >= 0 {
+		raw = raw[idx+1:]
+	}
+	if idx := strings.Index(raw, "@"); idx >= 0 {
+		raw = raw[:idx]
+	}
+	if idx := strings.Index(raw, ":"); idx >= 0 {
+		raw = raw[:idx]
+	}
+	prefix := sanitizeSpritzNameToken(raw)
+	if trimmed := strings.TrimPrefix(prefix, "spritz-"); trimmed != "" && trimmed != prefix {
+		return trimmed
+	}
+	return prefix
+}
+
+func resolveSpritzNamePrefix(explicit, image string) string {
+	if prefix := sanitizeSpritzNameToken(explicit); prefix != "" {
+		return prefix
+	}
+	return deriveSpritzNamePrefixFromImage(image)
+}
+
 func createSpritzNameBase(words int) string {
 	parts := []string{
 		randomChoice(spritzNameAdjectives, "steady"),
@@ -146,19 +200,61 @@ func createSpritzNameBase(words int) string {
 	return strings.Join(parts, "-")
 }
 
-func createRandomSpritzName(isTaken func(string) bool) string {
+func joinSpritzName(prefix, base, suffix string) string {
+	tailParts := []string{}
+	if base != "" {
+		tailParts = append(tailParts, sanitizeSpritzNameToken(base))
+	}
+	if suffix != "" {
+		tailParts = append(tailParts, sanitizeSpritzNameToken(suffix))
+	}
+	tail := strings.Trim(strings.Join(tailParts, "-"), "-")
+	if tail == "" {
+		tail = "spritz"
+	}
+	prefix = sanitizeSpritzNameToken(prefix)
+	if prefix == "" {
+		if len(tail) <= 63 {
+			return tail
+		}
+		return strings.Trim(tail[:63], "-")
+	}
+	if len(prefix)+1+len(tail) <= 63 {
+		return prefix + "-" + tail
+	}
+	maxPrefixLen := 63 - 1 - len(tail)
+	if maxPrefixLen <= 0 {
+		if len(tail) <= 63 {
+			return tail
+		}
+		return strings.Trim(tail[:63], "-")
+	}
+	if len(prefix) > maxPrefixLen {
+		prefix = strings.Trim(prefix[:maxPrefixLen], "-")
+	}
+	if prefix == "" {
+		if len(tail) <= 63 {
+			return tail
+		}
+		return strings.Trim(tail[:63], "-")
+	}
+	return prefix + "-" + tail
+}
+
+func createRandomSpritzName(prefix string, isTaken func(string) bool) string {
 	used := isTaken
 	if used == nil {
 		used = func(string) bool { return false }
 	}
 
 	for attempt := 0; attempt < 12; attempt++ {
-		base := createSpritzNameBase(2)
+		nameBase := createSpritzNameBase(2)
+		base := joinSpritzName(prefix, nameBase, "")
 		if !used(base) {
 			return base
 		}
 		for i := 2; i <= 12; i++ {
-			candidate := base + "-" + strconv.Itoa(i)
+			candidate := joinSpritzName(prefix, nameBase, strconv.Itoa(i))
 			if !used(candidate) {
 				return candidate
 			}
@@ -166,21 +262,23 @@ func createRandomSpritzName(isTaken func(string) bool) string {
 	}
 
 	for attempt := 0; attempt < 12; attempt++ {
-		base := createSpritzNameBase(3)
+		nameBase := createSpritzNameBase(3)
+		base := joinSpritzName(prefix, nameBase, "")
 		if !used(base) {
 			return base
 		}
 		for i := 2; i <= 12; i++ {
-			candidate := base + "-" + strconv.Itoa(i)
+			candidate := joinSpritzName(prefix, nameBase, strconv.Itoa(i))
 			if !used(candidate) {
 				return candidate
 			}
 		}
 	}
 
-	fallback := createSpritzNameBase(3) + "-" + randomSuffix(3)
+	nameBase := createSpritzNameBase(3)
+	fallback := joinSpritzName(prefix, nameBase, randomSuffix(3))
 	if used(fallback) {
-		return fallback + "-" + randomSuffix(4)
+		return joinSpritzName(prefix, nameBase, randomSuffix(4))
 	}
 	return fallback
 }
@@ -197,7 +295,7 @@ func randomSuffix(length int) string {
 	return out.String()
 }
 
-func (s *server) newSpritzNameGenerator(ctx context.Context, namespace string) (func() string, error) {
+func (s *server) newSpritzNameGenerator(ctx context.Context, namespace string, prefix string) (func() string, error) {
 	list := &spritzv1.SpritzList{}
 	opts := []client.ListOption{client.InNamespace(namespace)}
 	if err := s.client.List(ctx, list, opts...); err != nil {
@@ -210,7 +308,7 @@ func (s *server) newSpritzNameGenerator(ctx context.Context, namespace string) (
 		}
 	}
 	return func() string {
-		name := createRandomSpritzName(func(candidate string) bool {
+		name := createRandomSpritzName(prefix, func(candidate string) bool {
 			_, ok := existing[candidate]
 			return ok
 		})

--- a/api/random_name_test.go
+++ b/api/random_name_test.go
@@ -2,16 +2,48 @@ package main
 
 import (
 	"regexp"
+	"strings"
 	"testing"
 )
 
 func TestCreateRandomSpritzNameFormat(t *testing.T) {
-	name := createRandomSpritzName(nil)
+	name := createRandomSpritzName("", nil)
 	if name == "" {
 		t.Fatal("expected non-empty name")
 	}
 	pattern := regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
 	if !pattern.MatchString(name) {
 		t.Fatalf("name %q did not match expected format", name)
+	}
+}
+
+func TestCreateRandomSpritzNamePrefixesDerivedImageName(t *testing.T) {
+	name := createRandomSpritzName(resolveSpritzNamePrefix("", "registry.example.com/spritz-openclaw:staging"), nil)
+	if !strings.HasPrefix(name, "openclaw-") {
+		t.Fatalf("expected openclaw prefix, got %q", name)
+	}
+}
+
+func TestResolveSpritzNamePrefixPrefersExplicitValue(t *testing.T) {
+	got := resolveSpritzNamePrefix("Claude Code", "registry.example.com/spritz-openclaw:staging")
+	if got != "claude-code" {
+		t.Fatalf("expected explicit prefix to win, got %q", got)
+	}
+}
+
+func TestResolveSpritzNamePrefixDerivesFromImageAndStripsSpritzPrefix(t *testing.T) {
+	got := resolveSpritzNamePrefix("", "registry.example.com/spritz-claude-code:staging")
+	if got != "claude-code" {
+		t.Fatalf("expected claude-code, got %q", got)
+	}
+}
+
+func TestJoinSpritzNamePreservesTailWhenPrefixIsLong(t *testing.T) {
+	name := joinSpritzName("this-prefix-is-way-too-long-for-a-single-kubernetes-resource-name", "tidal-otter", "12")
+	if len(name) > 63 {
+		t.Fatalf("expected name length <= 63, got %d for %q", len(name), name)
+	}
+	if !strings.HasSuffix(name, "-tidal-otter-12") {
+		t.Fatalf("expected tail to be preserved, got %q", name)
 	}
 }

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -42,12 +42,12 @@ let activeTerminalName = '';
 let activeACPPage = null;
 let presetController = null;
 let activePresetEnv = null;
+let activePreset = null;
 const authRedirectStorageKey = 'spritz-auth-redirected';
 let authRefreshInFlight = null;
 let authRefreshAttemptId = 0;
 let lastAuthRefreshAt = 0;
 let activeTerminalPoll = null;
-let knownSpritzNames = new Set();
 const presetPlaceholder = '__SPRITZ_UI_PRESETS__';
 const ACP_CLIENT_INFO = {
   name: 'spritz-ui',
@@ -73,108 +73,6 @@ const defaultPresets = [
   },
 ];
 
-const NAME_ADJECTIVES = [
-  'amber',
-  'briny',
-  'brisk',
-  'calm',
-  'clear',
-  'cool',
-  'crisp',
-  'dawn',
-  'delta',
-  'ember',
-  'faint',
-  'fast',
-  'fresh',
-  'gentle',
-  'glow',
-  'good',
-  'grand',
-  'keen',
-  'kind',
-  'lucky',
-  'marine',
-  'mellow',
-  'mild',
-  'neat',
-  'nimble',
-  'nova',
-  'oceanic',
-  'plaid',
-  'quick',
-  'quiet',
-  'rapid',
-  'salty',
-  'sharp',
-  'swift',
-  'tender',
-  'tidal',
-  'tidy',
-  'tide',
-  'vivid',
-  'warm',
-  'wild',
-  'young',
-];
-
-const NAME_NOUNS = [
-  'atlas',
-  'basil',
-  'bison',
-  'bloom',
-  'breeze',
-  'canyon',
-  'cedar',
-  'claw',
-  'cloud',
-  'comet',
-  'coral',
-  'cove',
-  'crest',
-  'crustacean',
-  'daisy',
-  'dune',
-  'ember',
-  'falcon',
-  'fjord',
-  'forest',
-  'glade',
-  'gulf',
-  'harbor',
-  'haven',
-  'kelp',
-  'lagoon',
-  'lobster',
-  'meadow',
-  'mist',
-  'nudibranch',
-  'nexus',
-  'ocean',
-  'orbit',
-  'otter',
-  'pine',
-  'prairie',
-  'reef',
-  'ridge',
-  'river',
-  'rook',
-  'sable',
-  'sage',
-  'seaslug',
-  'shell',
-  'shoal',
-  'shore',
-  'slug',
-  'summit',
-  'tidepool',
-  'trail',
-  'valley',
-  'wharf',
-  'willow',
-  'zephyr',
-];
-
 function parseBoolean(value, fallback) {
   if (value === undefined || value === null || value === '') return fallback;
   if (typeof value === 'boolean') return value;
@@ -188,48 +86,6 @@ function parseNumber(value, fallback) {
   if (value === undefined || value === null || value === '') return fallback;
   const parsed = Number(value);
   return Number.isNaN(parsed) ? fallback : parsed;
-}
-
-function randomChoice(values, fallback) {
-  return values[Math.floor(Math.random() * values.length)] ?? fallback;
-}
-
-function createNameBase(words = 2) {
-  const parts = [randomChoice(NAME_ADJECTIVES, 'steady'), randomChoice(NAME_NOUNS, 'harbor')];
-  if (words > 2) {
-    parts.push(randomChoice(NAME_NOUNS, 'reef'));
-  }
-  return parts.join('-');
-}
-
-function createRandomName(isTaken) {
-  const isIdTaken = typeof isTaken === 'function' ? isTaken : () => false;
-  for (let attempt = 0; attempt < 12; attempt += 1) {
-    const base = createNameBase(2);
-    if (!isIdTaken(base)) {
-      return base;
-    }
-    for (let i = 2; i <= 12; i += 1) {
-      const candidate = `${base}-${i}`;
-      if (!isIdTaken(candidate)) {
-        return candidate;
-      }
-    }
-  }
-  for (let attempt = 0; attempt < 12; attempt += 1) {
-    const base = createNameBase(3);
-    if (!isIdTaken(base)) {
-      return base;
-    }
-    for (let i = 2; i <= 12; i += 1) {
-      const candidate = `${base}-${i}`;
-      if (!isIdTaken(candidate)) {
-        return candidate;
-      }
-    }
-  }
-  const fallback = `${createNameBase(3)}-${Math.random().toString(36).slice(2, 5)}`;
-  return isIdTaken(fallback) ? `${fallback}-${Date.now().toString(36)}` : fallback;
 }
 
 function parseYamlScalar(value) {
@@ -514,18 +370,6 @@ function applyUserConfigDefaults() {
   if (!textarea.value.trim()) {
     textarea.value = defaultUserConfigYaml;
   }
-}
-
-function updateKnownSpritzNames(items) {
-  knownSpritzNames = new Set(
-    (items || [])
-      .map((item) => item?.metadata?.name)
-      .filter((name) => typeof name === 'string' && name.trim() !== ''),
-  );
-}
-
-function generateSpritzName() {
-  return createRandomName((candidate) => knownSpritzNames.has(candidate));
 }
 
 function applyNameDefaults() {
@@ -922,6 +766,44 @@ async function request(path, options = {}) {
   return text ? text : null;
 }
 
+function imagesMatch(left, right) {
+  return String(left || '').trim() === String(right || '').trim();
+}
+
+function resolveRequestedNamePrefix(imageValue) {
+  if (!activePreset || !imagesMatch(imageValue, activePreset.image)) {
+    return '';
+  }
+  return String(activePreset.namePrefix || '').trim();
+}
+
+async function suggestSpritzName() {
+  if (!form) {
+    throw new Error('Create form unavailable.');
+  }
+  const imageInput = form.querySelector('input[name="image"]');
+  const namespaceInput = form.querySelector('input[name="namespace"]');
+  const image = String(imageInput?.value || '').trim();
+  if (!image) {
+    throw new Error('Image is required before generating a name.');
+  }
+  const payload = { image };
+  const namespace = String(namespaceInput?.value || '').trim();
+  if (namespace) {
+    payload.namespace = namespace;
+  }
+  const namePrefix = resolveRequestedNamePrefix(image);
+  if (namePrefix) {
+    payload.namePrefix = namePrefix;
+  }
+  const data = await request('/spritzes/suggest-name', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  return String(data?.name || '').trim();
+}
+
 async function fetchSpritzes() {
   try {
     const data = await request('/spritzes');
@@ -985,7 +867,6 @@ function buildOpenUrl(rawUrl, spritz) {
 }
 
 function renderList(items) {
-  updateKnownSpritzNames(items);
   if (!items.length) {
     listEl.innerHTML = '<p>No spritzes yet.</p>';
     return;
@@ -1424,6 +1305,9 @@ function setupPresets() {
     setActivePresetEnv(env) {
       activePresetEnv = env;
     },
+    setActivePreset(preset) {
+      activePreset = preset;
+    },
   });
 }
 
@@ -1454,10 +1338,18 @@ window.addEventListener('hashchange', handleRoute);
 
 if (form && refreshBtn) {
   if (randomNameBtn) {
-    randomNameBtn.addEventListener('click', () => {
+    randomNameBtn.addEventListener('click', async () => {
       const input = form.querySelector('input[name="name"]');
       if (!input) return;
-      input.value = generateSpritzName();
+      randomNameBtn.disabled = true;
+      try {
+        input.value = await suggestSpritzName();
+        showNotice('');
+      } catch (err) {
+        showNotice(err.message || 'Failed to generate a name.');
+      } finally {
+        randomNameBtn.disabled = false;
+      }
     });
   }
 
@@ -1467,15 +1359,21 @@ if (form && refreshBtn) {
     const name = data.get('name');
     const image = data.get('image');
     const rawName = (name || '').toString().trim();
+    const imageValue = (image || '').toString().trim();
 
     const payload = {
       namespace: data.get('namespace') || undefined,
       spec: {
-        image,
+        image: imageValue,
       },
     };
     if (rawName) {
       payload.name = rawName;
+    } else {
+      const namePrefix = resolveRequestedNamePrefix(imageValue);
+      if (namePrefix) {
+        payload.namePrefix = namePrefix;
+      }
     }
 
     if (config.ownerId) {

--- a/ui/public/preset-panel.js
+++ b/ui/public/preset-panel.js
@@ -14,6 +14,7 @@
       applyRepoDefaults,
       normalizePresetEnv,
       setActivePresetEnv,
+      setActivePreset,
     } = options || {};
 
     if (!document || !form || !Array.isArray(presets) || presets.length === 0) {
@@ -28,6 +29,7 @@
           const help = form.querySelector('.preset-help');
           if (help) help.textContent = '';
           setActivePresetEnv(null);
+          if (typeof setActivePreset === 'function') setActivePreset(null);
         },
       };
     }
@@ -82,12 +84,14 @@
       if (ttlInput && preset.ttl !== undefined) ttlInput.value = preset.ttl || '';
       help.textContent = preset.description || '';
       setActivePresetEnv(typeof normalizePresetEnv === 'function' ? normalizePresetEnv(preset.env) : null);
+      if (typeof setActivePreset === 'function') setActivePreset(preset);
     };
 
     const reset = () => {
       select.value = '';
       help.textContent = '';
       setActivePresetEnv(null);
+      if (typeof setActivePreset === 'function') setActivePreset(null);
     };
 
     select.addEventListener('change', () => {

--- a/ui/public/preset-panel.test.mjs
+++ b/ui/public/preset-panel.test.mjs
@@ -152,6 +152,7 @@ test('setupPresetPanel injects the preset selector and updates image fields', as
 
   const { document, form, imageInput, repoInput, branchInput, ttlInput } = buildFormFixture();
   let activeEnv = null;
+  let activePreset = null;
   let repoDefaultsApplied = 0;
   const presets = [
     {
@@ -188,6 +189,9 @@ test('setupPresetPanel injects the preset selector and updates image fields', as
     setActivePresetEnv(env) {
       activeEnv = env;
     },
+    setActivePreset(preset) {
+      activePreset = preset;
+    },
   });
 
   assert.ok(controller, 'expected a preset controller');
@@ -200,6 +204,7 @@ test('setupPresetPanel injects the preset selector and updates image fields', as
   assert.equal(branchInput.value, 'main');
   assert.equal(ttlInput.value, '8h');
   assert.deepEqual(activeEnv, [{ name: 'FOO', value: 'bar' }]);
+  assert.equal(activePreset?.name, 'Starter Devbox');
   assert.equal(form.querySelector('.preset-help').textContent, 'Starter image');
 
   presetSelect.value = '1';
@@ -210,10 +215,12 @@ test('setupPresetPanel injects the preset selector and updates image fields', as
   assert.equal(branchInput.value, 'staging');
   assert.equal(ttlInput.value, '12h');
   assert.deepEqual(activeEnv, [{ name: 'BAZ', value: 'qux' }]);
+  assert.equal(activePreset?.name, 'OpenClaw Devbox');
   assert.equal(form.querySelector('.preset-help').textContent, 'OpenClaw image');
 
   controller.reset();
   assert.equal(presetSelect.value, '');
   assert.equal(form.querySelector('.preset-help').textContent, '');
   assert.equal(activeEnv, null);
+  assert.equal(activePreset, null);
 });


### PR DESCRIPTION
This makes backend name generation prefix auto-generated spritz names with the selected image slug, so names like openclaw-tide-wind and claude-code-tender-otter come from one canonical path.

The UI no longer invents names locally; both the random-name button and create flow now use the backend suggestion logic, with tests covering prefix derivation and preset state wiring.