### PR TITLE
fix(ui): align docker build with ui context

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,13 +1,13 @@
 FROM node:22-alpine AS build
 
-WORKDIR /workspace/ui
+WORKDIR /workspace
 
 RUN corepack enable
 
-COPY ui/package.json ui/pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 
-COPY ui/ ./
+COPY . ./
 RUN pnpm build
 
 FROM nginxinc/nginx-unprivileged:1.27-alpine
@@ -15,9 +15,9 @@ FROM nginxinc/nginx-unprivileged:1.27-alpine
 USER root
 RUN apk add --no-cache sed
 
-COPY --from=build /workspace/ui/dist/ /usr/share/nginx/html/
-COPY ui/nginx.conf /etc/nginx/conf.d/default.conf
-COPY ui/entrypoint.sh /entrypoint.sh
+COPY --from=build /workspace/dist/ /usr/share/nginx/html/
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY entrypoint.sh /entrypoint.sh
 RUN chown -R 101:101 /usr/share/nginx/html /entrypoint.sh /etc/nginx/conf.d/default.conf
 
 ENV SPRITZ_API_BASE_URL=/api


### PR DESCRIPTION
## Summary
- fix the Spritz UI Dockerfile to work with the ui-only build context used by platform deploy workflows
- keep the TypeScript UI build output and runtime layout unchanged
- validate the exact UI package, test, and Docker build path used in CI

## Testing
- cd /Users/onur/repos/spritz/ui && pnpm build && pnpm typecheck && pnpm test && docker build -t spritz-ui-ts-test .
- cd /Users/onur/repos/spritz && bash -n ui/entrypoint.sh
- cd /Users/onur/repos/spritz && git diff --check