### PR TITLE
fix(ui): preserve preset secret refs on create

### DIFF
--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -41,7 +41,6 @@ let activeTerminalSession = null;
 let activeTerminalName = '';
 let activeACPPage = null;
 let presetController = null;
-let activePresetEnv = null;
 let activePreset = null;
 const authRedirectStorageKey = 'spritz-auth-redirected';
 let authRefreshInFlight = null;
@@ -432,30 +431,6 @@ function restoreCreateFormState() {
   if (!createFormStateModule) return false;
   const state = createFormStateModule.readCreateFormState(getCreateFormStorage());
   return applyPersistedCreateFormState(state);
-}
-
-function normalizePresetEnv(env) {
-  if (!env) return null;
-  if (Array.isArray(env)) {
-    return env
-      .map((item) => {
-        if (!item || typeof item !== 'object') return null;
-        const name = String(item.name || '').trim();
-        if (!name) return null;
-        const value = item.value === undefined ? '' : String(item.value);
-        return { name, value };
-      })
-      .filter(Boolean);
-  }
-  if (typeof env === 'object') {
-    return Object.entries(env)
-      .map(([name, value]) => ({
-        name,
-        value: value === undefined ? '' : String(value),
-      }))
-      .filter((item) => item.name.trim() !== '');
-  }
-  return null;
 }
 
 function applyUserConfigDefaults() {
@@ -1414,10 +1389,6 @@ function setupPresets() {
     presets,
     hideRepoInputs,
     applyRepoDefaults,
-    normalizePresetEnv,
-    setActivePresetEnv(env) {
-      activePresetEnv = env;
-    },
     setActivePreset(preset) {
       activePreset = preset;
     },
@@ -1478,42 +1449,61 @@ if (form && refreshBtn) {
     const data = new FormData(form);
     const name = data.get('name');
     const image = data.get('image');
-    const rawName = (name || '').toString().trim();
     const imageValue = (image || '').toString().trim();
-
-    const payload = {
-      namespace: data.get('namespace') || undefined,
-      spec: {
-        image: imageValue,
-      },
-    };
-    if (rawName) {
-      payload.name = rawName;
-    } else {
-      const namePrefix = resolveRequestedNamePrefix(imageValue);
-      if (namePrefix) {
-        payload.namePrefix = namePrefix;
-      }
-    }
-
-    if (config.ownerId) {
-      payload.spec.owner = { id: config.ownerId };
-    }
 
     const repo = data.get('repo');
     const branch = data.get('branch');
     const ttl = data.get('ttl');
     const userConfigRaw = data.get('user_config');
-    const { repoUrl, repoBranch } = resolveCreateRepoSelection(repo, branch);
-    if (repoUrl) {
-      payload.spec.repo = { url: repoUrl };
-      if (repoBranch) payload.spec.repo.branch = repoBranch;
-      if (defaultRepoDir) payload.spec.repo.dir = defaultRepoDir;
-    }
-    if (ttl) payload.spec.ttl = ttl;
-    if (activePresetEnv && activePresetEnv.length > 0) {
-      payload.spec.env = activePresetEnv;
-    }
+    const payload =
+      typeof createFormRequestModule?.buildCreatePayload === 'function'
+        ? createFormRequestModule.buildCreatePayload({
+            name,
+            imageValue,
+            namespace: data.get('namespace') || undefined,
+            ownerId: config.ownerId || '',
+            activePreset,
+            repoValue: repo,
+            branchValue: branch,
+            defaultRepoUrl,
+            defaultRepoBranch,
+            defaultRepoDir,
+            ttlValue: ttl,
+          })
+        : (() => {
+            const fallbackPayload = {
+              namespace: data.get('namespace') || undefined,
+              spec: {
+                image: imageValue,
+              },
+            };
+            const rawName = (name || '').toString().trim();
+            if (rawName) {
+              fallbackPayload.name = rawName;
+            } else {
+              const namePrefix = resolveRequestedNamePrefix(imageValue);
+              if (namePrefix) {
+                fallbackPayload.namePrefix = namePrefix;
+              }
+            }
+            if (config.ownerId) {
+              fallbackPayload.spec.owner = { id: config.ownerId };
+            }
+            const { repoUrl, repoBranch } = resolveCreateRepoSelection({
+              activePreset,
+              repoValue: repo,
+              branchValue: branch,
+              defaultRepoUrl,
+              defaultRepoBranch,
+            });
+            if (repoUrl) {
+              fallbackPayload.spec.repo = { url: repoUrl };
+              if (repoBranch) fallbackPayload.spec.repo.branch = repoBranch;
+              if (defaultRepoDir) fallbackPayload.spec.repo.dir = defaultRepoDir;
+            }
+            if (ttl) fallbackPayload.spec.ttl = ttl;
+            return fallbackPayload;
+          })();
     if (userConfigRaw) {
       try {
         const userConfig = parseUserConfigInput(userConfigRaw);

--- a/ui/public/create-form-request.js
+++ b/ui/public/create-form-request.js
@@ -5,6 +5,27 @@
   }
   root.SpritzCreateFormRequest = exports;
 })(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+  function normalizeNamePrefix(value) {
+    return String(value || '')
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9-]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .replace(/--+/g, '-');
+  }
+
+  function resolveNamePrefix(activePreset, imageValue) {
+    const presetPrefix = normalizeNamePrefix(activePreset?.namePrefix || '');
+    if (presetPrefix) return presetPrefix;
+    const image = String(imageValue || '').trim();
+    if (!image) return '';
+    const lastSegment = image.split('/').pop() || '';
+    const withoutDigest = lastSegment.split('@')[0];
+    const withoutTag = withoutDigest.split(':')[0];
+    const withoutPrefix = withoutTag.replace(/^spritz-/, '');
+    return normalizeNamePrefix(withoutPrefix);
+  }
+
   function resolveRepoSelection(options) {
     const activePreset = options?.activePreset || null;
     const repoValue = String(options?.repoValue || '').trim();
@@ -29,5 +50,62 @@
     };
   }
 
-  return { resolveRepoSelection };
+  function buildCreatePayload(options) {
+    const name = String(options?.name || '').trim();
+    const imageValue = String(options?.imageValue || '').trim();
+    const namespace = String(options?.namespace || '').trim();
+    const ttlValue = String(options?.ttlValue || '').trim();
+    const ownerId = String(options?.ownerId || '').trim();
+    const activePreset = options?.activePreset || null;
+    const presetMatchesImage =
+      !!activePreset && imageValue !== '' && String(activePreset.image || '').trim() === imageValue;
+
+    const payload = {
+      namespace: namespace || undefined,
+      spec: {},
+    };
+
+    if (name) {
+      payload.name = name;
+    } else {
+      const namePrefix = resolveNamePrefix(presetMatchesImage ? activePreset : null, imageValue);
+      if (namePrefix) {
+        payload.namePrefix = namePrefix;
+      }
+    }
+
+    if (presetMatchesImage && String(activePreset.id || '').trim()) {
+      payload.presetId = String(activePreset.id).trim();
+    } else if (imageValue) {
+      payload.spec.image = imageValue;
+    }
+
+    if (ownerId) {
+      payload.spec.owner = { id: ownerId };
+    }
+
+    const { repoUrl, repoBranch } = resolveRepoSelection({
+      activePreset: presetMatchesImage ? activePreset : null,
+      repoValue: options?.repoValue,
+      branchValue: options?.branchValue,
+      defaultRepoUrl: options?.defaultRepoUrl,
+      defaultRepoBranch: options?.defaultRepoBranch,
+    });
+
+    if (repoUrl) {
+      payload.spec.repo = { url: repoUrl };
+      if (repoBranch) payload.spec.repo.branch = repoBranch;
+      if (String(options?.defaultRepoDir || '').trim()) {
+        payload.spec.repo.dir = String(options.defaultRepoDir).trim();
+      }
+    }
+
+    if (ttlValue) {
+      payload.spec.ttl = ttlValue;
+    }
+
+    return payload;
+  }
+
+  return { resolveRepoSelection, buildCreatePayload };
 });

--- a/ui/public/create-form-request.test.mjs
+++ b/ui/public/create-form-request.test.mjs
@@ -44,3 +44,69 @@ test('resolveRepoSelection preserves explicit blank repo settings owned by the p
     },
   );
 });
+
+test('buildCreatePayload uses presetId and does not serialize preset env overrides', async () => {
+  const require = createRequire(import.meta.url);
+  const { buildCreatePayload } = require('./create-form-request.js');
+
+  const payload = buildCreatePayload({
+    name: '',
+    imageValue: 'registry.example/spritz-claude-code@sha256:abc',
+    namespace: 'spritz-production',
+    ownerId: 'user-123',
+    activePreset: {
+      id: 'claude-code',
+      name: 'Claude Code',
+      image: 'registry.example/spritz-claude-code@sha256:abc',
+      namePrefix: 'claude-code',
+      env: [
+        {
+          name: 'ANTHROPIC_API_KEY',
+          valueFrom: {
+            secretKeyRef: {
+              name: 'spritz-claude-code-anthropic',
+              key: 'api-key',
+            },
+          },
+        },
+      ],
+    },
+    repoValue: '',
+    branchValue: '',
+    defaultRepoUrl: '',
+    defaultRepoBranch: '',
+    defaultRepoDir: '',
+    ttlValue: '',
+  });
+
+  assert.equal(payload.presetId, 'claude-code');
+  assert.equal(payload.namePrefix, 'claude-code');
+  assert.deepEqual(payload.spec.owner, { id: 'user-123' });
+  assert.equal(payload.spec.image, undefined);
+  assert.equal(payload.spec.env, undefined);
+});
+
+test('buildCreatePayload falls back to explicit image when preset is no longer aligned', async () => {
+  const require = createRequire(import.meta.url);
+  const { buildCreatePayload } = require('./create-form-request.js');
+
+  const payload = buildCreatePayload({
+    name: '',
+    imageValue: 'registry.example/custom-image:latest',
+    activePreset: {
+      id: 'claude-code',
+      name: 'Claude Code',
+      image: 'registry.example/spritz-claude-code@sha256:abc',
+      namePrefix: 'claude-code',
+    },
+    repoValue: '',
+    branchValue: '',
+    defaultRepoUrl: '',
+    defaultRepoBranch: '',
+    defaultRepoDir: '',
+    ttlValue: '',
+  });
+
+  assert.equal(payload.presetId, undefined);
+  assert.equal(payload.spec.image, 'registry.example/custom-image:latest');
+});

--- a/ui/public/preset-panel.js
+++ b/ui/public/preset-panel.js
@@ -12,8 +12,6 @@
       presets,
       hideRepoInputs,
       applyRepoDefaults,
-      normalizePresetEnv,
-      setActivePresetEnv,
       setActivePreset,
     } = options || {};
 
@@ -72,14 +70,12 @@
       if (branchInput && preset.branch !== undefined) branchInput.value = preset.branch || '';
       if (ttlInput && preset.ttl !== undefined) ttlInput.value = preset.ttl || '';
       help.textContent = preset.description || '';
-      setActivePresetEnv(typeof normalizePresetEnv === 'function' ? normalizePresetEnv(preset.env) : null);
       if (typeof setActivePreset === 'function') setActivePreset(preset);
     };
 
     const reset = () => {
       select.value = '';
       help.textContent = '';
-      setActivePresetEnv(null);
       if (typeof setActivePreset === 'function') setActivePreset(null);
     };
 

--- a/ui/public/preset-panel.test.mjs
+++ b/ui/public/preset-panel.test.mjs
@@ -151,7 +151,6 @@ test('setupPresetPanel injects the preset selector and updates image fields', as
   const { setupPresetPanel } = require('./preset-panel.js');
 
   const { document, form, imageInput, repoInput, branchInput, ttlInput } = buildFormFixture();
-  let activeEnv = null;
   let activePreset = null;
   let repoDefaultsApplied = 0;
   const presets = [
@@ -183,12 +182,6 @@ test('setupPresetPanel injects the preset selector and updates image fields', as
     applyRepoDefaults() {
       repoDefaultsApplied += 1;
     },
-    normalizePresetEnv(env) {
-      return env;
-    },
-    setActivePresetEnv(env) {
-      activeEnv = env;
-    },
     setActivePreset(preset) {
       activePreset = preset;
     },
@@ -203,7 +196,6 @@ test('setupPresetPanel injects the preset selector and updates image fields', as
   assert.equal(repoInput.value, 'https://example.com/a.git');
   assert.equal(branchInput.value, 'main');
   assert.equal(ttlInput.value, '8h');
-  assert.deepEqual(activeEnv, [{ name: 'FOO', value: 'bar' }]);
   assert.equal(activePreset?.name, 'Starter Devbox');
   assert.equal(form.querySelector('.preset-help').textContent, 'Starter image');
 
@@ -214,14 +206,12 @@ test('setupPresetPanel injects the preset selector and updates image fields', as
   assert.equal(repoInput.value, 'https://example.com/b.git');
   assert.equal(branchInput.value, 'staging');
   assert.equal(ttlInput.value, '12h');
-  assert.deepEqual(activeEnv, [{ name: 'BAZ', value: 'qux' }]);
   assert.equal(activePreset?.name, 'OpenClaw Devbox');
   assert.equal(form.querySelector('.preset-help').textContent, 'OpenClaw image');
 
   controller.reset();
   assert.equal(presetSelect.value, '');
   assert.equal(form.querySelector('.preset-help').textContent, '');
-  assert.equal(activeEnv, null);
   assert.equal(activePreset, null);
 });
 
@@ -256,10 +246,6 @@ test('setupPresetPanel restores a saved preset selection and falls back to custo
     presets,
     hideRepoInputs: false,
     applyRepoDefaults() {},
-    normalizePresetEnv() {
-      return null;
-    },
-    setActivePresetEnv() {},
     setActivePreset(preset) {
       activePreset = preset;
     },
@@ -304,10 +290,6 @@ test('setupPresetPanel clears hidden repo defaults when a preset explicitly owns
     presets,
     hideRepoInputs: true,
     applyRepoDefaults() {},
-    normalizePresetEnv(env) {
-      return env;
-    },
-    setActivePresetEnv() {},
     setActivePreset() {},
   });
 


### PR DESCRIPTION
## Summary
- keep preset-backed creates on the preset path instead of flattening secret-backed env into raw form values
- move create payload shaping into a dedicated helper with tests
- stop the browser from stripping secretKeyRef env entries for Claude Code and similar presets

## Testing
- node --test ui/public/*.test.mjs
- node --check ui/public/app.js ui/public/create-form-request.js ui/public/preset-panel.js