### PR TITLE
fix(openclaw-acp): suppress silent no-reply output

### DIFF
--- a/docs/2026-04-16-slack-gateway-no-reply-outcome-architecture.md
+++ b/docs/2026-04-16-slack-gateway-no-reply-outcome-architecture.md
@@ -16,6 +16,13 @@ reply, the gateway should usually send nothing to Slack.
 
 This document defines the long-term contract for that behavior.
 
+The verified ownership boundary is:
+
+- OpenClaw-specific silent control tokens such as `NO_REPLY` must be consumed
+  in the OpenClaw ACP bridge before they become ACP-visible assistant text
+- the Slack gateway should stay ACP-generic and only decide between "deliver a
+  visible message", "deliver nothing", and "surface a real failure"
+
 Related docs:
 
 - [Slack Channel Gateway Implementation Plan](2026-03-24-slack-channel-gateway-implementation-plan.md)
@@ -83,6 +90,14 @@ For Slack, that means:
 - `hard_error`: post the generic failure message only when product policy says
   the user should see one
 
+The ownership rule is:
+
+- OpenClaw semantics belong in the OpenClaw ACP bridge
+- channel transport semantics belong in the Slack gateway
+
+That means literal `NO_REPLY` handling should not be owned primarily by the
+Slack gateway.
+
 ## Why This Is the Right Abstraction
 
 The Slack gateway is a delivery adapter. Its job is to:
@@ -136,6 +151,33 @@ Recommended shape:
 
 The internal representation does not need to match this JSON exactly, but the
 typed semantics should.
+
+## Verified Current Behavior
+
+The current system has two different layers:
+
+1. OpenClaw, which has a real silent sentinel token: `NO_REPLY`
+2. Spritz Slack gateway, which consumes ACP `agent_message_chunk` updates
+
+Verified facts:
+
+- OpenClaw treats exact `NO_REPLY` as a silent reply token and suppresses it in
+  its own delivery layer
+- upstream OpenClaw ACP behavior can still forward raw assistant text blocks
+  through ACP
+- the Spritz OpenClaw ACP wrapper currently forwards assistant text from
+  transcript replay as `agent_message_chunk` without stripping `NO_REPLY`
+- the Spritz Slack gateway currently treats only empty assembled assistant text
+  as `no_reply`
+
+So the current bug is not "Slack needs provider-specific Kimi logic."
+
+The current bug is:
+
+- an OpenClaw-specific silent token can cross the OpenClaw-to-ACP boundary as
+  visible assistant text
+- once that happens, the Slack gateway has no typed signal telling it that the
+  outcome was intentionally silent
 
 ### Required fields
 
@@ -225,7 +267,9 @@ no-message completions, not real failures.
 
 The current Slack gateway flow in
 [`integrations/slack-gateway/slack_events.go`](/Users/onur/repos/spritz/integrations/slack-gateway/slack_events.go)
-still treats part of this space as an error path.
+still treats part of this space as an error path, and the current OpenClaw ACP
+wrapper does not fully normalize OpenClaw silent control output before it
+reaches the gateway.
 
 Today, after prompting the runtime:
 
@@ -238,8 +282,12 @@ That behavior is reasonable for true failures, but wrong for the specific case
 where the prompt completed and the only issue is missing visible output.
 
 The implementation gap is not "Slack needs to understand one model provider."
-The gap is "the runtime result contract does not cleanly distinguish no visible
-reply from hard failure."
+The gap is:
+
+- the OpenClaw ACP bridge does not fully translate OpenClaw silent semantics
+  into an ACP-visible no-reply outcome
+- the runtime result contract does not cleanly distinguish no visible reply
+  from hard failure once the gateway receives the ACP stream
 
 ## Recommended Implementation Shape
 
@@ -253,6 +301,21 @@ instead of relying on a mixed interpretation of:
 - error presence
 
 That keeps the decision at the right layer.
+
+### 1a. Consume OpenClaw silent tokens in the ACP bridge
+
+For the OpenClaw-backed path specifically, the bridge that converts OpenClaw
+runtime events into ACP updates should own OpenClaw sentinel handling.
+
+Rules:
+
+- exact silent outputs such as `NO_REPLY` must not be emitted as visible
+  `agent_message_chunk` text
+- silent-token lead fragments must not leak during streaming
+- if OpenClaw produces no deliverable assistant text after normalization, the
+  bridge should complete the prompt without a visible assistant message
+
+This keeps OpenClaw-specific knowledge in the OpenClaw integration boundary.
 
 ### 2. Centralize empty-visible-output classification
 
@@ -273,6 +336,14 @@ The Slack gateway should only map typed outcomes to channel behavior:
 - post failure message
 
 This keeps the adapter simple and reusable.
+
+Defense in depth is still acceptable:
+
+- Slack gateway may suppress empty final text
+- Slack gateway may optionally guard against exact silent control tokens if
+  they somehow slip through
+
+But that guard should not be the primary owner of OpenClaw sentinel semantics.
 
 ### 4. Keep structured operator visibility
 
@@ -321,14 +392,19 @@ Required tests:
 
 1. runtime returns normal visible text
    - Slack gateway posts exactly one reply
-2. runtime completes with empty visible output
+2. OpenClaw ACP bridge receives exact `NO_REPLY`
+   - bridge emits no visible `agent_message_chunk`
+   - prompt resolves as a no-reply outcome
+3. OpenClaw ACP bridge receives silent-token lead fragments
+   - fragments do not leak into visible assistant output
+4. runtime completes with empty visible output
    - Slack gateway posts nothing
    - gateway reports success for delivery bookkeeping
-3. runtime fails before prompt completion
+5. runtime fails before prompt completion
    - Slack gateway follows the hard-failure path
-4. runtime fails after a typed `hard_error`
+6. runtime fails after a typed `hard_error`
    - Slack gateway posts the generic error message when configured to do so
-5. Slack post fails after `deliver_message`
+7. Slack post fails after `deliver_message`
    - gateway preserves existing retry and deduplication behavior
 
 Important assertion:
@@ -367,18 +443,23 @@ not as Slack-only conditional logic.
 
 ## Migration Plan
 
-1. Define the typed prompt delivery outcome in the conversation prompt layer.
-2. Update Slack gateway prompt handling to consume the typed result.
-3. Add regression tests for `no_reply`.
-4. Add outcome metrics and logs.
-5. Reuse the same contract in other channel adapters if and when needed.
+1. Normalize OpenClaw silent control output in the OpenClaw ACP bridge.
+2. Define or preserve a typed no-reply prompt delivery outcome in the prompt
+   layer.
+3. Update Slack gateway prompt handling to consume the typed result without
+   learning OpenClaw-specific sentinel rules.
+4. Add regression tests for bridge-level silent handling and gateway-level
+   no-reply handling.
+5. Add outcome metrics and logs.
+6. Reuse the same contract in other channel adapters if and when needed.
 
 ## Final Recommendation
 
 The production-ready fix is:
 
 - make `no_reply` a first-class outcome
-- classify empty visible output into that outcome centrally
+- consume OpenClaw `NO_REPLY` semantics in the OpenClaw ACP bridge
+- classify empty visible output into `no_reply` centrally
 - have Slack acknowledge the event and send nothing
 - reserve the generic Slack error message for real failures only
 

--- a/docs/2026-04-16-slack-gateway-no-reply-outcome-architecture.md
+++ b/docs/2026-04-16-slack-gateway-no-reply-outcome-architecture.md
@@ -1,0 +1,386 @@
+---
+date: 2026-04-16
+author: Onur Solmaz <onur@textcortex.com>
+title: Slack Gateway No-Reply Outcome Architecture
+tags: [spritz, slack, channel-gateway, runtime, error-handling, architecture]
+---
+
+## Overview
+
+Spritz should treat "the runtime produced no user-visible reply" as a normal,
+typed outcome instead of a gateway error.
+
+Today the Slack gateway can collapse this case into a generic public error
+message. That is the wrong product behavior. If the runtime produced no visible
+reply, the gateway should usually send nothing to Slack.
+
+This document defines the long-term contract for that behavior.
+
+Related docs:
+
+- [Slack Channel Gateway Implementation Plan](2026-03-24-slack-channel-gateway-implementation-plan.md)
+- [Unified Public Error Architecture](2026-04-03-unified-public-error-architecture.md)
+- [OpenClaw Integration](2026-03-13-openclaw-integration.md)
+
+## Problem
+
+The Slack gateway currently has a binary outcome model after it prompts the
+conversation runtime:
+
+- reply succeeded and a message is posted to Slack
+- prompt path failed and the gateway may post a generic internal error message
+
+That is too coarse.
+
+There is a third real-world outcome:
+
+- the runtime accepted and processed the prompt, but produced no user-visible
+  message
+
+This can happen for valid reasons, for example:
+
+- the runtime only emitted internal reasoning or trace material
+- the runtime intentionally decided not to answer
+- the runtime ended with no assistant text after filtering or normalization
+- a future backend supports explicit "no reply" behavior
+
+When that happens, posting a generic Slack error is misleading. Nothing may
+actually be broken. The runtime may have completed successfully and simply not
+produced deliverable content.
+
+## Goals
+
+- make "no visible reply" a first-class outcome in Spritz
+- stop posting false error messages to Slack for that outcome
+- keep true runtime or transport failures visible
+- make the contract reusable across channel gateways, not Slack-only in spirit
+- preserve observability so operators can distinguish `no_reply` from failures
+
+## Non-Goals
+
+- changing model behavior to always emit visible text
+- exposing internal reasoning or trace content to end users
+- inventing Slack-specific business logic for one backend only
+- suppressing genuine runtime, gateway, or transport errors
+
+## Core Decision
+
+Spritz should model delivery after a prompted conversation as three distinct
+outcomes:
+
+1. `deliver_message`
+2. `no_reply`
+3. `hard_error`
+
+The important rule is:
+
+- `no_reply` is not a public error
+
+For Slack, that means:
+
+- `deliver_message`: post the message
+- `no_reply`: do not post a message
+- `hard_error`: post the generic failure message only when product policy says
+  the user should see one
+
+## Why This Is the Right Abstraction
+
+The Slack gateway is a delivery adapter. Its job is to:
+
+- send user input to a conversation runtime
+- receive the runtime outcome
+- map that outcome to Slack delivery behavior
+
+The gateway should not infer that "empty visible output" means failure.
+
+That inference is unsafe because:
+
+- the runtime may have succeeded
+- the backend may intentionally support silent completion
+- "no visible output" and "internal execution failed" are semantically
+  different
+- users see a false signal when the adapter converts silence into an error
+
+The clean architecture is to make the runtime outcome explicit, then let the
+gateway handle each outcome deterministically.
+
+## Proposed Contract
+
+### Runtime prompt result
+
+The prompt path should return a typed result, not just `(reply, promptSent,
+err)`.
+
+Recommended shape:
+
+```json
+{
+  "type": "deliver_message",
+  "message": "Hello from the runtime."
+}
+```
+
+```json
+{
+  "type": "no_reply",
+  "reason": "empty_visible_output"
+}
+```
+
+```json
+{
+  "type": "hard_error",
+  "publicMessage": "I hit an internal error while processing that request."
+}
+```
+
+The internal representation does not need to match this JSON exactly, but the
+typed semantics should.
+
+### Required fields
+
+- `type`: one of `deliver_message`, `no_reply`, `hard_error`
+
+### Outcome-specific fields
+
+For `deliver_message`:
+
+- `message`: non-empty user-visible text
+
+For `no_reply`:
+
+- `reason`: stable machine-readable reason such as `empty_visible_output`
+- optional operator metadata for logs and metrics
+
+For `hard_error`:
+
+- internal cause information for logs
+- optional public copy override when the channel should show one
+
+## Slack Delivery Rules
+
+### `deliver_message`
+
+The gateway posts the returned message into the correct Slack thread.
+
+Rules:
+
+- message must be non-empty after final normalization
+- this is the only outcome that produces a normal assistant reply post
+
+### `no_reply`
+
+The gateway acknowledges the Slack event and posts nothing.
+
+Rules:
+
+- do not post the generic internal error message
+- do not synthesize filler text such as "No response"
+- do record structured logs and metrics
+
+This is the key product fix.
+
+### `hard_error`
+
+The gateway handles the failure through the existing public error policy.
+
+Rules:
+
+- only real failures should reach this outcome
+- the generic Slack failure message remains acceptable here
+- transport failures and runtime execution failures stay visible
+
+## What Counts as `no_reply`
+
+Spritz should classify the following cases as `no_reply` unless product policy
+explicitly says otherwise:
+
+- the runtime completed but returned no assistant-visible text
+- the runtime output reduced to empty content after normalization
+- the runtime emitted internal-only material that the channel adapter cannot
+  deliver as a user message
+- the runtime explicitly signaled a silent completion outcome
+
+The key test is simple:
+
+- was there a successful prompt execution with no deliverable user-visible
+  message?
+
+If yes, the outcome is `no_reply`, not `hard_error`.
+
+## What Does Not Count as `no_reply`
+
+These are still `hard_error`:
+
+- the prompt request could not be sent
+- the runtime failed before completing the request
+- the session could not be bootstrapped
+- the gateway could not resolve the channel session
+- the gateway had a real Slack post failure after deciding to deliver a message
+
+That boundary matters because silent suppression is only correct for successful
+no-message completions, not real failures.
+
+## Current Gap in the Slack Gateway
+
+The current Slack gateway flow in
+[`integrations/slack-gateway/slack_events.go`](/Users/onur/repos/spritz/integrations/slack-gateway/slack_events.go)
+still treats part of this space as an error path.
+
+Today, after prompting the runtime:
+
+- if the prompt was sent and the path still returns an error
+- the gateway can overwrite the reply with:
+  `I hit an internal error while processing that request.`
+- then it posts that message back to Slack
+
+That behavior is reasonable for true failures, but wrong for the specific case
+where the prompt completed and the only issue is missing visible output.
+
+The implementation gap is not "Slack needs to understand one model provider."
+The gap is "the runtime result contract does not cleanly distinguish no visible
+reply from hard failure."
+
+## Recommended Implementation Shape
+
+### 1. Introduce a typed delivery outcome in the prompt path
+
+Refactor the conversation prompt flow so it returns a typed outcome object
+instead of relying on a mixed interpretation of:
+
+- reply text
+- prompt-sent bookkeeping
+- error presence
+
+That keeps the decision at the right layer.
+
+### 2. Centralize empty-visible-output classification
+
+One owning function should decide whether the runtime result is:
+
+- `deliver_message`
+- `no_reply`
+- `hard_error`
+
+Do not duplicate that logic at multiple Slack callsites.
+
+### 3. Keep Slack posting logic dumb
+
+The Slack gateway should only map typed outcomes to channel behavior:
+
+- post message
+- post nothing
+- post failure message
+
+This keeps the adapter simple and reusable.
+
+### 4. Keep structured operator visibility
+
+`no_reply` must still be visible operationally.
+
+Record:
+
+- outcome type
+- normalized reason
+- conversation ID
+- channel ID
+- message timestamp
+- whether the prompt was accepted
+
+That gives operators evidence without turning silent completions into public
+errors.
+
+## Observability
+
+Spritz should track `no_reply` explicitly.
+
+Recommended logs:
+
+- prompt completed with `delivery_outcome=no_reply`
+- stable reason such as `empty_visible_output`
+- conversation and channel identifiers
+
+Recommended metrics:
+
+- `channel_gateway_prompt_outcomes_total{provider="slack",type="deliver_message"}`
+- `channel_gateway_prompt_outcomes_total{provider="slack",type="no_reply"}`
+- `channel_gateway_prompt_outcomes_total{provider="slack",type="hard_error"}`
+
+Recommended alerts:
+
+- alert on sustained `hard_error` rate
+- do not alert on normal low-volume `no_reply`
+- investigate `no_reply` spikes because they may reveal runtime regressions or
+  policy mismatches
+
+## Testing Strategy
+
+This behavior needs direct regression coverage.
+
+Required tests:
+
+1. runtime returns normal visible text
+   - Slack gateway posts exactly one reply
+2. runtime completes with empty visible output
+   - Slack gateway posts nothing
+   - gateway reports success for delivery bookkeeping
+3. runtime fails before prompt completion
+   - Slack gateway follows the hard-failure path
+4. runtime fails after a typed `hard_error`
+   - Slack gateway posts the generic error message when configured to do so
+5. Slack post fails after `deliver_message`
+   - gateway preserves existing retry and deduplication behavior
+
+Important assertion:
+
+- the empty-output case must not post `I hit an internal error while
+  processing that request.`
+
+## Interaction With Public Error Policy
+
+This design fits the broader public error architecture.
+
+The public error model should be used when something user-visible failed.
+`no_reply` is different:
+
+- it is a valid delivery outcome
+- it may still deserve operator visibility
+- it does not automatically deserve a user-facing error message
+
+In plain terms:
+
+- no visible answer is not the same thing as a visible failure
+
+## Future Extension
+
+Although Slack is the immediate driver, this should be treated as a shared
+channel-gateway contract.
+
+Other adapters may also need to distinguish:
+
+- message to send
+- nothing to send
+- actual failure
+
+That argues for defining the outcome in the shared conversation delivery layer,
+not as Slack-only conditional logic.
+
+## Migration Plan
+
+1. Define the typed prompt delivery outcome in the conversation prompt layer.
+2. Update Slack gateway prompt handling to consume the typed result.
+3. Add regression tests for `no_reply`.
+4. Add outcome metrics and logs.
+5. Reuse the same contract in other channel adapters if and when needed.
+
+## Final Recommendation
+
+The production-ready fix is:
+
+- make `no_reply` a first-class outcome
+- classify empty visible output into that outcome centrally
+- have Slack acknowledge the event and send nothing
+- reserve the generic Slack error message for real failures only
+
+That is the smallest clean architecture that fixes the current behavior without
+adding provider-specific hacks or hiding genuine failures.

--- a/images/examples/openclaw/acp-wrapper.test.ts
+++ b/images/examples/openclaw/acp-wrapper.test.ts
@@ -212,6 +212,37 @@ test("history replay strips ACP sender metadata and cwd prefix from user text", 
   ]);
 });
 
+test("history replay suppresses assistant NO_REPLY-only text", () => {
+  const updates = buildHistoryReplayUpdates([
+    {
+      role: "assistant",
+      content: [{ type: "text", text: "  NO_REPLY  " }],
+    },
+  ]);
+
+  assert.deepEqual(updates, []);
+});
+
+test("history replay strips a glued leading NO_REPLY token from assistant text", () => {
+  const updates = buildHistoryReplayUpdates([
+    {
+      role: "assistant",
+      content: [{ type: "text", text: "NO_REPLYActual answer" }],
+    },
+  ]);
+
+  assert.deepEqual(updates, [
+    {
+      sessionUpdate: "agent_message_chunk",
+      historyMessageId: "history-0",
+      content: {
+        type: "text",
+        text: "Actual answer",
+      },
+    },
+  ]);
+});
+
 test("findPendingPromptBySessionKey falls back to the sole session match when run IDs differ", () => {
   const pending = {
     sessionId: "session-1",
@@ -486,6 +517,137 @@ test("handleDeltaEvent does not wait on transcript fetch before assistant text",
         content: {
           type: "text",
           text: "hi",
+        },
+      },
+    },
+  ]);
+});
+
+test("handleDeltaEvent suppresses NO_REPLY lead fragments and silent-only finals", async () => {
+  class FakeBaseAgent {
+    constructor() {
+      const updates = [];
+      this.connection = {
+        updates,
+        async sessionUpdate(payload) {
+          updates.push(payload);
+        },
+      };
+      this.pendingPrompts = new Map([
+        [
+          "session-1",
+          {
+            sessionId: "session-1",
+            sessionKey: "agent:main:spritz-acp:session-1",
+            idempotencyKey: "client-run-id",
+          },
+        ],
+      ]);
+    }
+
+    async handleDeltaEvent(sessionId, messageData) {
+      const content = messageData.content ?? [];
+      const pending = this.pendingPrompts.get(sessionId);
+      if (!pending) {
+        return;
+      }
+      const fullText = content
+        .filter((block) => block?.type === "text")
+        .map((block) => block.text ?? "")
+        .join("\n")
+        .trimEnd();
+      if (!fullText) {
+        return;
+      }
+      await this.connection.sessionUpdate({
+        sessionId,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: {
+            type: "text",
+            text: fullText,
+          },
+        },
+      });
+    }
+  }
+
+  const SpritzAgent = createSpritzAcpGatewayAgentClass(FakeBaseAgent, {});
+  const agent = new SpritzAgent();
+
+  for (const text of ["NO", "NO_", "NO_RE", "NO_REPLY"]) {
+    await agent.handleDeltaEvent("session-1", {
+      content: [{ type: "text", text }],
+    });
+  }
+
+  assert.deepEqual(agent.connection.updates, []);
+});
+
+test("handleDeltaEvent keeps normal NO-prefixed text", async () => {
+  class FakeBaseAgent {
+    constructor() {
+      const updates = [];
+      this.connection = {
+        updates,
+        async sessionUpdate(payload) {
+          updates.push(payload);
+        },
+      };
+      this.pendingPrompts = new Map([
+        [
+          "session-1",
+          {
+            sessionId: "session-1",
+            sessionKey: "agent:main:spritz-acp:session-1",
+            idempotencyKey: "client-run-id",
+          },
+        ],
+      ]);
+    }
+
+    async handleDeltaEvent(sessionId, messageData) {
+      const content = messageData.content ?? [];
+      const pending = this.pendingPrompts.get(sessionId);
+      if (!pending) {
+        return;
+      }
+      const fullText = content
+        .filter((block) => block?.type === "text")
+        .map((block) => block.text ?? "")
+        .join("\n")
+        .trimEnd();
+      if (!fullText) {
+        return;
+      }
+      await this.connection.sessionUpdate({
+        sessionId,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: {
+            type: "text",
+            text: fullText,
+          },
+        },
+      });
+    }
+  }
+
+  const SpritzAgent = createSpritzAcpGatewayAgentClass(FakeBaseAgent, {});
+  const agent = new SpritzAgent();
+
+  await agent.handleDeltaEvent("session-1", {
+    content: [{ type: "text", text: "NOW" }],
+  });
+
+  assert.deepEqual(agent.connection.updates, [
+    {
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: {
+          type: "text",
+          text: "NOW",
         },
       },
     },

--- a/images/examples/openclaw/acp-wrapper.ts
+++ b/images/examples/openclaw/acp-wrapper.ts
@@ -27,6 +27,7 @@ const DEFAULT_OPENCLAW_ACP_AGENT_INFO = {
   name: "openclaw-acp",
   title: "OpenClaw ACP Gateway",
 };
+const SILENT_REPLY_TOKEN = "NO_REPLY";
 const UUIDISH_SESSION_ID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -103,6 +104,161 @@ function normalizeHistoryContent(content) {
     return [{ type: "text", text: content }];
   }
   return [];
+}
+
+const silentExactRegexByToken = new Map();
+const silentTrailingRegexByToken = new Map();
+const silentLeadingRegexByToken = new Map();
+const silentLeadingAttachedRegexByToken = new Map();
+
+/**
+ * Returns whether text is exactly the OpenClaw silent reply token.
+ */
+function isSilentReplyText(text, token = SILENT_REPLY_TOKEN) {
+  if (!text) {
+    return false;
+  }
+  let regex = silentExactRegexByToken.get(token);
+  if (!regex) {
+    regex = new RegExp(`^\\s*${token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*$`, "i");
+    silentExactRegexByToken.set(token, regex);
+  }
+  return regex.test(text);
+}
+
+/**
+ * Removes a trailing silent token from mixed-content OpenClaw assistant text.
+ */
+function stripSilentToken(text, token = SILENT_REPLY_TOKEN) {
+  let regex = silentTrailingRegexByToken.get(token);
+  if (!regex) {
+    regex = new RegExp(
+      `(?:^|\\s+|\\*+)${token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*$`,
+      "i",
+    );
+    silentTrailingRegexByToken.set(token, regex);
+  }
+  return text.replace(regex, "").trim();
+}
+
+/**
+ * Returns whether text starts with a glued leading silent token like
+ * `NO_REPLYActual answer`.
+ */
+function startsWithSilentToken(text, token = SILENT_REPLY_TOKEN) {
+  if (!text) {
+    return false;
+  }
+  let regex = silentLeadingAttachedRegexByToken.get(token);
+  if (!regex) {
+    regex = new RegExp(
+      `^\\s*(?:${token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s+)*${token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?=[\\p{L}\\p{N}])`,
+      "iu",
+    );
+    silentLeadingAttachedRegexByToken.set(token, regex);
+  }
+  return regex.test(text);
+}
+
+/**
+ * Removes one or more leading silent tokens from assistant text.
+ */
+function stripLeadingSilentToken(text, token = SILENT_REPLY_TOKEN) {
+  let regex = silentLeadingRegexByToken.get(token);
+  if (!regex) {
+    regex = new RegExp(`^(?:\\s*${token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})+\\s*`, "i");
+    silentLeadingRegexByToken.set(token, regex);
+  }
+  return text.replace(regex, "").trim();
+}
+
+/**
+ * Returns whether text is an uppercase lead fragment of `NO_REPLY` during
+ * streaming, for example `NO`, `NO_`, or `NO_RE`.
+ */
+function isSilentReplyPrefixText(text, token = SILENT_REPLY_TOKEN) {
+  if (!text) {
+    return false;
+  }
+  const trimmed = text.trimStart();
+  if (!trimmed || trimmed !== trimmed.toUpperCase()) {
+    return false;
+  }
+  const normalized = trimmed.toUpperCase();
+  if (normalized.length < 2 || /[^A-Z_]/.test(normalized)) {
+    return false;
+  }
+  const tokenUpper = token.toUpperCase();
+  if (!tokenUpper.startsWith(normalized)) {
+    return false;
+  }
+  if (normalized.includes("_")) {
+    return true;
+  }
+  return tokenUpper === SILENT_REPLY_TOKEN && normalized === "NO";
+}
+
+/**
+ * Normalizes OpenClaw assistant text so silent control tokens never become
+ * ACP-visible assistant output.
+ */
+function normalizeAssistantTextForAcp(text, { suppressLeadFragments = false } = {}) {
+  if (typeof text !== "string") {
+    return "";
+  }
+  let normalized = text.trim();
+  if (!normalized) {
+    return "";
+  }
+  if (isSilentReplyText(normalized)) {
+    return "";
+  }
+  if (suppressLeadFragments && isSilentReplyPrefixText(normalized)) {
+    return "";
+  }
+  if (startsWithSilentToken(normalized)) {
+    normalized = stripLeadingSilentToken(normalized);
+  }
+  if (normalized.toUpperCase().includes(SILENT_REPLY_TOKEN)) {
+    normalized = stripSilentToken(normalized);
+  }
+  return normalized.trim();
+}
+
+/**
+ * Sanitizes assistant content blocks before they are replayed or streamed over
+ * ACP so OpenClaw silent control tokens stay internal to the wrapper.
+ */
+function sanitizeAssistantContentForAcp(content, { suppressLeadFragments = false } = {}) {
+  const sanitized = [];
+  for (const item of normalizeHistoryContent(content)) {
+    const type = normalizeContentItemType(item);
+    if (type !== "text") {
+      sanitized.push(item);
+      continue;
+    }
+    const sourceText =
+      typeof item.text === "string"
+        ? item.text
+        : typeof item.content === "string"
+          ? item.content
+          : "";
+    const normalizedText = normalizeAssistantTextForAcp(sourceText, {
+      suppressLeadFragments,
+    });
+    if (!normalizedText) {
+      continue;
+    }
+    sanitized.push({
+      ...item,
+      ...(typeof item.text === "string" ? { text: normalizedText } : {}),
+      ...(typeof item.content === "string" ? { content: normalizedText } : {}),
+      ...(typeof item.text !== "string" && typeof item.content !== "string"
+        ? { text: normalizedText }
+        : {}),
+    });
+  }
+  return sanitized;
 }
 
 function readTextFromHistoryContent(content) {
@@ -586,7 +742,8 @@ export function buildHistoryReplayUpdates(messages = []) {
     }
 
     if (role === "assistant") {
-      for (const item of content) {
+      const sanitizedContent = sanitizeAssistantContentForAcp(content);
+      for (const item of sanitizedContent) {
         const type = typeof item.type === "string" ? item.type.toLowerCase() : "";
         if (["toolcall", "tool_call", "tooluse", "tool_use"].includes(type)) {
           const toolUpdate = buildHistoryToolCallUpdate(item);
@@ -595,7 +752,7 @@ export function buildHistoryReplayUpdates(messages = []) {
           }
         }
       }
-      const text = readTextFromHistoryContent(content);
+      const text = readTextFromHistoryContent(sanitizedContent);
       if (text) {
         updates.push({
           sessionUpdate: "agent_message_chunk",
@@ -793,7 +950,16 @@ export function createSpritzAcpGatewayAgentClass(
       if (pending) {
         await emitLiveToolCallContentUpdates(this, sessionId, pending, messageData);
       }
-      return await super.handleDeltaEvent(sessionId, messageData);
+      const sanitizedMessageData =
+        messageData && typeof messageData === "object"
+          ? {
+              ...messageData,
+              content: sanitizeAssistantContentForAcp(messageData.content, {
+                suppressLeadFragments: true,
+              }),
+            }
+          : messageData;
+      return await super.handleDeltaEvent(sessionId, sanitizedMessageData);
     }
 
     async finishPrompt(sessionId, pending, stopReason) {

--- a/integrations/slack-gateway/acp_client.go
+++ b/integrations/slack-gateway/acp_client.go
@@ -25,17 +25,30 @@ type acpRPCMessage struct {
 	} `json:"error,omitempty"`
 }
 
-func (g *slackGateway) promptConversation(ctx context.Context, serviceToken, namespace, conversationID, sessionID, cwd, prompt string) (string, bool, error) {
+type promptDeliveryType string
+
+const (
+	promptDeliveryMessage promptDeliveryType = "deliver_message"
+	promptDeliveryNoReply promptDeliveryType = "no_reply"
+)
+
+type promptConversationResult struct {
+	typeName   promptDeliveryType
+	reply      string
+	promptSent bool
+}
+
+func (g *slackGateway) promptConversation(ctx context.Context, serviceToken, namespace, conversationID, sessionID, cwd, prompt string) (promptConversationResult, error) {
 	wsURL, err := g.spritzWebSocketURL("/api/acp/conversations/"+url.PathEscape(conversationID)+"/connect", map[string]string{"namespace": namespace})
 	if err != nil {
-		return "", false, err
+		return promptConversationResult{}, err
 	}
 	dialer := websocket.Dialer{HandshakeTimeout: g.cfg.HTTPTimeout}
 	headers := http.Header{}
 	headers.Set("Authorization", "Bearer "+serviceToken)
 	conn, _, err := dialer.DialContext(ctx, wsURL, headers)
 	if err != nil {
-		return "", false, err
+		return promptConversationResult{}, err
 	}
 	defer conn.Close()
 
@@ -49,14 +62,14 @@ func (g *slackGateway) promptConversation(ctx context.Context, serviceToken, nam
 			"version": "1.0.0",
 		},
 	}, nil); err != nil {
-		return "", false, err
+		return promptConversationResult{}, err
 	}
 	if _, _, err := client.call(ctx, "session/load", map[string]any{
 		"sessionId":  sessionID,
 		"cwd":        cwd,
 		"mcpServers": []any{},
 	}, nil); err != nil {
-		return "", false, err
+		return promptConversationResult{}, err
 	}
 	chunks := make([]any, 0, 8)
 	if _, promptSent, err := client.call(ctx, "session/prompt", map[string]any{
@@ -80,13 +93,24 @@ func (g *slackGateway) promptConversation(ctx context.Context, serviceToken, nam
 		}
 		chunks = append(chunks, payload.Update["content"])
 	}); err != nil {
-		return acptext.JoinChunks(chunks), promptSent, err
+		return promptConversationResult{
+			typeName:   promptDeliveryMessage,
+			reply:      acptext.JoinChunks(chunks),
+			promptSent: promptSent,
+		}, err
 	}
 	text := acptext.JoinChunks(chunks)
 	if strings.TrimSpace(text) == "" {
-		return "", true, fmt.Errorf("agent returned an empty reply")
+		return promptConversationResult{
+			typeName:   promptDeliveryNoReply,
+			promptSent: true,
+		}, nil
 	}
-	return text, true, nil
+	return promptConversationResult{
+		typeName:   promptDeliveryMessage,
+		reply:      text,
+		promptSent: true,
+	}, nil
 }
 
 type acpPromptClient struct {

--- a/integrations/slack-gateway/gateway_test.go
+++ b/integrations/slack-gateway/gateway_test.go
@@ -1743,7 +1743,7 @@ func TestPromptConversationRejectsInteractivePermissionRequests(t *testing.T) {
 	}
 	gateway := newSlackGateway(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
 
-	reply, promptSent, err := gateway.promptConversation(
+	result, err := gateway.promptConversation(
 		t.Context(),
 		"owner-token",
 		"spritz-staging",
@@ -1755,11 +1755,11 @@ func TestPromptConversationRejectsInteractivePermissionRequests(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected promptConversation to fail when permission is denied")
 	}
-	if !promptSent {
+	if !result.promptSent {
 		t.Fatalf("expected prompt delivery to be marked as sent")
 	}
-	if strings.TrimSpace(reply) != "" {
-		t.Fatalf("expected no reply text on permission denial, got %q", reply)
+	if strings.TrimSpace(result.reply) != "" {
+		t.Fatalf("expected no reply text on permission denial, got %q", result.reply)
 	}
 	select {
 	case response := <-permissionResponse:
@@ -1850,7 +1850,7 @@ func TestPromptConversationPreservesChunkBoundaryWhitespaceAndNewlines(t *testin
 	}
 	gateway := newSlackGateway(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
 
-	reply, promptSent, err := gateway.promptConversation(
+	result, err := gateway.promptConversation(
 		t.Context(),
 		"owner-token",
 		"spritz-staging",
@@ -1862,12 +1862,79 @@ func TestPromptConversationPreservesChunkBoundaryWhitespaceAndNewlines(t *testin
 	if err != nil {
 		t.Fatalf("promptConversation returned error: %v", err)
 	}
-	if !promptSent {
+	if !result.promptSent {
 		t.Fatalf("expected prompt delivery to be marked as sent")
 	}
 	want := "I'll spawn a dedicated agent for you using the\nSpritz controls.\n\nThe Slack account could not be resolved.\n"
-	if reply != want {
-		t.Fatalf("expected reply %q, got %q", want, reply)
+	if result.typeName != promptDeliveryMessage {
+		t.Fatalf("expected message delivery type, got %q", result.typeName)
+	}
+	if result.reply != want {
+		t.Fatalf("expected reply %q, got %q", want, result.reply)
+	}
+}
+
+func TestPromptConversationAllowsEmptyVisibleReply(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	spritz := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/acp/conversations/conv-1/connect" {
+			t.Fatalf("unexpected spritz path %s", r.URL.Path)
+		}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade failed: %v", err)
+		}
+		defer conn.Close()
+		for {
+			_, payload, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			var message map[string]any
+			if err := json.Unmarshal(payload, &message); err != nil {
+				t.Fatalf("decode ws payload: %v", err)
+			}
+			switch message["method"] {
+			case "initialize":
+				_ = conn.WriteJSON(map[string]any{"jsonrpc": "2.0", "id": message["id"], "result": map[string]any{"protocolVersion": 1}})
+			case "session/load":
+				_ = conn.WriteJSON(map[string]any{"jsonrpc": "2.0", "id": message["id"], "result": map[string]any{}})
+			case "session/prompt":
+				_ = conn.WriteJSON(map[string]any{"jsonrpc": "2.0", "id": message["id"], "result": map[string]any{}})
+				return
+			default:
+				t.Fatalf("unexpected ACP method %#v", message["method"])
+			}
+		}
+	}))
+	defer spritz.Close()
+
+	cfg := config{
+		SpritzBaseURL: spritz.URL,
+		HTTPTimeout:   5 * time.Second,
+	}
+	gateway := newSlackGateway(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	result, err := gateway.promptConversation(
+		t.Context(),
+		"owner-token",
+		"spritz-staging",
+		"conv-1",
+		"session-1",
+		"/home/dev",
+		"hello",
+	)
+	if err != nil {
+		t.Fatalf("expected empty visible reply to succeed, got %v", err)
+	}
+	if !result.promptSent {
+		t.Fatalf("expected prompt delivery to be marked as sent")
+	}
+	if result.typeName != promptDeliveryNoReply {
+		t.Fatalf("expected no-reply delivery type, got %q", result.typeName)
+	}
+	if result.reply != "" {
+		t.Fatalf("expected empty reply text, got %q", result.reply)
 	}
 }
 
@@ -5645,6 +5712,135 @@ func TestProcessMessageEventAllowsRetryWhenPromptWasNotDelivered(t *testing.T) {
 	}
 	if postCalls.Load() != 0 {
 		t.Fatalf("expected no slack reply on undelivered prompt failure, got %d posts", postCalls.Load())
+	}
+}
+
+func TestProcessMessageEventSuppressesSlackReplyWhenRuntimeHasNoVisibleOutput(t *testing.T) {
+	var postCalls atomic.Int32
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/internal/v1/spritz/channel-sessions/exchange" {
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"status": "resolved",
+			"session": map[string]any{
+				"accessToken": "owner-token",
+				"ownerAuthId": "owner-123",
+				"namespace":   "spritz-staging",
+				"instanceId":  "zeno-acme",
+				"providerAuth": map[string]any{
+					"providerInstallRef": "cred_slack_workspace_1",
+					"apiAppId":           "A_app_1",
+					"teamId":             "T_workspace_1",
+					"botUserId":          "U_bot",
+					"botAccessToken":     "xoxb-installed",
+				},
+			},
+		})
+	}))
+	defer backend.Close()
+
+	slackAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat.postMessage" {
+			t.Fatalf("unexpected slack path %s", r.URL.Path)
+		}
+		postCalls.Add(1)
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+	}))
+	defer slackAPI.Close()
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	spritz := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/channel-conversations/upsert":
+			writeJSON(w, http.StatusCreated, map[string]any{
+				"status": "success",
+				"data": map[string]any{
+					"created": true,
+					"conversation": map[string]any{
+						"metadata": map[string]any{"name": "conv-1"},
+						"spec":     map[string]any{"cwd": "/home/dev"},
+					},
+				},
+			})
+		case "/api/acp/conversations/conv-1/bootstrap":
+			writeJSON(w, http.StatusOK, map[string]any{
+				"status": "success",
+				"data": map[string]any{
+					"effectiveSessionId": "session-1",
+					"conversation": map[string]any{
+						"metadata": map[string]any{"name": "conv-1"},
+						"spec":     map[string]any{"sessionId": "session-1", "cwd": "/home/dev"},
+					},
+				},
+			})
+		case "/api/acp/conversations/conv-1/connect":
+			conn, err := upgrader.Upgrade(w, r, nil)
+			if err != nil {
+				t.Fatalf("upgrade failed: %v", err)
+			}
+			defer conn.Close()
+			for {
+				_, payload, err := conn.ReadMessage()
+				if err != nil {
+					return
+				}
+				var message map[string]any
+				if err := json.Unmarshal(payload, &message); err != nil {
+					t.Fatalf("decode ws payload: %v", err)
+				}
+				switch message["method"] {
+				case "initialize":
+					_ = conn.WriteJSON(map[string]any{"jsonrpc": "2.0", "id": message["id"], "result": map[string]any{"protocolVersion": 1}})
+				case "session/load":
+					_ = conn.WriteJSON(map[string]any{"jsonrpc": "2.0", "id": message["id"], "result": map[string]any{}})
+				case "session/prompt":
+					_ = conn.WriteJSON(map[string]any{"jsonrpc": "2.0", "id": message["id"], "result": map[string]any{}})
+					return
+				default:
+					t.Fatalf("unexpected ACP method %#v", message["method"])
+				}
+			}
+		default:
+			t.Fatalf("unexpected spritz path %s", r.URL.Path)
+		}
+	}))
+	defer spritz.Close()
+
+	cfg := config{
+		SlackSigningSecret:   "signing-secret",
+		OAuthStateSecret:     "oauth-state-secret",
+		SlackAPIBaseURL:      slackAPI.URL,
+		BackendBaseURL:       backend.URL,
+		BackendInternalToken: "backend-internal-token",
+		SpritzBaseURL:        spritz.URL,
+		SpritzServiceToken:   "spritz-service-token",
+		PrincipalID:          "shared-slack-gateway",
+		HTTPTimeout:          5 * time.Second,
+		DedupeTTL:            time.Minute,
+	}
+	gateway := newSlackGateway(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	envelope := slackEnvelope{
+		Type:     "event_callback",
+		TeamID:   "T_workspace_1",
+		APIAppID: "A_app_1",
+		EventID:  "Ev_no_reply",
+		Event: slackEventInner{
+			Type:        "app_mention",
+			User:        "U_1",
+			Text:        "<@U_bot> hello",
+			Channel:     "C_1",
+			ChannelType: "channel",
+			TS:          "1711387375.000100",
+		},
+	}
+
+	if err := gateway.processMessageEvent(t.Context(), envelope); err != nil {
+		t.Fatalf("expected empty visible output to be treated as success, got %v", err)
+	}
+	if postCalls.Load() != 0 {
+		t.Fatalf("expected no slack post for empty visible output, got %d", postCalls.Load())
 	}
 }
 

--- a/integrations/slack-gateway/slack_events.go
+++ b/integrations/slack-gateway/slack_events.go
@@ -660,6 +660,17 @@ func (g *slackGateway) processMessageEventWithDelivery(
 		result.reply = "I hit an internal error while processing that request."
 		g.logger.Error("acp prompt failed", "error", err, "conversation_id", result.conversationID)
 	}
+	if result.deliveryType == promptDeliveryNoReply {
+		g.logger.Info(
+			"acp prompt completed without a visible reply",
+			"conversation_id", result.conversationID,
+			"team_id", strings.TrimSpace(envelope.TeamID),
+			"channel_id", strings.TrimSpace(event.Channel),
+			"message_ts", strings.TrimSpace(event.TS),
+		)
+		success = true
+		return nil
+	}
 	replyThreadTS := slackReplyThreadTS(event)
 	replyCtx, cancelReply := context.WithTimeout(context.WithoutCancel(ctx), g.cfg.HTTPTimeout)
 	defer cancelReply()
@@ -676,6 +687,7 @@ func (g *slackGateway) processMessageEventWithDelivery(
 
 type conversationPromptResult struct {
 	conversationID string
+	deliveryType   promptDeliveryType
 	reply          string
 	promptSent     bool
 }
@@ -709,7 +721,7 @@ func (g *slackGateway) executeConversationPrompt(
 	if err != nil {
 		return conversationPromptResult{conversationID: conversationID}, err
 	}
-	reply, promptSent, err := g.promptConversation(
+	promptResult, err := g.promptConversation(
 		ctx,
 		g.cfg.SpritzServiceToken,
 		session.Namespace,
@@ -720,8 +732,9 @@ func (g *slackGateway) executeConversationPrompt(
 	)
 	return conversationPromptResult{
 		conversationID: conversationID,
-		reply:          reply,
-		promptSent:     promptSent,
+		deliveryType:   promptResult.typeName,
+		reply:          promptResult.reply,
+		promptSent:     promptResult.promptSent,
 	}, err
 }
 


### PR DESCRIPTION
## Summary
- suppress OpenClaw `NO_REPLY` silent control text in the ACP bridge before it becomes ACP-visible assistant output
- cover transcript replay and live delta handling, including lead fragments like `NO_` and glued `NO_REPLY...` text
- document the ownership boundary so OpenClaw sentinel handling stays in the bridge and the Slack gateway stays ACP-generic

## Testing
- `cd /Users/onur/repos/spritz/cli && pnpm exec node --test --import tsx ../images/examples/openclaw/acp-wrapper.test.ts`
- `cd /Users/onur/repos/spritz && npx -y @simpledoc/simpledoc check`