### PR TITLE
test(e2e): add ACP preset smoke harness

### DIFF
--- a/e2e/acp-smoke-lib.mjs
+++ b/e2e/acp-smoke-lib.mjs
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process';
 import { createRequire } from 'node:module';
 import net from 'node:net';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -10,6 +11,8 @@ const cliRequire = createRequire(new URL('../cli/package.json', import.meta.url)
 
 const defaultPromptTemplate = 'Reply with the exact token {{token}} and nothing else.';
 const defaultTimeoutSeconds = 300;
+const defaultACPPort = 2529;
+const defaultACPPath = '/';
 
 function normalizePresetID(value) {
   return String(value || '')
@@ -50,6 +53,8 @@ export function parseSmokeArgs(argv, env = process.env) {
   const values = {
     ownerId: env.SPRITZ_SMOKE_OWNER_ID || '',
     namespace: env.SPRITZ_SMOKE_NAMESPACE || env.SPRITZ_NAMESPACE || '',
+    apiUrl: env.SPRITZ_SMOKE_API_URL || '',
+    bearerToken: env.SPRITZ_SMOKE_BEARER_TOKEN || '',
     presets: parsePresetList(env.SPRITZ_SMOKE_PRESETS || ''),
     timeoutSeconds: defaultTimeoutSeconds,
     keep: false,
@@ -103,6 +108,12 @@ export function parseSmokeArgs(argv, env = process.env) {
   if (!values.ownerId.trim()) {
     throw new Error('--owner-id is required');
   }
+  if (!String(values.apiUrl).trim()) {
+    throw new Error('SPRITZ_SMOKE_API_URL is required');
+  }
+  if (!String(values.bearerToken).trim()) {
+    throw new Error('SPRITZ_SMOKE_BEARER_TOKEN is required');
+  }
   if (!values.presets.length) {
     throw new Error('--presets is required');
   }
@@ -111,6 +122,43 @@ export function parseSmokeArgs(argv, env = process.env) {
   }
 
   return { values, help: false };
+}
+
+/**
+ * Build an isolated spz environment that cannot inherit ambient auth or profile state.
+ */
+export function buildSmokeSpzEnvironment(baseEnv = process.env, options = {}) {
+  const env = { ...baseEnv };
+  const keysToClear = [
+    'SPRITZ_API_URL',
+    'SPRITZ_BEARER_TOKEN',
+    'SPRITZ_PROFILE',
+    'SPRITZ_OWNER_ID',
+    'SPRITZ_USER_ID',
+    'SPRITZ_USER_EMAIL',
+    'SPRITZ_USER_TEAMS',
+    'SPRITZ_NAMESPACE',
+    'SPRITZ_CONFIG_DIR',
+  ];
+  for (const key of keysToClear) {
+    delete env[key];
+  }
+  const apiUrl = String(options.apiUrl || '').trim();
+  const bearerToken = String(options.bearerToken || '').trim();
+  if (!apiUrl) {
+    throw new Error('smoke environment requires an explicit apiUrl');
+  }
+  if (!bearerToken) {
+    throw new Error('smoke environment requires an explicit bearerToken');
+  }
+  env.SPRITZ_API_URL = apiUrl;
+  env.SPRITZ_BEARER_TOKEN = bearerToken;
+  if (String(options.namespace || '').trim()) {
+    env.SPRITZ_NAMESPACE = String(options.namespace).trim();
+  }
+  env.SPRITZ_CONFIG_DIR = String(options.configDir || '').trim()
+    || path.join(os.tmpdir(), `spritz-smoke-config-${process.pid}-${Date.now()}`);
+  return env;
 }
 
 /**
@@ -164,6 +212,18 @@ export function joinACPTextChunks(values) {
  */
 export function buildSmokeToken(presetId) {
   return `spritz-smoke-${normalizePresetID(presetId) || 'workspace'}`;
+}
+
+/**
+ * Resolve the ACP endpoint advertised by a ready spritz, falling back to the reserved defaults.
+ */
+export function resolveACPEndpoint(spritz) {
+  const endpoint = spritz?.status?.acp?.endpoint || {};
+  const parsedPort = Number.parseInt(String(endpoint.port ?? ''), 10);
+  const port = Number.isFinite(parsedPort) && parsedPort > 0 ? parsedPort : defaultACPPort;
+  const rawPath = String(endpoint.path || defaultACPPath).trim();
+  const pathValue = rawPath ? (rawPath.startsWith('/') ? rawPath : `/${rawPath}`) : defaultACPPath;
+  return { port, path: pathValue };
 }
 
 /**

--- a/e2e/acp-smoke-lib.test.mjs
+++ b/e2e/acp-smoke-lib.test.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 
 import {
   assertSmokeCreateResponse,
+  buildSmokeSpzEnvironment,
   buildIdempotencyKey,
   buildSmokeToken,
   extractACPText,
@@ -12,6 +13,7 @@ import {
   joinACPTextChunks,
   parseSmokeArgs,
   parsePresetList,
+  resolveACPEndpoint,
   resolveWebSocketConstructor,
   resolveSpzCommand,
   runCommand,
@@ -42,22 +44,67 @@ test('parsePresetList normalizes comma-delimited values', () => {
 
 test('parseSmokeArgs requires explicit presets instead of assuming example ids', () => {
   assert.throws(
-    () => parseSmokeArgs(['--owner-id', 'user-123'], {}),
+    () => parseSmokeArgs(['--owner-id', 'user-123'], { SPRITZ_SMOKE_API_URL: 'https://example.com/api', SPRITZ_SMOKE_BEARER_TOKEN: 'token' }),
     /--presets is required/,
   );
 });
 
 test('parseSmokeArgs normalizes provided preset ids', () => {
-  const { values } = parseSmokeArgs(['--owner-id', 'user-123', '--presets', 'OPENCLAW,Claude Code'], {});
+  const { values } = parseSmokeArgs(
+    ['--owner-id', 'user-123', '--presets', 'OPENCLAW,Claude Code'],
+    { SPRITZ_SMOKE_API_URL: 'https://example.com/api', SPRITZ_SMOKE_BEARER_TOKEN: 'token' },
+  );
   assert.deepEqual(values.presets, ['openclaw', 'claude-code']);
 });
 
 test('parseSmokeArgs prefers the smoke namespace env over the generic namespace env', () => {
   const { values } = parseSmokeArgs(['--owner-id', 'user-123', '--presets', 'openclaw'], {
+    SPRITZ_SMOKE_API_URL: 'https://example.com/api',
+    SPRITZ_SMOKE_BEARER_TOKEN: 'token',
     SPRITZ_NAMESPACE: 'generic-ns',
     SPRITZ_SMOKE_NAMESPACE: 'smoke-ns',
   });
   assert.equal(values.namespace, 'smoke-ns');
+});
+
+test('parseSmokeArgs requires an explicit smoke api url and bearer token', () => {
+  assert.throws(
+    () => parseSmokeArgs(['--owner-id', 'user-123', '--presets', 'openclaw'], {}),
+    /SPRITZ_SMOKE_API_URL is required/,
+  );
+  assert.throws(
+    () => parseSmokeArgs(
+      ['--owner-id', 'user-123', '--presets', 'openclaw'],
+      { SPRITZ_SMOKE_API_URL: 'https://example.com/api' },
+    ),
+    /SPRITZ_SMOKE_BEARER_TOKEN is required/,
+  );
+});
+
+test('buildSmokeSpzEnvironment strips ambient spritz auth and profile state', () => {
+  const env = buildSmokeSpzEnvironment(
+    {
+      PATH: process.env.PATH,
+      SPRITZ_API_URL: 'http://ambient/api',
+      SPRITZ_BEARER_TOKEN: 'ambient-token',
+      SPRITZ_PROFILE: 'ambient-profile',
+      SPRITZ_NAMESPACE: 'ambient-ns',
+      SPRITZ_USER_ID: 'ambient-user',
+    },
+    {
+      apiUrl: 'https://smoke.example.com/api',
+      bearerToken: 'smoke-token',
+      namespace: 'smoke-ns',
+      configDir: '/tmp/smoke-config',
+    },
+  );
+
+  assert.equal(env.SPRITZ_API_URL, 'https://smoke.example.com/api');
+  assert.equal(env.SPRITZ_BEARER_TOKEN, 'smoke-token');
+  assert.equal(env.SPRITZ_NAMESPACE, 'smoke-ns');
+  assert.equal(env.SPRITZ_CONFIG_DIR, '/tmp/smoke-config');
+  assert.equal(env.SPRITZ_PROFILE, undefined);
+  assert.equal(env.SPRITZ_USER_ID, undefined);
 });
 
 test('extractACPText flattens nested content blocks', () => {
@@ -74,6 +121,23 @@ test('joinACPTextChunks preserves chunked tokens without inserted separators', (
 test('buildIdempotencyKey and smoke token normalize preset names', () => {
   assert.equal(buildIdempotencyKey('spritz smoke', 'claude-code'), 'spritz-smoke-claude-code');
   assert.equal(buildSmokeToken('openclaw'), 'spritz-smoke-openclaw');
+});
+
+test('resolveACPEndpoint prefers discovered ACP port/path and normalizes the path', () => {
+  assert.deepEqual(
+    resolveACPEndpoint({
+      status: {
+        acp: {
+          endpoint: {
+            port: 9421,
+            path: 'rpc',
+          },
+        },
+      },
+    }),
+    { port: 9421, path: '/rpc' },
+  );
+  assert.deepEqual(resolveACPEndpoint({}), { port: 2529, path: '/' });
 });
 
 test('resolveWebSocketConstructor returns a usable client constructor', () => {

--- a/e2e/acp-smoke.mjs
+++ b/e2e/acp-smoke.mjs
@@ -6,6 +6,7 @@ import net from 'node:net';
 
 import {
   assertSmokeCreateResponse,
+  buildSmokeSpzEnvironment,
   buildIdempotencyKey,
   buildSmokeToken,
   extractACPText,
@@ -13,6 +14,7 @@ import {
   isForbiddenFailure,
   joinACPTextChunks,
   parseSmokeArgs,
+  resolveACPEndpoint,
   resolveSpzCommand,
   resolveWebSocketConstructor,
   runCommand,
@@ -35,17 +37,13 @@ function printUsage(code) {
     '  --idempotency-prefix <s> Prefix used to derive idempotency keys for smoke creates',
     '  --keep                   Keep created workspaces instead of deleting them',
     '  --help                   Show this message',
+    '',
+    'Environment:',
+    '  SPRITZ_SMOKE_API_URL       Required API base for the service-principal smoke client',
+    '  SPRITZ_SMOKE_BEARER_TOKEN  Required bearer token for the service-principal smoke client',
   ];
   console.error(lines.join('\n'));
   process.exit(code);
-}
-
-function buildSpzEnvironment(namespace) {
-  const env = { ...process.env };
-  if (process.env.SPRITZ_SMOKE_API_URL) env.SPRITZ_API_URL = process.env.SPRITZ_SMOKE_API_URL;
-  if (process.env.SPRITZ_SMOKE_BEARER_TOKEN) env.SPRITZ_BEARER_TOKEN = process.env.SPRITZ_SMOKE_BEARER_TOKEN;
-  if (namespace) env.SPRITZ_NAMESPACE = namespace;
-  return env;
 }
 
 async function runSpz(spzCommand, subcommandArgs, options = {}) {
@@ -163,9 +161,9 @@ async function startPortForward(namespace, serviceName, targetPort) {
   }
 }
 
-async function connectACP(localPort, timeoutSeconds) {
+async function connectACP(localPort, acpPath, timeoutSeconds) {
   const WebSocket = resolveWebSocketConstructor();
-  const socket = new WebSocket(`ws://127.0.0.1:${localPort}/`);
+  const socket = new WebSocket(`ws://127.0.0.1:${localPort}${acpPath}`);
   const pending = new Map();
   const updates = [];
   const rpcTimeoutMs = Math.max(timeoutSeconds * 1000, 1000);
@@ -209,12 +207,12 @@ function buildPromptText(template, token) {
   return String(template || defaultPromptTemplate).replaceAll('{{token}}', token);
 }
 
-async function promptWorkspace(namespace, name, presetId, promptTemplate, timeoutSeconds) {
+async function promptWorkspace(namespace, name, presetId, promptTemplate, timeoutSeconds, endpoint) {
   const token = buildSmokeToken(presetId);
-  const portForward = await startPortForward(namespace, name, 2529);
+  const portForward = await startPortForward(namespace, name, endpoint.port);
   let client;
   try {
-    client = await connectACP(portForward.localPort, timeoutSeconds);
+    client = await connectACP(portForward.localPort, endpoint.path, timeoutSeconds);
     const init = await client.rpc('init-1', 'initialize', {
       protocolVersion: 1,
       clientCapabilities: {},
@@ -327,7 +325,11 @@ async function main() {
   }
   const options = parsed.values;
   const spzCommand = resolveSpzCommand(process.env);
-  const env = buildSpzEnvironment(options.namespace);
+  const env = buildSmokeSpzEnvironment(process.env, {
+    apiUrl: options.apiUrl,
+    bearerToken: options.bearerToken,
+    namespace: options.namespace,
+  });
   const createdWorkspaces = [];
 
   try {
@@ -380,14 +382,23 @@ async function main() {
         }
       }
 
-      await waitForWorkspace(namespace, workspaceName, options.timeoutSeconds);
-      const acpResult = await promptWorkspace(namespace, workspaceName, presetId, options.promptTemplate, options.timeoutSeconds);
+      const workspaceState = await waitForWorkspace(namespace, workspaceName, options.timeoutSeconds);
+      const acpEndpoint = resolveACPEndpoint(workspaceState.spritz);
+      const acpResult = await promptWorkspace(
+        namespace,
+        workspaceName,
+        presetId,
+        options.promptTemplate,
+        options.timeoutSeconds,
+        acpEndpoint,
+      );
       console.log(JSON.stringify({
         presetId,
         workspaceName,
         namespace,
         chatUrl: createResponse.chatUrl,
         workspaceUrl: createResponse.workspaceUrl,
+        acpEndpoint,
         stopReason: acpResult.stopReason,
         assistantText: acpResult.assistantText,
       }, null, 2));


### PR DESCRIPTION
## Summary
- add a reusable ACP smoke helper library for service-principal workspace provisioning checks
- add an executable end-to-end smoke script that exercises create, idempotent replay, deny rules, readiness, and ACP prompting for OpenClaw and Claude Code
- cover the harness-specific parsing and failure summarization behavior with unit tests

## Validation
- node --test e2e/acp-smoke-lib.test.mjs
- node --check e2e/acp-smoke-lib.mjs && node --check e2e/acp-smoke.mjs
- node e2e/acp-smoke.mjs --owner-id <redacted> --namespace spritz-production --timeout-seconds 420 --idempotency-prefix preset-acp-smoke-prod-2 (via local spritz-api port-forward and live Zenobot service token)
