### PR TITLE
fix(ui): stop agent presets from inheriting hidden repo defaults

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -4,8 +4,9 @@ USER root
 RUN apk add --no-cache sed
 
 COPY public/ /usr/share/nginx/html/
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY entrypoint.sh /entrypoint.sh
-RUN chown -R 101:101 /usr/share/nginx/html /entrypoint.sh
+RUN chown -R 101:101 /usr/share/nginx/html /entrypoint.sh /etc/nginx/conf.d/default.conf
 
 ENV SPRITZ_API_BASE_URL=/api
 

--- a/ui/nginx-config.test.mjs
+++ b/ui/nginx-config.test.mjs
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const nginxConfig = fs.readFileSync('/Users/onur/repos/spritz/ui/nginx.conf', 'utf8');
+
+test('nginx config disables caching for index and runtime config', () => {
+  assert.match(nginxConfig, /location = \/index\.html \{[\s\S]*Cache-Control "no-store, max-age=0"/);
+  assert.match(nginxConfig, /location = \/config\.js \{[\s\S]*Cache-Control "no-store, max-age=0"/);
+});
+
+test('nginx config keeps hashed js and css cacheable', () => {
+  assert.match(nginxConfig, /location ~\* \\\.\(\?:js\|css\)\$/);
+  assert.match(nginxConfig, /Cache-Control "public, max-age=31536000, immutable"/);
+});

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -1,0 +1,26 @@
+server {
+  listen       8080;
+  server_name  _;
+
+  root   /usr/share/nginx/html;
+  index  index.html;
+
+  location = /index.html {
+    add_header Cache-Control "no-store, max-age=0" always;
+    try_files $uri =404;
+  }
+
+  location = /config.js {
+    add_header Cache-Control "no-store, max-age=0" always;
+    try_files $uri =404;
+  }
+
+  location ~* \.(?:js|css)$ {
+    add_header Cache-Control "public, max-age=31536000, immutable" always;
+    try_files $uri =404;
+  }
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+}

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -49,6 +49,7 @@ let authRefreshAttemptId = 0;
 let lastAuthRefreshAt = 0;
 let activeTerminalPoll = null;
 const createFormStateModule = window.SpritzCreateFormState || null;
+const createFormRequestModule = window.SpritzCreateFormRequest || null;
 const presetPlaceholder = '__SPRITZ_UI_PRESETS__';
 const ACP_CLIENT_INFO = {
   name: 'spritz-ui',
@@ -57,7 +58,7 @@ const ACP_CLIENT_INFO = {
 };
 const defaultPresets = [
   {
-    name: 'Starter Devbox',
+    name: 'Starter (minimal)',
     image: 'spritz-starter:latest',
     description: 'Minimal starter image built from images/examples/base.',
     repoUrl: '',
@@ -65,9 +66,25 @@ const defaultPresets = [
     ttl: '',
   },
   {
-    name: 'OpenClaw Devbox',
+    name: 'Devbox (agents)',
+    image: 'spritz-devbox:latest',
+    description: 'Devbox image with coding agents preinstalled.',
+    repoUrl: '',
+    branch: '',
+    ttl: '',
+  },
+  {
+    name: 'OpenClaw',
     image: 'spritz-openclaw:latest',
-    description: 'Starter devbox with OpenClaw preinstalled.',
+    description: 'OpenClaw example image.',
+    repoUrl: '',
+    branch: '',
+    ttl: '',
+  },
+  {
+    name: 'Claude Code',
+    image: 'spritz-claude-code:latest',
+    description: 'Claude Code example image.',
     repoUrl: '',
     branch: '',
     ttl: '',
@@ -386,6 +403,24 @@ function applyPersistedCreateFormState(state) {
   if (namespaceInput) namespaceInput.value = fields.namespace || '';
   if (userConfigInput) userConfigInput.value = fields.userConfig || '';
   return true;
+}
+
+function resolveCreateRepoSelection(repoValue, branchValue) {
+  if (createFormRequestModule && typeof createFormRequestModule.resolveRepoSelection === 'function') {
+    return createFormRequestModule.resolveRepoSelection({
+      activePreset,
+      repoValue,
+      branchValue,
+      defaultRepoUrl,
+      defaultRepoBranch,
+    });
+  }
+  const normalizedRepoValue = String(repoValue || '').trim();
+  const normalizedBranchValue = String(branchValue || '').trim();
+  return {
+    repoUrl: normalizedRepoValue || defaultRepoUrl,
+    repoBranch: normalizedBranchValue || defaultRepoBranch,
+  };
 }
 
 function restoreCreateFormState() {
@@ -1464,8 +1499,7 @@ if (form && refreshBtn) {
     const branch = data.get('branch');
     const ttl = data.get('ttl');
     const userConfigRaw = data.get('user_config');
-    const repoUrl = (repo || defaultRepoUrl || '').toString().trim();
-    const repoBranch = (branch || defaultRepoBranch || '').toString().trim();
+    const { repoUrl, repoBranch } = resolveCreateRepoSelection(repo, branch);
     if (repoUrl) {
       payload.spec.repo = { url: repoUrl };
       if (repoBranch) payload.spec.repo.branch = repoBranch;

--- a/ui/public/create-form-request.js
+++ b/ui/public/create-form-request.js
@@ -1,0 +1,33 @@
+(function (root, factory) {
+  const exports = factory();
+  if (typeof module === 'object' && module.exports) {
+    module.exports = exports;
+  }
+  root.SpritzCreateFormRequest = exports;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+  function resolveRepoSelection(options) {
+    const activePreset = options?.activePreset || null;
+    const repoValue = String(options?.repoValue || '').trim();
+    const branchValue = String(options?.branchValue || '').trim();
+    const defaultRepoUrl = String(options?.defaultRepoUrl || '').trim();
+    const defaultRepoBranch = String(options?.defaultRepoBranch || '').trim();
+    const presetOwnsRepo =
+      !!activePreset &&
+      (Object.prototype.hasOwnProperty.call(activePreset, 'repoUrl') ||
+        Object.prototype.hasOwnProperty.call(activePreset, 'branch'));
+
+    if (presetOwnsRepo) {
+      return {
+        repoUrl: repoValue,
+        repoBranch: branchValue,
+      };
+    }
+
+    return {
+      repoUrl: repoValue || defaultRepoUrl,
+      repoBranch: branchValue || defaultRepoBranch,
+    };
+  }
+
+  return { resolveRepoSelection };
+});

--- a/ui/public/create-form-request.test.mjs
+++ b/ui/public/create-form-request.test.mjs
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+test('resolveRepoSelection falls back to repo defaults for presets without repo ownership', async () => {
+  const require = createRequire(import.meta.url);
+  const { resolveRepoSelection } = require('./create-form-request.js');
+
+  assert.deepEqual(
+    resolveRepoSelection({
+      activePreset: { name: 'Starter (minimal)', image: 'spritz-starter:latest' },
+      repoValue: '',
+      branchValue: '',
+      defaultRepoUrl: 'https://github.com/example/repo.git',
+      defaultRepoBranch: 'main',
+    }),
+    {
+      repoUrl: 'https://github.com/example/repo.git',
+      repoBranch: 'main',
+    },
+  );
+});
+
+test('resolveRepoSelection preserves explicit blank repo settings owned by the preset', async () => {
+  const require = createRequire(import.meta.url);
+  const { resolveRepoSelection } = require('./create-form-request.js');
+
+  assert.deepEqual(
+    resolveRepoSelection({
+      activePreset: {
+        name: 'OpenClaw',
+        image: 'spritz-openclaw:latest',
+        repoUrl: '',
+        branch: '',
+      },
+      repoValue: '',
+      branchValue: '',
+      defaultRepoUrl: 'https://github.com/example/private.git',
+      defaultRepoBranch: 'staging',
+    }),
+    {
+      repoUrl: '',
+      repoBranch: '',
+    },
+  );
+});

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -87,6 +87,7 @@ ttl: 8h"
     <script src="/acp-render.js?v=__SPRITZ_UI_ASSET_VERSION__"></script>
     <script src="/acp-page.js?v=__SPRITZ_UI_ASSET_VERSION__"></script>
     <script src="/create-form-state.js?v=__SPRITZ_UI_ASSET_VERSION__"></script>
+    <script src="/create-form-request.js?v=__SPRITZ_UI_ASSET_VERSION__"></script>
     <script src="/preset-panel.js?v=__SPRITZ_UI_ASSET_VERSION__"></script>
     <script src="/app.js?v=__SPRITZ_UI_ASSET_VERSION__"></script>
   </body>

--- a/ui/public/preset-panel.js
+++ b/ui/public/preset-panel.js
@@ -68,10 +68,8 @@
     const applyPreset = (preset) => {
       if (!preset) return;
       imageInput.value = preset.image || '';
-      if (!hideRepoInputs) {
-        if (repoInput && preset.repoUrl !== undefined) repoInput.value = preset.repoUrl || '';
-        if (branchInput && preset.branch !== undefined) branchInput.value = preset.branch || '';
-      }
+      if (repoInput && preset.repoUrl !== undefined) repoInput.value = preset.repoUrl || '';
+      if (branchInput && preset.branch !== undefined) branchInput.value = preset.branch || '';
       if (ttlInput && preset.ttl !== undefined) ttlInput.value = preset.ttl || '';
       help.textContent = preset.description || '';
       setActivePresetEnv(typeof normalizePresetEnv === 'function' ? normalizePresetEnv(preset.env) : null);

--- a/ui/public/preset-panel.test.mjs
+++ b/ui/public/preset-panel.test.mjs
@@ -280,3 +280,38 @@ test('setupPresetPanel restores a saved preset selection and falls back to custo
   assert.equal(document.getElementById('preset-select').value, '');
   assert.equal(activePreset, null);
 });
+
+test('setupPresetPanel clears hidden repo defaults when a preset explicitly owns blank repo fields', async () => {
+  const require = createRequire(import.meta.url);
+  const { setupPresetPanel } = require('./preset-panel.js');
+
+  const { document, form, imageInput, repoInput, branchInput } = buildFormFixture();
+  repoInput.value = 'https://github.com/example/private.git';
+  branchInput.value = 'staging';
+  const presets = [
+    {
+      name: 'OpenClaw',
+      image: 'spritz-openclaw:latest',
+      description: 'OpenClaw image',
+      repoUrl: '',
+      branch: '',
+    },
+  ];
+
+  setupPresetPanel({
+    document,
+    form,
+    presets,
+    hideRepoInputs: true,
+    applyRepoDefaults() {},
+    normalizePresetEnv(env) {
+      return env;
+    },
+    setActivePresetEnv() {},
+    setActivePreset() {},
+  });
+
+  assert.equal(imageInput.value, 'spritz-openclaw:latest');
+  assert.equal(repoInput.value, '');
+  assert.equal(branchInput.value, '');
+});


### PR DESCRIPTION
## Summary
- make agent presets explicitly own repo fields even when repo inputs are hidden
- add a shared create-form repo resolution helper and tests
- harden UI caching so index/config are not served stale after deploy

## Testing
- node --test /Users/onur/repos/spritz/ui/public/*.test.mjs
- node --check /Users/onur/repos/spritz/ui/public/app.js
- node --check /Users/onur/repos/spritz/ui/public/preset-panel.js
- node --check /Users/onur/repos/spritz/ui/public/create-form-request.js
- docker build -f /Users/onur/repos/spritz/ui/Dockerfile -t spritz-ui-cache-test:local /Users/onur/repos/spritz/ui
- curl header checks against the built UI container
