### PR TITLE
fix(openclaw): support current ACP bundle layout

### DIFF
--- a/images/examples/openclaw/generate-openclaw-acp-compat.mjs
+++ b/images/examples/openclaw/generate-openclaw-acp-compat.mjs
@@ -7,27 +7,53 @@ import { pathToFileURL } from "node:url";
 export const ACP_CLI_COMPAT_BASENAME = "spritz-acp-cli-compat.js";
 export const ACP_COMPAT_BASENAME = "spritz-acp-compat.js";
 
-function requireMatch(source, pattern, label) {
-  const match = source.match(pattern);
-  if (!match?.[1]) {
-    throw new Error(`Failed to resolve ${label} from the installed OpenClaw ACP bundle.`);
-  }
-  return match[1];
+function parseNamedImports(source) {
+  return [...source.matchAll(/import\s+\{([\s\S]*?)\}\s+from\s+["']\.\/([^"']+)["']/g)].map(
+    (match) => ({
+      basename: match[2],
+      specifiers: match[1]
+        .split(",")
+        .map((part) => part.trim())
+        .filter(Boolean)
+        .map((part) => {
+          const aliasMatch = part.match(/^(.+?)\s+as\s+([A-Za-z_$][\w$]*)$/);
+          if (aliasMatch) {
+            return {
+              imported: aliasMatch[1].trim(),
+              local: aliasMatch[2].trim(),
+            };
+          }
+          return {
+            imported: part,
+            local: part,
+          };
+        }),
+    }),
+  );
 }
 
-function findMatch(source, pattern) {
-  return source.match(pattern)?.[1] ?? null;
-}
-
-function findGatewayConstantsBundle(acpCliSource) {
-  const importMatches = [...acpCliSource.matchAll(/import\s+\{([^}]*)\}\s+from\s+"\.\/([^"]+)"/g)];
-  for (const match of importMatches) {
-    const names = match[1];
-    if (names.includes("GATEWAY_CLIENT_NAMES") && names.includes("GATEWAY_CLIENT_MODES")) {
-      return match[2];
+function findImportBasename(namedImports, predicate) {
+  for (const entry of namedImports) {
+    const locals = new Set(entry.specifiers.map((specifier) => specifier.local));
+    if (predicate(locals)) {
+      return entry.basename;
     }
   }
   return null;
+}
+
+function requireImportBasename(namedImports, localNames, label) {
+  const basename = findImportBasename(namedImports, (locals) =>
+    localNames.every((localName) => locals.has(localName)),
+  );
+  if (!basename) {
+    throw new Error(`Failed to resolve ${label} from the installed OpenClaw ACP bundle.`);
+  }
+  return basename;
+}
+
+function findImportBasenameByLocalName(namedImports, localName) {
+  return findImportBasename(namedImports, (locals) => locals.has(localName));
 }
 
 function assertReadableFile(filePath, label) {
@@ -60,23 +86,24 @@ export function selectAcpCliBundle(distDir) {
 }
 
 export function resolveAcpCliDependencies(acpCliSource) {
+  const namedImports = parseNamedImports(acpCliSource);
   return {
-    callBasename: requireMatch(
-      acpCliSource,
-      /import\s+\{[^}]*GatewayClient[^}]*buildGatewayConnectionDetails[^}]*\}\s+from\s+"\.\/([^"]+)"/,
+    callBasename: requireImportBasename(
+      namedImports,
+      ["GatewayClient", "buildGatewayConnectionDetails"],
       "GatewayClient/buildGatewayConnectionDetails bundle",
     ),
-    connectionAuthBasename: requireMatch(
-      acpCliSource,
-      /import\s+\{[^}]*resolveGatewayConnectionAuth[^}]*\}\s+from\s+"\.\/([^"]+)"/,
+    connectionAuthBasename: requireImportBasename(
+      namedImports,
+      ["resolveGatewayConnectionAuth"],
       "resolveGatewayConnectionAuth bundle",
     ),
-    gatewayConstantsBasename:
-      findGatewayConstantsBundle(acpCliSource) ??
-      requireMatch(acpCliSource, /$^/, "gateway client constants bundle"),
-    loadConfigBasename:
-      findMatch(acpCliSource, /import\s+\{[^}]*loadConfig[^}]*\}\s+from\s+"\.\/([^"]+)"/) ??
-      "index.js",
+    gatewayConstantsBasename: requireImportBasename(
+      namedImports,
+      ["GATEWAY_CLIENT_NAMES", "GATEWAY_CLIENT_MODES"],
+      "gateway client constants bundle",
+    ),
+    loadConfigBasename: findImportBasenameByLocalName(namedImports, "loadConfig") ?? "index.js",
   };
 }
 

--- a/images/examples/openclaw/generate-openclaw-acp-compat.test.mjs
+++ b/images/examples/openclaw/generate-openclaw-acp-compat.test.mjs
@@ -63,6 +63,19 @@ test("resolveAcpCliDependencies supports loadConfig and gateway constants from t
   });
 });
 
+test("resolveAcpCliDependencies supports the current published OpenClaw ACP import layout", () => {
+  const dependencies = resolveAcpCliDependencies(`
+    import { Cm as GATEWAY_CLIENT_MODES, Eg as isKnownCoreToolId, Es as buildGatewayConnectionDetails, Wt as resolveGatewayConnectionAuth, u_ as loadConfig, uv as VERSION, wm as GATEWAY_CLIENT_NAMES, zs as GatewayClient, zv as listThinkingLevels } from "./reply-demo.js";
+  `);
+
+  assert.deepEqual(dependencies, {
+    callBasename: "reply-demo.js",
+    connectionAuthBasename: "reply-demo.js",
+    gatewayConstantsBasename: "reply-demo.js",
+    loadConfigBasename: "reply-demo.js",
+  });
+});
+
 test("generateOpenclawAcpCompat writes stable compat modules for the installed package", async () => {
   const packageRoot = makeTempPackageRoot();
   const distDir = path.join(packageRoot, "dist");


### PR DESCRIPTION
## Summary
- make the OpenClaw ACP compat generator resolve bundles by named imports instead of import order
- handle the current published `openclaw@latest` layout where the needed symbols come from one hashed bundle
- add a regression test for that published layout

## Why
The OpenClaw example Docker build currently installs `openclaw@latest`, but the committed compat generator assumes `GatewayClient` appears before `buildGatewayConnectionDetails` in the ACP CLI import list. The current published package no longer has that order, so the image build fails before the compat files are generated.

## Verification
- `node --test images/examples/openclaw/generate-openclaw-acp-compat.test.mjs`
- `docker build -f images/examples/openclaw/Dockerfile -t spritz-openclaw:pr1-check images`