### PR TITLE
fix(openclaw): seed anthropic auth profile at startup

### DIFF
--- a/images/examples/openclaw/entrypoint.sh
+++ b/images/examples/openclaw/entrypoint.sh
@@ -13,6 +13,7 @@ acp_port="${OPENCLAW_ACP_PORT:-2529}"
 acp_path="${OPENCLAW_ACP_PATH:-/}"
 server_bin="${SPRITZ_OPENCLAW_SERVER_BIN:-/usr/local/bin/spritz-openclaw-acp-server}"
 spritz_entrypoint_bin="${SPRITZ_OPENCLAW_MAIN_ENTRYPOINT:-/usr/local/bin/spritz-entrypoint}"
+auth_store_path="${OPENCLAW_AUTH_PROFILES_PATH:-${config_dir}/agents/main/agent/auth-profiles.json}"
 
 detect_bridge_gateway_host() {
   if [[ -n "${SPRITZ_OPENCLAW_ACP_GATEWAY_HOST:-}" ]]; then
@@ -113,6 +114,77 @@ process.stdout.write(JSON.stringify(headers));
 NODE
 }
 
+seed_env_auth_profiles() {
+  local auth_store_dir
+  auth_store_dir="$(dirname "${auth_store_path}")"
+  mkdir -p "${auth_store_dir}"
+
+  node - "${auth_store_path}" <<'NODE'
+const fs = require("node:fs");
+
+const authStorePath = process.argv[2];
+const env = process.env;
+
+const candidates = [];
+if (typeof env.ANTHROPIC_API_KEY === "string" && env.ANTHROPIC_API_KEY.trim()) {
+  candidates.push({
+    profileId: "anthropic:default",
+    provider: "anthropic",
+    envKey: "ANTHROPIC_API_KEY",
+  });
+}
+
+if (candidates.length === 0) {
+  process.exit(0);
+}
+
+let store = {};
+if (fs.existsSync(authStorePath)) {
+  try {
+    store = JSON.parse(fs.readFileSync(authStorePath, "utf8"));
+  } catch {
+    store = {};
+  }
+}
+if (!store || typeof store !== "object" || Array.isArray(store)) {
+  store = {};
+}
+const profiles = store.profiles && typeof store.profiles === "object" && !Array.isArray(store.profiles)
+  ? { ...store.profiles }
+  : {};
+const lastGood = store.lastGood && typeof store.lastGood === "object" && !Array.isArray(store.lastGood)
+  ? { ...store.lastGood }
+  : {};
+
+for (const candidate of candidates) {
+  profiles[candidate.profileId] = {
+    ...(profiles[candidate.profileId] && typeof profiles[candidate.profileId] === "object"
+      ? profiles[candidate.profileId]
+      : {}),
+    type: "api_key",
+    provider: candidate.provider,
+    keyRef: {
+      source: "env",
+      provider: "default",
+      id: candidate.envKey,
+    },
+  };
+  lastGood[candidate.provider] = candidate.profileId;
+}
+
+const nextStore = {
+  ...store,
+  version: 1,
+  profiles,
+  lastGood,
+};
+
+fs.writeFileSync(authStorePath, `${JSON.stringify(nextStore, null, 2)}\n`, {
+  mode: 0o600,
+});
+NODE
+}
+
 mkdir -p "${config_dir}"
 
 if [[ -n "${OPENCLAW_CONFIG_JSON:-}" ]]; then
@@ -134,6 +206,7 @@ JSON
 fi
 
 chmod 600 "${config_path}" || true
+seed_env_auth_profiles
 
 # Force OpenClaw to use the same file path we prepared above.
 export OPENCLAW_CONFIG_PATH="${config_path}"

--- a/images/examples/openclaw/entrypoint_test.sh
+++ b/images/examples/openclaw/entrypoint_test.sh
@@ -88,10 +88,61 @@ EOF
   assert_eq "${actual}" "${expected_url}" "gateway URL should match"
 }
 
+run_auth_profile_case() {
+  local test_dir="$1"
+
+  mkdir -p "${test_dir}/bin" "${test_dir}/home"
+  make_openclaw_stub "${test_dir}/bin/openclaw"
+
+  cat > "${test_dir}/bin/acp-server" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+sleep 1
+EOF
+  chmod +x "${test_dir}/bin/acp-server"
+
+  cat > "${test_dir}/bin/main-entrypoint" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+sleep 1
+EOF
+  chmod +x "${test_dir}/bin/main-entrypoint"
+
+  (
+    export PATH="${test_dir}/bin:${PATH}"
+    export HOME="${test_dir}/home"
+    export OPENCLAW_AUTO_START=false
+    export ANTHROPIC_API_KEY="sk-test-anthropic"
+    export SPRITZ_OPENCLAW_SERVER_BIN="${test_dir}/bin/acp-server"
+    export SPRITZ_OPENCLAW_MAIN_ENTRYPOINT="${test_dir}/bin/main-entrypoint"
+    bash "${entrypoint}" true
+  )
+
+  local auth_path="${test_dir}/home/.openclaw/agents/main/agent/auth-profiles.json"
+  [[ -f "${auth_path}" ]] || {
+    printf 'expected auth profile store at %s\n' "${auth_path}" >&2
+    exit 1
+  }
+
+  grep -q '"anthropic:default"' "${auth_path}" || {
+    printf 'expected anthropic default profile in %s\n' "${auth_path}" >&2
+    exit 1
+  }
+  grep -q '"provider": "anthropic"' "${auth_path}" || {
+    printf 'expected anthropic provider in %s\n' "${auth_path}" >&2
+    exit 1
+  }
+  grep -q '"id": "ANTHROPIC_API_KEY"' "${auth_path}" || {
+    printf 'expected ANTHROPIC_API_KEY ref in %s\n' "${auth_path}" >&2
+    exit 1
+  }
+}
+
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "${tmpdir}"' EXIT
 
 run_case "${tmpdir}/pod-ip-default" "10.244.3.160 2001:db8:1:3::e3ab" "ws://127.0.0.1:8080"
 run_case "${tmpdir}/explicit-override" "10.244.3.160 2001:db8:1:3::e3ab" "ws://bridge.example.internal:9000" "ws://bridge.example.internal:9000"
+run_auth_profile_case "${tmpdir}/anthropic-auth-profile"
 
 printf 'entrypoint ACP gateway URL tests passed\n'


### PR DESCRIPTION
## Summary
- seed an Anthropic env-backed auth profile into OpenClaw at startup
- keep the OpenClaw example image ready for Sonnet-backed Spritz presets
- add entrypoint coverage for auth profile materialization

## Testing
- bash images/examples/openclaw/entrypoint_test.sh
- bash -n images/examples/openclaw/entrypoint.sh
- git diff --check