### PR TITLE
fix(openclaw): support current acp-cli bundle layout

### DIFF
--- a/images/examples/openclaw/generate-openclaw-acp-compat.mjs
+++ b/images/examples/openclaw/generate-openclaw-acp-compat.mjs
@@ -15,6 +15,21 @@ function requireMatch(source, pattern, label) {
   return match[1];
 }
 
+function findMatch(source, pattern) {
+  return source.match(pattern)?.[1] ?? null;
+}
+
+function findGatewayConstantsBundle(acpCliSource) {
+  const importMatches = [...acpCliSource.matchAll(/import\s+\{([^}]*)\}\s+from\s+"\.\/([^"]+)"/g)];
+  for (const match of importMatches) {
+    const names = match[1];
+    if (names.includes("GATEWAY_CLIENT_NAMES") && names.includes("GATEWAY_CLIENT_MODES")) {
+      return match[2];
+    }
+  }
+  return null;
+}
+
 function assertReadableFile(filePath, label) {
   if (!fs.existsSync(filePath)) {
     throw new Error(`${label} not found: ${filePath}`);
@@ -56,11 +71,12 @@ export function resolveAcpCliDependencies(acpCliSource) {
       /import\s+\{[^}]*resolveGatewayConnectionAuth[^}]*\}\s+from\s+"\.\/([^"]+)"/,
       "resolveGatewayConnectionAuth bundle",
     ),
-    messageChannelBasename: requireMatch(
-      acpCliSource,
-      /import\s+\{[^}]*GATEWAY_CLIENT_NAMES[^}]*GATEWAY_CLIENT_MODES[^}]*\}\s+from\s+"\.\/([^"]+)"/,
-      "gateway client constants bundle",
-    ),
+    gatewayConstantsBasename:
+      findGatewayConstantsBundle(acpCliSource) ??
+      requireMatch(acpCliSource, /$^/, "gateway client constants bundle"),
+    loadConfigBasename:
+      findMatch(acpCliSource, /import\s+\{[^}]*loadConfig[^}]*\}\s+from\s+"\.\/([^"]+)"/) ??
+      "index.js",
   };
 }
 
@@ -75,10 +91,10 @@ export function buildAcpCliCompatSource(acpCliSource) {
 }
 
 export function buildCompatModuleSource(params) {
-  return `import { loadConfig } from "./index.js";
+  return `import * as configModule from "./${params.loadConfigBasename}";
 import * as callModule from "./${params.callBasename}";
 import * as connectionAuthModule from "./${params.connectionAuthBasename}";
-import * as messageChannelModule from "./${params.messageChannelBasename}";
+import * as gatewayConstantsModule from "./${params.gatewayConstantsBasename}";
 import {
   AcpGatewayAgent,
   registerAcpCli,
@@ -103,6 +119,7 @@ function pickNamedObject(moduleNs, name) {
   throw new Error(\`OpenClaw ACP compat object not found: \${name}\`);
 }
 
+const loadConfig = pickNamedFunction(configModule, "loadConfig");
 const GatewayClient = pickNamedFunction(callModule, "GatewayClient");
 const buildGatewayConnectionDetails = pickNamedFunction(
   callModule,
@@ -112,8 +129,8 @@ const resolveGatewayConnectionAuth = pickNamedFunction(
   connectionAuthModule,
   "resolveGatewayConnectionAuth",
 );
-const GATEWAY_CLIENT_NAMES = pickNamedObject(messageChannelModule, "CONTROL_UI");
-const GATEWAY_CLIENT_MODES = pickNamedObject(messageChannelModule, "WEBCHAT");
+const GATEWAY_CLIENT_NAMES = pickNamedObject(gatewayConstantsModule, "CONTROL_UI");
+const GATEWAY_CLIENT_MODES = pickNamedObject(gatewayConstantsModule, "WEBCHAT");
 
 export {
   AcpGatewayAgent,
@@ -141,13 +158,13 @@ export function generateOpenclawAcpCompat(packageRoot) {
 
   const callPath = path.join(distDir, dependencies.callBasename);
   const connectionAuthPath = path.join(distDir, dependencies.connectionAuthBasename);
-  const messageChannelPath = path.join(distDir, dependencies.messageChannelBasename);
-  const indexPath = path.join(distDir, "index.js");
+  const gatewayConstantsPath = path.join(distDir, dependencies.gatewayConstantsBasename);
+  const loadConfigPath = path.join(distDir, dependencies.loadConfigBasename);
 
   assertReadableFile(callPath, "OpenClaw call bundle");
   assertReadableFile(connectionAuthPath, "OpenClaw connection-auth bundle");
-  assertReadableFile(messageChannelPath, "OpenClaw message-channel bundle");
-  assertReadableFile(indexPath, "OpenClaw dist index");
+  assertReadableFile(gatewayConstantsPath, "OpenClaw gateway-constants bundle");
+  assertReadableFile(loadConfigPath, "OpenClaw loadConfig bundle");
 
   const acpCliCompatPath = path.join(distDir, ACP_CLI_COMPAT_BASENAME);
   const compatPath = path.join(distDir, ACP_COMPAT_BASENAME);
@@ -179,7 +196,8 @@ async function main() {
       acpCliCompatPath: result.acpCliCompatPath,
       callBasename: result.callBasename,
       connectionAuthBasename: result.connectionAuthBasename,
-      messageChannelBasename: result.messageChannelBasename,
+      gatewayConstantsBasename: result.gatewayConstantsBasename,
+      loadConfigBasename: result.loadConfigBasename,
     })}\n`,
   );
 }

--- a/images/examples/openclaw/generate-openclaw-acp-compat.test.mjs
+++ b/images/examples/openclaw/generate-openclaw-acp-compat.test.mjs
@@ -18,6 +18,7 @@ function makeTempPackageRoot() {
 
 test("resolveAcpCliDependencies extracts the hashed bundles imported by acp-cli", () => {
   const dependencies = resolveAcpCliDependencies(`
+    import { loadConfig } from "./index.js";
     import { h as GATEWAY_CLIENT_NAMES, m as GATEWAY_CLIENT_MODES } from "./message-channel-abc123.js";
     import { p as GatewayClient, t as buildGatewayConnectionDetails } from "./call-def456.js";
     import { t as resolveGatewayConnectionAuth } from "./connection-auth-ghi789.js";
@@ -26,7 +27,39 @@ test("resolveAcpCliDependencies extracts the hashed bundles imported by acp-cli"
   assert.deepEqual(dependencies, {
     callBasename: "call-def456.js",
     connectionAuthBasename: "connection-auth-ghi789.js",
-    messageChannelBasename: "message-channel-abc123.js",
+    gatewayConstantsBasename: "message-channel-abc123.js",
+    loadConfigBasename: "index.js",
+  });
+});
+
+test("resolveAcpCliDependencies supports gateway constant imports in either order", () => {
+  const dependencies = resolveAcpCliDependencies(`
+    import { loadConfig } from "./index.js";
+    import { m as GATEWAY_CLIENT_MODES, h as GATEWAY_CLIENT_NAMES } from "./message-channel-abc123.js";
+    import { p as GatewayClient, t as buildGatewayConnectionDetails } from "./call-def456.js";
+    import { t as resolveGatewayConnectionAuth } from "./connection-auth-ghi789.js";
+  `);
+
+  assert.deepEqual(dependencies, {
+    callBasename: "call-def456.js",
+    connectionAuthBasename: "connection-auth-ghi789.js",
+    gatewayConstantsBasename: "message-channel-abc123.js",
+    loadConfigBasename: "index.js",
+  });
+});
+
+test("resolveAcpCliDependencies supports loadConfig and gateway constants from the same hashed bundle", () => {
+  const dependencies = resolveAcpCliDependencies(`
+    import { Gs as loadConfig, di as GATEWAY_CLIENT_NAMES, ui as GATEWAY_CLIENT_MODES } from "./model-selection-demo.js";
+    import { p as GatewayClient, t as buildGatewayConnectionDetails } from "./call-demo.js";
+    import { t as resolveGatewayConnectionAuth } from "./connection-auth-demo.js";
+  `);
+
+  assert.deepEqual(dependencies, {
+    callBasename: "call-demo.js",
+    connectionAuthBasename: "connection-auth-demo.js",
+    gatewayConstantsBasename: "model-selection-demo.js",
+    loadConfigBasename: "model-selection-demo.js",
   });
 });
 
@@ -85,7 +118,8 @@ test("generateOpenclawAcpCompat writes stable compat modules for the installed p
 
   assert.equal(result.callBasename, "call-demo.js");
   assert.equal(result.connectionAuthBasename, "connection-auth-demo.js");
-  assert.equal(result.messageChannelBasename, "message-channel-demo.js");
+  assert.equal(result.gatewayConstantsBasename, "message-channel-demo.js");
+  assert.equal(result.loadConfigBasename, "index.js");
   assert.equal(path.basename(result.acpCliCompatPath), ACP_CLI_COMPAT_BASENAME);
   assert.equal(path.basename(result.compatPath), ACP_COMPAT_BASENAME);
 
@@ -101,4 +135,67 @@ test("generateOpenclawAcpCompat writes stable compat modules for the installed p
   assert.equal(acpCliCompatModule.AcpGatewayAgent.name, "AcpGatewayAgent");
   assert.equal(typeof acpCliCompatModule.serveAcpGateway, "function");
   assert.equal(typeof acpCliCompatModule.registerAcpCli, "function");
+});
+
+test("generateOpenclawAcpCompat supports hashed config bundles that also export gateway constants", async () => {
+  const packageRoot = makeTempPackageRoot();
+  const distDir = path.join(packageRoot, "dist");
+  fs.mkdirSync(distDir, { recursive: true });
+
+  fs.writeFileSync(
+    path.join(distDir, "model-selection-demo.js"),
+    [
+      'function loadConfig() { return { gateway: { mode: "remote" } }; }',
+      'export const y = { CLI: "cli", CONTROL_UI: "openclaw-control-ui" };',
+      'export const z = { CLI: "cli", WEBCHAT: "webchat" };',
+      'export { loadConfig as x };',
+      "",
+    ].join("\n"),
+  );
+  fs.writeFileSync(
+    path.join(distDir, "call-demo.js"),
+    [
+      'export class GatewayClient {}',
+      'export function buildGatewayConnectionDetails() { return { url: "wss://example.test", urlSource: "remote" }; }',
+      "",
+    ].join("\n"),
+  );
+  fs.writeFileSync(
+    path.join(distDir, "connection-auth-demo.js"),
+    'export async function resolveGatewayConnectionAuth() { return { password: "password" }; }\n',
+  );
+  fs.writeFileSync(
+    path.join(distDir, "acp-cli-demo.js"),
+    [
+      'import { x as loadConfig, y as GATEWAY_CLIENT_NAMES, z as GATEWAY_CLIENT_MODES } from "./model-selection-demo.js";',
+      'import { GatewayClient, buildGatewayConnectionDetails } from "./call-demo.js";',
+      'import { resolveGatewayConnectionAuth } from "./connection-auth-demo.js";',
+      "class AcpGatewayAgent {}",
+      "async function serveAcpGateway() {",
+      "  return {",
+      "    GatewayClient,",
+      "    buildGatewayConnectionDetails,",
+      "    resolveGatewayConnectionAuth,",
+      "    GATEWAY_CLIENT_NAMES,",
+      "    GATEWAY_CLIENT_MODES,",
+      "    loadConfig,",
+      "  };",
+      "}",
+      "function registerAcpCli() {}",
+      "export { registerAcpCli };",
+      "",
+    ].join("\n"),
+  );
+
+  const result = generateOpenclawAcpCompat(packageRoot);
+  const compatModule = await import(pathToFileURL(result.compatPath).href);
+
+  assert.equal(result.loadConfigBasename, "model-selection-demo.js");
+  assert.equal(result.gatewayConstantsBasename, "model-selection-demo.js");
+  assert.equal(compatModule.loadConfig().gateway.mode, "remote");
+  assert.equal(compatModule.GatewayClient.name, "GatewayClient");
+  assert.equal(compatModule.buildGatewayConnectionDetails().url, "wss://example.test");
+  assert.deepEqual(await compatModule.resolveGatewayConnectionAuth(), { password: "password" });
+  assert.equal(compatModule.GATEWAY_CLIENT_NAMES.CONTROL_UI, "openclaw-control-ui");
+  assert.equal(compatModule.GATEWAY_CLIENT_MODES.WEBCHAT, "webchat");
 });


### PR DESCRIPTION
## Summary
- make the OpenClaw ACP compat generator resolve gateway constants regardless of import order
- support current published acp-cli bundles where loadConfig and gateway constants live in the same hashed module
- add regression coverage for both bundle layouts

## Validation
- node --test /Users/onur/repos/spritz/images/examples/openclaw/generate-openclaw-acp-compat.test.mjs /Users/onur/repos/spritz/images/examples/openclaw/acp-server.test.mjs /Users/onur/repos/spritz/images/examples/openclaw/acp-wrapper.test.mjs /Users/onur/repos/spritz/images/examples/openclaw/image-contract.test.mjs
- docker build -f /Users/onur/repos/spritz/images/examples/openclaw/Dockerfile -t spritz-openclaw-local:test /Users/onur/repos/spritz/images
- docker run --rm --entrypoint bash spritz-openclaw-local:test -lc 'test -x /usr/local/lib/node_modules/openclaw/extensions/acpx/node_modules/.bin/acpx && /usr/local/lib/node_modules/openclaw/extensions/acpx/node_modules/.bin/acpx --version'