### PR TITLE
fix(ui): persist create form preset state

### DIFF
--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -48,6 +48,7 @@ let authRefreshInFlight = null;
 let authRefreshAttemptId = 0;
 let lastAuthRefreshAt = 0;
 let activeTerminalPoll = null;
+const createFormStateModule = window.SpritzCreateFormState || null;
 const presetPlaceholder = '__SPRITZ_UI_PRESETS__';
 const ACP_CLIENT_INFO = {
   name: 'spritz-ui',
@@ -338,6 +339,60 @@ const defaultUserConfigYaml = `sharedMounts:
     mode: snapshot
     syncMode: poll
     pollSeconds: 30`;
+
+function getCreateFormStorage() {
+  return window.localStorage || null;
+}
+
+function getCreateFormField(name) {
+  if (!form) return null;
+  return form.querySelector(`input[name="${name}"]`) || form.querySelector(`textarea[name="${name}"]`) || null;
+}
+
+function buildCreateFormStateSnapshot() {
+  if (!createFormStateModule || !form) return null;
+  return createFormStateModule.buildCreateFormState({
+    activePreset,
+    image: getCreateFormField('image')?.value || '',
+    repo: getCreateFormField('repo')?.value || '',
+    branch: getCreateFormField('branch')?.value || '',
+    ttl: getCreateFormField('ttl')?.value || '',
+    namespace: getCreateFormField('namespace')?.value || '',
+    userConfig: getCreateFormField('user_config')?.value || '',
+  });
+}
+
+function persistCreateFormState() {
+  if (!createFormStateModule) return;
+  createFormStateModule.writeCreateFormState(getCreateFormStorage(), buildCreateFormStateSnapshot());
+}
+
+function applyPersistedCreateFormState(state) {
+  if (!state || !form) return false;
+  if (presetController && typeof presetController.restoreSelection === 'function') {
+    presetController.restoreSelection(state.selection);
+  }
+  const fields = state.fields || {};
+  const imageInput = getCreateFormField('image');
+  const repoInput = getCreateFormField('repo');
+  const branchInput = getCreateFormField('branch');
+  const ttlInput = getCreateFormField('ttl');
+  const namespaceInput = getCreateFormField('namespace');
+  const userConfigInput = getCreateFormField('user_config');
+  if (imageInput) imageInput.value = fields.image || '';
+  if (repoInput) repoInput.value = fields.repo || '';
+  if (branchInput) branchInput.value = fields.branch || '';
+  if (ttlInput) ttlInput.value = fields.ttl || '';
+  if (namespaceInput) namespaceInput.value = fields.namespace || '';
+  if (userConfigInput) userConfigInput.value = fields.userConfig || '';
+  return true;
+}
+
+function restoreCreateFormState() {
+  if (!createFormStateModule) return false;
+  const state = createFormStateModule.readCreateFormState(getCreateFormStorage());
+  return applyPersistedCreateFormState(state);
+}
 
 function normalizePresetEnv(env) {
   if (!env) return null;
@@ -1330,6 +1385,7 @@ function handleRoute() {
       applyRepoDefaults();
       applyUserConfigDefaults();
       setupPresets();
+      restoreCreateFormState();
       fetchSpritzes();
     }
   }
@@ -1337,6 +1393,12 @@ function handleRoute() {
 window.addEventListener('hashchange', handleRoute);
 
 if (form && refreshBtn) {
+  const persistCreateFormStateFromEvent = () => {
+    persistCreateFormState();
+  };
+  form.addEventListener('input', persistCreateFormStateFromEvent);
+  form.addEventListener('change', persistCreateFormStateFromEvent);
+
   if (randomNameBtn) {
     randomNameBtn.addEventListener('click', async () => {
       const input = form.querySelector('input[name="name"]');
@@ -1414,12 +1476,11 @@ if (form && refreshBtn) {
         body: JSON.stringify(payload),
       });
 
-      form.reset();
-      activePresetEnv = null;
-      if (presetController) presetController.reset();
-      applyNameDefaults();
-      applyRepoDefaults();
-      applyUserConfigDefaults();
+      const nameInput = getCreateFormField('name');
+      if (nameInput) {
+        nameInput.value = '';
+      }
+      persistCreateFormState();
       await fetchSpritzes();
       showNotice('');
     } catch (err) {

--- a/ui/public/create-form-state.js
+++ b/ui/public/create-form-state.js
@@ -1,0 +1,133 @@
+(function (root, factory) {
+  const exports = factory();
+  if (typeof module === 'object' && module.exports) {
+    module.exports = exports;
+  }
+  root.SpritzCreateFormState = exports;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+  const CREATE_FORM_STORAGE_KEY = 'spritz:create-form';
+
+  function normalizeString(value) {
+    if (value === undefined || value === null) return '';
+    return String(value);
+  }
+
+  function trimString(value) {
+    return normalizeString(value).trim();
+  }
+
+  function imagesMatch(left, right) {
+    return trimString(left) === trimString(right);
+  }
+
+  function deriveCreateFormSelection(activePreset, imageValue) {
+    if (!activePreset || !imagesMatch(imageValue, activePreset.image)) {
+      return { mode: 'custom' };
+    }
+    return {
+      mode: 'preset',
+      presetName: trimString(activePreset.name),
+      presetImage: trimString(activePreset.image),
+    };
+  }
+
+  function hasMeaningfulState(state) {
+    if (!state || typeof state !== 'object') return false;
+    if (state.selection?.mode === 'preset') return true;
+    const fields = state.fields;
+    if (!fields || typeof fields !== 'object') return false;
+    return ['image', 'repo', 'branch', 'ttl', 'namespace', 'userConfig']
+      .some((key) => trimString(fields[key]) !== '');
+  }
+
+  function sanitizeSelection(raw) {
+    if (!raw || typeof raw !== 'object') {
+      return { mode: 'custom' };
+    }
+    if (raw.mode !== 'preset') {
+      return { mode: 'custom' };
+    }
+    return {
+      mode: 'preset',
+      presetName: trimString(raw.presetName),
+      presetImage: trimString(raw.presetImage),
+    };
+  }
+
+  function sanitizeFields(raw) {
+    const input = raw && typeof raw === 'object' ? raw : {};
+    return {
+      image: normalizeString(input.image),
+      repo: normalizeString(input.repo),
+      branch: normalizeString(input.branch),
+      ttl: normalizeString(input.ttl),
+      namespace: normalizeString(input.namespace),
+      userConfig: normalizeString(input.userConfig),
+    };
+  }
+
+  function sanitizeCreateFormState(raw) {
+    if (!raw || typeof raw !== 'object') return null;
+    const state = {
+      selection: sanitizeSelection(raw.selection),
+      fields: sanitizeFields(raw.fields),
+    };
+    return hasMeaningfulState(state) ? state : null;
+  }
+
+  function buildCreateFormState(values) {
+    const input = values && typeof values === 'object' ? values : {};
+    return sanitizeCreateFormState({
+      selection: deriveCreateFormSelection(input.activePreset, input.image),
+      fields: {
+        image: input.image,
+        repo: input.repo,
+        branch: input.branch,
+        ttl: input.ttl,
+        namespace: input.namespace,
+        userConfig: input.userConfig,
+      },
+    });
+  }
+
+  function readCreateFormState(storage) {
+    if (!storage || typeof storage.getItem !== 'function') return null;
+    const raw = storage.getItem(CREATE_FORM_STORAGE_KEY);
+    if (!raw) return null;
+    try {
+      return sanitizeCreateFormState(JSON.parse(raw));
+    } catch {
+      if (typeof storage.removeItem === 'function') {
+        storage.removeItem(CREATE_FORM_STORAGE_KEY);
+      }
+      return null;
+    }
+  }
+
+  function writeCreateFormState(storage, state) {
+    if (!storage || typeof storage.setItem !== 'function') return null;
+    const sanitized = sanitizeCreateFormState(state);
+    if (!sanitized) {
+      if (typeof storage.removeItem === 'function') {
+        storage.removeItem(CREATE_FORM_STORAGE_KEY);
+      }
+      return null;
+    }
+    storage.setItem(CREATE_FORM_STORAGE_KEY, JSON.stringify(sanitized));
+    return sanitized;
+  }
+
+  function clearCreateFormState(storage) {
+    if (!storage || typeof storage.removeItem !== 'function') return;
+    storage.removeItem(CREATE_FORM_STORAGE_KEY);
+  }
+
+  return {
+    CREATE_FORM_STORAGE_KEY,
+    buildCreateFormState,
+    clearCreateFormState,
+    deriveCreateFormSelection,
+    readCreateFormState,
+    writeCreateFormState,
+  };
+});

--- a/ui/public/create-form-state.test.mjs
+++ b/ui/public/create-form-state.test.mjs
@@ -1,0 +1,72 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+function createStorage(seed = {}) {
+  const values = new Map(Object.entries(seed).map(([key, value]) => [key, String(value)]));
+  return {
+    getItem(key) {
+      return values.has(key) ? values.get(key) : null;
+    },
+    setItem(key, value) {
+      values.set(key, String(value));
+    },
+    removeItem(key) {
+      values.delete(key);
+    },
+    dump() {
+      return Object.fromEntries(values.entries());
+    },
+  };
+}
+
+test('buildCreateFormState keeps preset selection only when image still matches', async () => {
+  const require = createRequire(import.meta.url);
+  const { buildCreateFormState } = require('./create-form-state.js');
+
+  const state = buildCreateFormState({
+    activePreset: {
+      name: 'OpenClaw Devbox',
+      image: 'spritz-openclaw:latest',
+    },
+    image: 'custom-image:latest',
+    repo: 'https://example.com/repo.git',
+    branch: 'main',
+    ttl: '8h',
+    namespace: 'team-a',
+    userConfig: 'sharedMounts: []',
+  });
+
+  assert.deepEqual(state.selection, { mode: 'custom' });
+  assert.equal(state.fields.image, 'custom-image:latest');
+});
+
+test('writeCreateFormState stores reusable form state without a name field', async () => {
+  const require = createRequire(import.meta.url);
+  const {
+    CREATE_FORM_STORAGE_KEY,
+    buildCreateFormState,
+    readCreateFormState,
+    writeCreateFormState,
+  } = require('./create-form-state.js');
+
+  const storage = createStorage();
+  const input = buildCreateFormState({
+    activePreset: {
+      name: 'Claude Code',
+      image: 'spritz-claude-code:latest',
+    },
+    image: 'spritz-claude-code:latest',
+    repo: 'https://example.com/repo.git',
+    branch: 'staging',
+    ttl: '12h',
+    namespace: 'workspace-a',
+    userConfig: 'sharedMounts: []',
+  });
+
+  writeCreateFormState(storage, input);
+
+  const raw = JSON.parse(storage.getItem(CREATE_FORM_STORAGE_KEY));
+  assert.equal(raw.name, undefined);
+  assert.deepEqual(readCreateFormState(storage), input);
+});

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -86,6 +86,7 @@ ttl: 8h"
     <script src="/acp-client.js?v=__SPRITZ_UI_ASSET_VERSION__"></script>
     <script src="/acp-render.js?v=__SPRITZ_UI_ASSET_VERSION__"></script>
     <script src="/acp-page.js?v=__SPRITZ_UI_ASSET_VERSION__"></script>
+    <script src="/create-form-state.js?v=__SPRITZ_UI_ASSET_VERSION__"></script>
     <script src="/preset-panel.js?v=__SPRITZ_UI_ASSET_VERSION__"></script>
     <script src="/app.js?v=__SPRITZ_UI_ASSET_VERSION__"></script>
   </body>

--- a/ui/public/preset-panel.js
+++ b/ui/public/preset-panel.js
@@ -21,19 +21,6 @@
       return null;
     }
 
-    const existingSelect = document.getElementById('preset-select');
-    if (existingSelect) {
-      return {
-        reset() {
-          existingSelect.value = '';
-          const help = form.querySelector('.preset-help');
-          if (help) help.textContent = '';
-          setActivePresetEnv(null);
-          if (typeof setActivePreset === 'function') setActivePreset(null);
-        },
-      };
-    }
-
     const imageInput = form.querySelector('input[name="image"]');
     const repoInput = form.querySelector('input[name="repo"]');
     const branchInput = form.querySelector('input[name="branch"]');
@@ -46,33 +33,37 @@
       applyRepoDefaults();
     }
 
-    const panel = document.createElement('div');
-    panel.className = 'preset-panel';
+    let select = document.getElementById('preset-select');
+    let help = form.querySelector('.preset-help');
+    if (!select) {
+      const panel = document.createElement('div');
+      panel.className = 'preset-panel';
 
-    const label = document.createElement('label');
-    label.textContent = 'Preset';
+      const label = document.createElement('label');
+      label.textContent = 'Preset';
 
-    const select = document.createElement('select');
-    select.id = 'preset-select';
+      select = document.createElement('select');
+      select.id = 'preset-select';
 
-    const customOption = document.createElement('option');
-    customOption.value = '';
-    customOption.textContent = 'Custom';
-    select.append(customOption);
+      const customOption = document.createElement('option');
+      customOption.value = '';
+      customOption.textContent = 'Custom';
+      select.append(customOption);
 
-    presets.forEach((preset, index) => {
-      const option = document.createElement('option');
-      option.value = String(index);
-      option.textContent = `${preset.name} (${preset.image})`;
-      select.append(option);
-    });
+      presets.forEach((preset, index) => {
+        const option = document.createElement('option');
+        option.value = String(index);
+        option.textContent = `${preset.name} (${preset.image})`;
+        select.append(option);
+      });
 
-    const help = document.createElement('small');
-    help.className = 'preset-help';
+      help = document.createElement('small');
+      help.className = 'preset-help';
 
-    label.append(select);
-    panel.append(label, help);
-    form.prepend(panel);
+      label.append(select);
+      panel.append(label, help);
+      form.prepend(panel);
+    }
 
     const applyPreset = (preset) => {
       if (!preset) return;
@@ -94,6 +85,35 @@
       if (typeof setActivePreset === 'function') setActivePreset(null);
     };
 
+    const findPresetIndex = (selection) => {
+      if (!selection || selection.mode !== 'preset') return -1;
+      const presetName = String(selection.presetName || '').trim();
+      const presetImage = String(selection.presetImage || '').trim();
+      return presets.findIndex((preset) => {
+        const matchesImage = presetImage && String(preset.image || '').trim() === presetImage;
+        const matchesName = presetName && String(preset.name || '').trim() === presetName;
+        if (presetImage && presetName) {
+          return matchesImage && matchesName;
+        }
+        return matchesImage || matchesName;
+      });
+    };
+
+    const restoreSelection = (selection) => {
+      if (!selection || selection.mode === 'custom') {
+        reset();
+        return true;
+      }
+      const index = findPresetIndex(selection);
+      if (index < 0) {
+        reset();
+        return false;
+      }
+      select.value = String(index);
+      applyPreset(presets[index]);
+      return true;
+    };
+
     select.addEventListener('change', () => {
       if (!select.value) {
         reset();
@@ -107,7 +127,7 @@
       applyPreset(presets[0]);
     }
 
-    return { reset };
+    return { reset, restoreSelection };
   }
 
   return { setupPresetPanel };

--- a/ui/public/preset-panel.test.mjs
+++ b/ui/public/preset-panel.test.mjs
@@ -224,3 +224,59 @@ test('setupPresetPanel injects the preset selector and updates image fields', as
   assert.equal(activeEnv, null);
   assert.equal(activePreset, null);
 });
+
+test('setupPresetPanel restores a saved preset selection and falls back to custom', async () => {
+  const require = createRequire(import.meta.url);
+  const { setupPresetPanel } = require('./preset-panel.js');
+
+  const { document, form, imageInput, repoInput, branchInput, ttlInput } = buildFormFixture();
+  let activePreset = null;
+  const presets = [
+    {
+      name: 'Starter Devbox',
+      image: 'spritz-starter:latest',
+      description: 'Starter image',
+      repoUrl: 'https://example.com/a.git',
+      branch: 'main',
+      ttl: '8h',
+    },
+    {
+      name: 'OpenClaw Devbox',
+      image: 'spritz-openclaw:latest',
+      description: 'OpenClaw image',
+      repoUrl: 'https://example.com/b.git',
+      branch: 'staging',
+      ttl: '12h',
+    },
+  ];
+
+  const controller = setupPresetPanel({
+    document,
+    form,
+    presets,
+    hideRepoInputs: false,
+    applyRepoDefaults() {},
+    normalizePresetEnv() {
+      return null;
+    },
+    setActivePresetEnv() {},
+    setActivePreset(preset) {
+      activePreset = preset;
+    },
+  });
+
+  assert.equal(
+    controller.restoreSelection({ mode: 'preset', presetName: 'OpenClaw Devbox', presetImage: 'spritz-openclaw:latest' }),
+    true,
+  );
+  assert.equal(document.getElementById('preset-select').value, '1');
+  assert.equal(imageInput.value, 'spritz-openclaw:latest');
+  assert.equal(repoInput.value, 'https://example.com/b.git');
+  assert.equal(branchInput.value, 'staging');
+  assert.equal(ttlInput.value, '12h');
+  assert.equal(activePreset?.name, 'OpenClaw Devbox');
+
+  assert.equal(controller.restoreSelection({ mode: 'custom' }), true);
+  assert.equal(document.getElementById('preset-select').value, '');
+  assert.equal(activePreset, null);
+});


### PR DESCRIPTION
This keeps the create form on the same preset/image after a successful create instead of snapping back to Custom. It also persists the reusable create-form configuration in local storage, so coming back to the page or refreshing restores the last selected preset/image and related fields.