### PR TITLE
fix(openclaw-acp): suppress silent no-reply output

### DIFF
--- a/docs/2026-04-16-slack-gateway-no-reply-outcome-architecture.md
+++ b/docs/2026-04-16-slack-gateway-no-reply-outcome-architecture.md
@@ -16,6 +16,13 @@ reply, the gateway should usually send nothing to Slack.
 
 This document defines the long-term contract for that behavior.
 
+The verified ownership boundary is:
+
+- OpenClaw-specific silent control tokens such as `NO_REPLY` must be consumed
+  in the OpenClaw ACP bridge before they become ACP-visible assistant text
+- the Slack gateway should stay ACP-generic and only decide between "deliver a
+  visible message", "deliver nothing", and "surface a real failure"
+
 Related docs:
 
 - [Slack Channel Gateway Implementation Plan](2026-03-24-slack-channel-gateway-implementation-plan.md)
@@ -83,6 +90,14 @@ For Slack, that means:
 - `hard_error`: post the generic failure message only when product policy says
   the user should see one
 
+The ownership rule is:
+
+- OpenClaw semantics belong in the OpenClaw ACP bridge
+- channel transport semantics belong in the Slack gateway
+
+That means literal `NO_REPLY` handling should not be owned primarily by the
+Slack gateway.
+
 ## Why This Is the Right Abstraction
 
 The Slack gateway is a delivery adapter. Its job is to:
@@ -136,6 +151,33 @@ Recommended shape:
 
 The internal representation does not need to match this JSON exactly, but the
 typed semantics should.
+
+## Verified Current Behavior
+
+The current system has two different layers:
+
+1. OpenClaw, which has a real silent sentinel token: `NO_REPLY`
+2. Spritz Slack gateway, which consumes ACP `agent_message_chunk` updates
+
+Verified facts:
+
+- OpenClaw treats exact `NO_REPLY` as a silent reply token and suppresses it in
+  its own delivery layer
+- upstream OpenClaw ACP behavior can still forward raw assistant text blocks
+  through ACP
+- the Spritz OpenClaw ACP wrapper currently forwards assistant text from
+  transcript replay as `agent_message_chunk` without stripping `NO_REPLY`
+- the Spritz Slack gateway currently treats only empty assembled assistant text
+  as `no_reply`
+
+So the current bug is not "Slack needs provider-specific Kimi logic."
+
+The current bug is:
+
+- an OpenClaw-specific silent token can cross the OpenClaw-to-ACP boundary as
+  visible assistant text
+- once that happens, the Slack gateway has no typed signal telling it that the
+  outcome was intentionally silent
 
 ### Required fields
 
@@ -225,7 +267,9 @@ no-message completions, not real failures.
 
 The current Slack gateway flow in
 [`integrations/slack-gateway/slack_events.go`](/Users/onur/repos/spritz/integrations/slack-gateway/slack_events.go)
-still treats part of this space as an error path.
+still treats part of this space as an error path, and the current OpenClaw ACP
+wrapper does not fully normalize OpenClaw silent control output before it
+reaches the gateway.
 
 Today, after prompting the runtime:
 
@@ -238,8 +282,12 @@ That behavior is reasonable for true failures, but wrong for the specific case
 where the prompt completed and the only issue is missing visible output.
 
 The implementation gap is not "Slack needs to understand one model provider."
-The gap is "the runtime result contract does not cleanly distinguish no visible
-reply from hard failure."
+The gap is:
+
+- the OpenClaw ACP bridge does not fully translate OpenClaw silent semantics
+  into an ACP-visible no-reply outcome
+- the runtime result contract does not cleanly distinguish no visible reply
+  from hard failure once the gateway receives the ACP stream
 
 ## Recommended Implementation Shape
 
@@ -253,6 +301,21 @@ instead of relying on a mixed interpretation of:
 - error presence
 
 That keeps the decision at the right layer.
+
+### 1a. Consume OpenClaw silent tokens in the ACP bridge
+
+For the OpenClaw-backed path specifically, the bridge that converts OpenClaw
+runtime events into ACP updates should own OpenClaw sentinel handling.
+
+Rules:
+
+- exact silent outputs such as `NO_REPLY` must not be emitted as visible
+  `agent_message_chunk` text
+- silent-token lead fragments must not leak during streaming
+- if OpenClaw produces no deliverable assistant text after normalization, the
+  bridge should complete the prompt without a visible assistant message
+
+This keeps OpenClaw-specific knowledge in the OpenClaw integration boundary.
 
 ### 2. Centralize empty-visible-output classification
 
@@ -273,6 +336,14 @@ The Slack gateway should only map typed outcomes to channel behavior:
 - post failure message
 
 This keeps the adapter simple and reusable.
+
+Defense in depth is still acceptable:
+
+- Slack gateway may suppress empty final text
+- Slack gateway may optionally guard against exact silent control tokens if
+  they somehow slip through
+
+But that guard should not be the primary owner of OpenClaw sentinel semantics.
 
 ### 4. Keep structured operator visibility
 
@@ -321,14 +392,19 @@ Required tests:
 
 1. runtime returns normal visible text
    - Slack gateway posts exactly one reply
-2. runtime completes with empty visible output
+2. OpenClaw ACP bridge receives exact `NO_REPLY`
+   - bridge emits no visible `agent_message_chunk`
+   - prompt resolves as a no-reply outcome
+3. OpenClaw ACP bridge receives silent-token lead fragments
+   - fragments do not leak into visible assistant output
+4. runtime completes with empty visible output
    - Slack gateway posts nothing
    - gateway reports success for delivery bookkeeping
-3. runtime fails before prompt completion
+5. runtime fails before prompt completion
    - Slack gateway follows the hard-failure path
-4. runtime fails after a typed `hard_error`
+6. runtime fails after a typed `hard_error`
    - Slack gateway posts the generic error message when configured to do so
-5. Slack post fails after `deliver_message`
+7. Slack post fails after `deliver_message`
    - gateway preserves existing retry and deduplication behavior
 
 Important assertion:
@@ -367,18 +443,23 @@ not as Slack-only conditional logic.
 
 ## Migration Plan
 
-1. Define the typed prompt delivery outcome in the conversation prompt layer.
-2. Update Slack gateway prompt handling to consume the typed result.
-3. Add regression tests for `no_reply`.
-4. Add outcome metrics and logs.
-5. Reuse the same contract in other channel adapters if and when needed.
+1. Normalize OpenClaw silent control output in the OpenClaw ACP bridge.
+2. Define or preserve a typed no-reply prompt delivery outcome in the prompt
+   layer.
+3. Update Slack gateway prompt handling to consume the typed result without
+   learning OpenClaw-specific sentinel rules.
+4. Add regression tests for bridge-level silent handling and gateway-level
+   no-reply handling.
+5. Add outcome metrics and logs.
+6. Reuse the same contract in other channel adapters if and when needed.
 
 ## Final Recommendation
 
 The production-ready fix is:
 
 - make `no_reply` a first-class outcome
-- classify empty visible output into that outcome centrally
+- consume OpenClaw `NO_REPLY` semantics in the OpenClaw ACP bridge
+- classify empty visible output into `no_reply` centrally
 - have Slack acknowledge the event and send nothing
 - reserve the generic Slack error message for real failures only
 

--- a/images/examples/openclaw/acp-wrapper.test.ts
+++ b/images/examples/openclaw/acp-wrapper.test.ts
@@ -212,6 +212,37 @@ test("history replay strips ACP sender metadata and cwd prefix from user text", 
   ]);
 });
 
+test("history replay suppresses assistant NO_REPLY-only text", () => {
+  const updates = buildHistoryReplayUpdates([
+    {
+      role: "assistant",
+      content: [{ type: "text", text: "  NO_REPLY  " }],
+    },
+  ]);
+
+  assert.deepEqual(updates, []);
+});
+
+test("history replay strips a glued leading NO_REPLY token from assistant text", () => {
+  const updates = buildHistoryReplayUpdates([
+    {
+      role: "assistant",
+      content: [{ type: "text", text: "NO_REPLYActual answer" }],
+    },
+  ]);
+
+  assert.deepEqual(updates, [
+    {
+      sessionUpdate: "agent_message_chunk",
+      historyMessageId: "history-0",
+      content: {
+        type: "text",
+        text: "Actual answer",
+      },
+    },
+  ]);
+});
+
 test("findPendingPromptBySessionKey falls back to the sole session match when run IDs differ", () => {
   const pending = {
     sessionId: "session-1",
@@ -486,6 +517,137 @@ test("handleDeltaEvent does not wait on transcript fetch before assistant text",
         content: {
           type: "text",
           text: "hi",
+        },
+      },
+    },
+  ]);
+});
+
+test("handleDeltaEvent suppresses NO_REPLY lead fragments and silent-only finals", async () => {
+  class FakeBaseAgent {
+    constructor() {
+      const updates = [];
+      this.connection = {
+        updates,
+        async sessionUpdate(payload) {
+          updates.push(payload);
+        },
+      };
+      this.pendingPrompts = new Map([
+        [
+          "session-1",
+          {
+            sessionId: "session-1",
+            sessionKey: "agent:main:spritz-acp:session-1",
+            idempotencyKey: "client-run-id",
+          },
+        ],
+      ]);
+    }
+
+    async handleDeltaEvent(sessionId, messageData) {
+      const content = messageData.content ?? [];
+      const pending = this.pendingPrompts.get(sessionId);
+      if (!pending) {
+        return;
+      }
+      const fullText = content
+        .filter((block) => block?.type === "text")
+        .map((block) => block.text ?? "")
+        .join("\n")
+        .trimEnd();
+      if (!fullText) {
+        return;
+      }
+      await this.connection.sessionUpdate({
+        sessionId,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: {
+            type: "text",
+            text: fullText,
+          },
+        },
+      });
+    }
+  }
+
+  const SpritzAgent = createSpritzAcpGatewayAgentClass(FakeBaseAgent, {});
+  const agent = new SpritzAgent();
+
+  for (const text of ["NO", "NO_", "NO_RE", "NO_REPLY"]) {
+    await agent.handleDeltaEvent("session-1", {
+      content: [{ type: "text", text }],
+    });
+  }
+
+  assert.deepEqual(agent.connection.updates, []);
+});
+
+test("handleDeltaEvent keeps normal NO-prefixed text", async () => {
+  class FakeBaseAgent {
+    constructor() {
+      const updates = [];
+      this.connection = {
+        updates,
+        async sessionUpdate(payload) {
+          updates.push(payload);
+        },
+      };
+      this.pendingPrompts = new Map([
+        [
+          "session-1",
+          {
+            sessionId: "session-1",
+            sessionKey: "agent:main:spritz-acp:session-1",
+            idempotencyKey: "client-run-id",
+          },
+        ],
+      ]);
+    }
+
+    async handleDeltaEvent(sessionId, messageData) {
+      const content = messageData.content ?? [];
+      const pending = this.pendingPrompts.get(sessionId);
+      if (!pending) {
+        return;
+      }
+      const fullText = content
+        .filter((block) => block?.type === "text")
+        .map((block) => block.text ?? "")
+        .join("\n")
+        .trimEnd();
+      if (!fullText) {
+        return;
+      }
+      await this.connection.sessionUpdate({
+        sessionId,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: {
+            type: "text",
+            text: fullText,
+          },
+        },
+      });
+    }
+  }
+
+  const SpritzAgent = createSpritzAcpGatewayAgentClass(FakeBaseAgent, {});
+  const agent = new SpritzAgent();
+
+  await agent.handleDeltaEvent("session-1", {
+    content: [{ type: "text", text: "NOW" }],
+  });
+
+  assert.deepEqual(agent.connection.updates, [
+    {
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: {
+          type: "text",
+          text: "NOW",
         },
       },
     },

--- a/images/examples/openclaw/acp-wrapper.ts
+++ b/images/examples/openclaw/acp-wrapper.ts
@@ -27,6 +27,7 @@ const DEFAULT_OPENCLAW_ACP_AGENT_INFO = {
   name: "openclaw-acp",
   title: "OpenClaw ACP Gateway",
 };
+const SILENT_REPLY_TOKEN = "NO_REPLY";
 const UUIDISH_SESSION_ID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -103,6 +104,161 @@ function normalizeHistoryContent(content) {
     return [{ type: "text", text: content }];
   }
   return [];
+}
+
+const silentExactRegexByToken = new Map();
+const silentTrailingRegexByToken = new Map();
+const silentLeadingRegexByToken = new Map();
+const silentLeadingAttachedRegexByToken = new Map();
+
+/**
+ * Returns whether text is exactly the OpenClaw silent reply token.
+ */
+function isSilentReplyText(text, token = SILENT_REPLY_TOKEN) {
+  if (!text) {
+    return false;
+  }
+  let regex = silentExactRegexByToken.get(token);
+  if (!regex) {
+    regex = new RegExp(`^\\s*${token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*$`, "i");
+    silentExactRegexByToken.set(token, regex);
+  }
+  return regex.test(text);
+}
+
+/**
+ * Removes a trailing silent token from mixed-content OpenClaw assistant text.
+ */
+function stripSilentToken(text, token = SILENT_REPLY_TOKEN) {
+  let regex = silentTrailingRegexByToken.get(token);
+  if (!regex) {
+    regex = new RegExp(
+      `(?:^|\\s+|\\*+)${token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*$`,
+      "i",
+    );
+    silentTrailingRegexByToken.set(token, regex);
+  }
+  return text.replace(regex, "").trim();
+}
+
+/**
+ * Returns whether text starts with a glued leading silent token like
+ * `NO_REPLYActual answer`.
+ */
+function startsWithSilentToken(text, token = SILENT_REPLY_TOKEN) {
+  if (!text) {
+    return false;
+  }
+  let regex = silentLeadingAttachedRegexByToken.get(token);
+  if (!regex) {
+    regex = new RegExp(
+      `^\\s*(?:${token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s+)*${token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?=[\\p{L}\\p{N}])`,
+      "iu",
+    );
+    silentLeadingAttachedRegexByToken.set(token, regex);
+  }
+  return regex.test(text);
+}
+
+/**
+ * Removes one or more leading silent tokens from assistant text.
+ */
+function stripLeadingSilentToken(text, token = SILENT_REPLY_TOKEN) {
+  let regex = silentLeadingRegexByToken.get(token);
+  if (!regex) {
+    regex = new RegExp(`^(?:\\s*${token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})+\\s*`, "i");
+    silentLeadingRegexByToken.set(token, regex);
+  }
+  return text.replace(regex, "").trim();
+}
+
+/**
+ * Returns whether text is an uppercase lead fragment of `NO_REPLY` during
+ * streaming, for example `NO`, `NO_`, or `NO_RE`.
+ */
+function isSilentReplyPrefixText(text, token = SILENT_REPLY_TOKEN) {
+  if (!text) {
+    return false;
+  }
+  const trimmed = text.trimStart();
+  if (!trimmed || trimmed !== trimmed.toUpperCase()) {
+    return false;
+  }
+  const normalized = trimmed.toUpperCase();
+  if (normalized.length < 2 || /[^A-Z_]/.test(normalized)) {
+    return false;
+  }
+  const tokenUpper = token.toUpperCase();
+  if (!tokenUpper.startsWith(normalized)) {
+    return false;
+  }
+  if (normalized.includes("_")) {
+    return true;
+  }
+  return tokenUpper === SILENT_REPLY_TOKEN && normalized === "NO";
+}
+
+/**
+ * Normalizes OpenClaw assistant text so silent control tokens never become
+ * ACP-visible assistant output.
+ */
+function normalizeAssistantTextForAcp(text, { suppressLeadFragments = false } = {}) {
+  if (typeof text !== "string") {
+    return "";
+  }
+  let normalized = text.trim();
+  if (!normalized) {
+    return "";
+  }
+  if (isSilentReplyText(normalized)) {
+    return "";
+  }
+  if (suppressLeadFragments && isSilentReplyPrefixText(normalized)) {
+    return "";
+  }
+  if (startsWithSilentToken(normalized)) {
+    normalized = stripLeadingSilentToken(normalized);
+  }
+  if (normalized.toUpperCase().includes(SILENT_REPLY_TOKEN)) {
+    normalized = stripSilentToken(normalized);
+  }
+  return normalized.trim();
+}
+
+/**
+ * Sanitizes assistant content blocks before they are replayed or streamed over
+ * ACP so OpenClaw silent control tokens stay internal to the wrapper.
+ */
+function sanitizeAssistantContentForAcp(content, { suppressLeadFragments = false } = {}) {
+  const sanitized = [];
+  for (const item of normalizeHistoryContent(content)) {
+    const type = normalizeContentItemType(item);
+    if (type !== "text") {
+      sanitized.push(item);
+      continue;
+    }
+    const sourceText =
+      typeof item.text === "string"
+        ? item.text
+        : typeof item.content === "string"
+          ? item.content
+          : "";
+    const normalizedText = normalizeAssistantTextForAcp(sourceText, {
+      suppressLeadFragments,
+    });
+    if (!normalizedText) {
+      continue;
+    }
+    sanitized.push({
+      ...item,
+      ...(typeof item.text === "string" ? { text: normalizedText } : {}),
+      ...(typeof item.content === "string" ? { content: normalizedText } : {}),
+      ...(typeof item.text !== "string" && typeof item.content !== "string"
+        ? { text: normalizedText }
+        : {}),
+    });
+  }
+  return sanitized;
 }
 
 function readTextFromHistoryContent(content) {
@@ -586,7 +742,8 @@ export function buildHistoryReplayUpdates(messages = []) {
     }
 
     if (role === "assistant") {
-      for (const item of content) {
+      const sanitizedContent = sanitizeAssistantContentForAcp(content);
+      for (const item of sanitizedContent) {
         const type = typeof item.type === "string" ? item.type.toLowerCase() : "";
         if (["toolcall", "tool_call", "tooluse", "tool_use"].includes(type)) {
           const toolUpdate = buildHistoryToolCallUpdate(item);
@@ -595,7 +752,7 @@ export function buildHistoryReplayUpdates(messages = []) {
           }
         }
       }
-      const text = readTextFromHistoryContent(content);
+      const text = readTextFromHistoryContent(sanitizedContent);
       if (text) {
         updates.push({
           sessionUpdate: "agent_message_chunk",
@@ -793,7 +950,16 @@ export function createSpritzAcpGatewayAgentClass(
       if (pending) {
         await emitLiveToolCallContentUpdates(this, sessionId, pending, messageData);
       }
-      return await super.handleDeltaEvent(sessionId, messageData);
+      const sanitizedMessageData =
+        messageData && typeof messageData === "object"
+          ? {
+              ...messageData,
+              content: sanitizeAssistantContentForAcp(messageData.content, {
+                suppressLeadFragments: true,
+              }),
+            }
+          : messageData;
+      return await super.handleDeltaEvent(sessionId, sanitizedMessageData);
     }
 
     async finishPrompt(sessionId, pending, stopReason) {


### PR DESCRIPTION
## Summary
- suppress OpenClaw `NO_REPLY` silent control text in the ACP bridge before it becomes ACP-visible assistant output
- cover transcript replay and live delta handling, including lead fragments like `NO_` and glued `NO_REPLY...` text
- document the ownership boundary so OpenClaw sentinel handling stays in the bridge and the Slack gateway stays ACP-generic

## Testing
- `cd /Users/onur/repos/spritz/cli && pnpm exec node --test --import tsx ../images/examples/openclaw/acp-wrapper.test.ts`
- `cd /Users/onur/repos/spritz && npx -y @simpledoc/simpledoc check`