### PR TITLE
fix(ui): render preset config as runtime JS values

### DIFF
--- a/ui/entrypoint.sh
+++ b/ui/entrypoint.sh
@@ -20,6 +20,8 @@ AUTH_REFRESH_TIMEOUT_MS="${SPRITZ_UI_AUTH_REFRESH_TIMEOUT_MS:-}"
 AUTH_REFRESH_COOLDOWN_MS="${SPRITZ_UI_AUTH_REFRESH_COOLDOWN_MS:-}"
 AUTH_REFRESH_HEADERS="${SPRITZ_UI_AUTH_REFRESH_HEADERS:-}"
 AUTH_PRESETS="${SPRITZ_UI_PRESETS:-}"
+HTML_DIR="${SPRITZ_UI_HTML_DIR:-/usr/share/nginx/html}"
+SKIP_NGINX="${SPRITZ_UI_SKIP_NGINX:-}"
 DEFAULT_REPO_URL="${SPRITZ_UI_DEFAULT_REPO_URL:-}"
 DEFAULT_REPO_DIR="${SPRITZ_UI_DEFAULT_REPO_DIR:-}"
 DEFAULT_REPO_BRANCH="${SPRITZ_UI_DEFAULT_REPO_BRANCH:-}"
@@ -56,7 +58,8 @@ AUTH_REFRESH_TOKEN_STORAGE_KEYS_ESCAPED="$(escape_sed "$AUTH_REFRESH_TOKEN_STORA
 AUTH_REFRESH_TIMEOUT_MS_ESCAPED="$(escape_sed "$AUTH_REFRESH_TIMEOUT_MS")"
 AUTH_REFRESH_COOLDOWN_MS_ESCAPED="$(escape_sed "$AUTH_REFRESH_COOLDOWN_MS")"
 AUTH_REFRESH_HEADERS_ESCAPED="$(escape_sed "$AUTH_REFRESH_HEADERS")"
-AUTH_PRESETS_ESCAPED="$(escape_sed "$AUTH_PRESETS")"
+AUTH_PRESETS_VALUE="${AUTH_PRESETS:-null}"
+AUTH_PRESETS_ESCAPED="$(escape_sed "$AUTH_PRESETS_VALUE")"
 DEFAULT_REPO_URL_ESCAPED="$(escape_sed "$DEFAULT_REPO_URL")"
 DEFAULT_REPO_DIR_ESCAPED="$(escape_sed "$DEFAULT_REPO_DIR")"
 DEFAULT_REPO_BRANCH_ESCAPED="$(escape_sed "$DEFAULT_REPO_BRANCH")"
@@ -64,7 +67,7 @@ HIDE_REPO_INPUTS_ESCAPED="$(escape_sed "$HIDE_REPO_INPUTS")"
 LAUNCH_QUERY_PARAMS_ESCAPED="$(escape_sed "$LAUNCH_QUERY_PARAMS")"
 ASSET_VERSION_ESCAPED="$(escape_sed "$ASSET_VERSION")"
 
-sed "s|__SPRITZ_API_BASE_URL__|${API_BASE_URL_ESCAPED}|g" /usr/share/nginx/html/config.js \
+sed "s|__SPRITZ_API_BASE_URL__|${API_BASE_URL_ESCAPED}|g" "${HTML_DIR}/config.js" \
   | sed "s|__SPRITZ_OWNER_ID__|${OWNER_ID_ESCAPED}|g" \
   | sed "s|__SPRITZ_UI_AUTH_MODE__|${AUTH_MODE_ESCAPED}|g" \
   | sed "s|__SPRITZ_UI_AUTH_TOKEN_STORAGE__|${AUTH_TOKEN_STORAGE_ESCAPED}|g" \
@@ -88,11 +91,15 @@ sed "s|__SPRITZ_API_BASE_URL__|${API_BASE_URL_ESCAPED}|g" /usr/share/nginx/html/
   | sed "s|__SPRITZ_UI_AUTH_REFRESH_TIMEOUT_MS__|${AUTH_REFRESH_TIMEOUT_MS_ESCAPED}|g" \
   | sed "s|__SPRITZ_UI_AUTH_REFRESH_COOLDOWN_MS__|${AUTH_REFRESH_COOLDOWN_MS_ESCAPED}|g" \
   | sed "s|__SPRITZ_UI_AUTH_REFRESH_HEADERS__|${AUTH_REFRESH_HEADERS_ESCAPED}|g" \
-  > /usr/share/nginx/html/config.runtime.js
-mv /usr/share/nginx/html/config.runtime.js /usr/share/nginx/html/config.js
+  > "${HTML_DIR}/config.runtime.js"
+mv "${HTML_DIR}/config.runtime.js" "${HTML_DIR}/config.js"
 
-sed "s|__SPRITZ_UI_ASSET_VERSION__|${ASSET_VERSION_ESCAPED}|g" /usr/share/nginx/html/index.html \
-  > /usr/share/nginx/html/index.runtime.html
-mv /usr/share/nginx/html/index.runtime.html /usr/share/nginx/html/index.html
+sed "s|__SPRITZ_UI_ASSET_VERSION__|${ASSET_VERSION_ESCAPED}|g" "${HTML_DIR}/index.html" \
+  > "${HTML_DIR}/index.runtime.html"
+mv "${HTML_DIR}/index.runtime.html" "${HTML_DIR}/index.html"
+
+if [ "$SKIP_NGINX" = "1" ]; then
+  exit 0
+fi
 
 exec nginx -g 'daemon off;'

--- a/ui/entrypoint.test.mjs
+++ b/ui/entrypoint.test.mjs
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import vm from 'node:vm';
+import { execFileSync } from 'node:child_process';
+
+function renderConfig(env = {}) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'spritz-ui-'));
+  fs.copyFileSync('/Users/onur/repos/spritz/ui/public/config.js', path.join(tmpDir, 'config.js'));
+  fs.copyFileSync('/Users/onur/repos/spritz/ui/public/index.html', path.join(tmpDir, 'index.html'));
+
+  execFileSync('/bin/sh', ['/Users/onur/repos/spritz/ui/entrypoint.sh'], {
+    env: {
+      ...process.env,
+      SPRITZ_UI_HTML_DIR: tmpDir,
+      SPRITZ_UI_SKIP_NGINX: '1',
+      ...env,
+    },
+  });
+
+  const source = fs.readFileSync(path.join(tmpDir, 'config.js'), 'utf8');
+  const context = { window: {} };
+  vm.createContext(context);
+  vm.runInContext(source, context);
+  return context.window.SPRITZ_CONFIG;
+}
+
+test('entrypoint renders presets as a real JS array even with nested JSON env values', () => {
+  const nestedConfig = JSON.stringify({ browser: { enabled: true, headless: true } });
+  const presets = JSON.stringify([
+    {
+      name: 'OpenClaw',
+      image: 'registry.example/openclaw@sha256:123',
+      env: [{ name: 'OPENCLAW_CONFIG_JSON', value: nestedConfig }],
+    },
+  ]);
+
+  const config = renderConfig({ SPRITZ_UI_PRESETS: presets });
+  assert.ok(Array.isArray(config.presets));
+  assert.equal(config.presets[0].image, 'registry.example/openclaw@sha256:123');
+  assert.equal(config.presets[0].env[0].value, nestedConfig);
+});
+
+test('entrypoint renders null when presets are unset', () => {
+  const config = renderConfig();
+  assert.equal(config.presets, null);
+});

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -50,6 +50,7 @@ let lastAuthRefreshAt = 0;
 let activeTerminalPoll = null;
 const createFormStateModule = window.SpritzCreateFormState || null;
 const createFormRequestModule = window.SpritzCreateFormRequest || null;
+const presetConfigModule = window.SpritzPresetConfig || null;
 const presetPlaceholder = '__SPRITZ_UI_PRESETS__';
 const ACP_CLIENT_INFO = {
   name: 'spritz-ui',
@@ -342,13 +343,17 @@ function parsePresets(raw) {
       const parsed = JSON.parse(trimmed);
       if (Array.isArray(parsed)) return parsed;
     } catch {
-      return null;
+      console.error('Failed to parse Spritz preset configuration.');
+      return [];
     }
   }
   return null;
 }
 
-const presets = parsePresets(config.presets) ?? defaultPresets;
+const presets =
+  (presetConfigModule?.parsePresets
+    ? presetConfigModule.parsePresets(config.presets, { placeholder: presetPlaceholder, logger: console })
+    : parsePresets(config.presets)) ?? defaultPresets;
 const defaultUserConfigYaml = `sharedMounts:
   - name: config
     mountPath: /home/dev/.config

--- a/ui/public/config.js
+++ b/ui/public/config.js
@@ -1,7 +1,7 @@
 window.SPRITZ_CONFIG = {
   apiBaseUrl: '__SPRITZ_API_BASE_URL__',
   ownerId: '__SPRITZ_OWNER_ID__',
-  presets: '__SPRITZ_UI_PRESETS__',
+  presets: __SPRITZ_UI_PRESETS__,
   repoDefaults: {
     url: '__SPRITZ_UI_DEFAULT_REPO_URL__',
     dir: '__SPRITZ_UI_DEFAULT_REPO_DIR__',

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -83,6 +83,7 @@ ttl: 8h"
     </main>
 
     <script src="/config.js?v=__SPRITZ_UI_ASSET_VERSION__"></script>
+    <script src="/preset-config.js?v=__SPRITZ_UI_ASSET_VERSION__"></script>
     <script src="/acp-client.js?v=__SPRITZ_UI_ASSET_VERSION__"></script>
     <script src="/acp-render.js?v=__SPRITZ_UI_ASSET_VERSION__"></script>
     <script src="/acp-page.js?v=__SPRITZ_UI_ASSET_VERSION__"></script>

--- a/ui/public/preset-config.js
+++ b/ui/public/preset-config.js
@@ -1,0 +1,32 @@
+(function (root, factory) {
+  const exports = factory();
+  if (typeof module === 'object' && module.exports) {
+    module.exports = exports;
+  }
+  root.SpritzPresetConfig = exports;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+  /**
+   * Parse the runtime preset configuration from config.js.
+   * Missing placeholders fall back to built-in defaults; malformed values fail closed.
+   */
+  function parsePresets(raw, options) {
+    const { placeholder = '', logger = console } = options || {};
+    if (Array.isArray(raw)) return raw;
+    if (typeof raw === 'string') {
+      const trimmed = raw.trim();
+      if (!trimmed || trimmed === placeholder) return null;
+      try {
+        const parsed = JSON.parse(trimmed);
+        return Array.isArray(parsed) ? parsed : [];
+      } catch (error) {
+        if (logger && typeof logger.error === 'function') {
+          logger.error('Failed to parse Spritz preset configuration.', error);
+        }
+        return [];
+      }
+    }
+    return null;
+  }
+
+  return { parsePresets };
+});

--- a/ui/public/preset-config.test.mjs
+++ b/ui/public/preset-config.test.mjs
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { parsePresets } = require('/Users/onur/repos/spritz/ui/public/preset-config.js');
+
+test('parsePresets returns raw arrays directly', () => {
+  const presets = [{ name: 'OpenClaw', image: 'example/openclaw' }];
+  assert.equal(parsePresets(presets), presets);
+});
+
+test('parsePresets returns null for the runtime placeholder', () => {
+  assert.equal(parsePresets('__SPRITZ_UI_PRESETS__', { placeholder: '__SPRITZ_UI_PRESETS__' }), null);
+});
+
+test('parsePresets fails closed for malformed values', () => {
+  const errors = [];
+  const parsed = parsePresets('[{"name":"OpenClaw","image":"broken"}', {
+    logger: { error: (...args) => errors.push(args) },
+  });
+  assert.deepEqual(parsed, []);
+  assert.equal(errors.length, 1);
+});


### PR DESCRIPTION
## Summary\n- emit runtime presets as raw JS values instead of embedding them in a quoted string\n- fail closed when preset config is malformed instead of silently falling back to baked-in latest tags\n- add regression coverage for the runtime config rendering path\n\n## Testing\n- node --test ui/entrypoint.test.mjs ui/public/*.test.mjs\n- node --check ui/public/app.js ui/public/preset-config.js ui/public/config.js\n- bash -n ui/entrypoint.sh\n- git diff --check