### PR TITLE
fix(openclaw-acp): suppress leaked thinking tags

### DIFF
--- a/images/examples/openclaw/acp-wrapper.test.ts
+++ b/images/examples/openclaw/acp-wrapper.test.ts
@@ -243,6 +243,42 @@ test("history replay strips a glued leading NO_REPLY token from assistant text",
   ]);
 });
 
+test("history replay suppresses assistant thinking-only text", () => {
+  const updates = buildHistoryReplayUpdates([
+    {
+      role: "assistant",
+      content: [{ type: "text", text: "<thinking>\ninternal reasoning\n</thinking>" }],
+    },
+  ]);
+
+  assert.deepEqual(updates, []);
+});
+
+test("history replay strips a leading thinking block from assistant text", () => {
+  const updates = buildHistoryReplayUpdates([
+    {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "<thinking>\ninternal reasoning\n</thinking>\nActual answer",
+        },
+      ],
+    },
+  ]);
+
+  assert.deepEqual(updates, [
+    {
+      sessionUpdate: "agent_message_chunk",
+      historyMessageId: "history-0",
+      content: {
+        type: "text",
+        text: "Actual answer",
+      },
+    },
+  ]);
+});
+
 test("findPendingPromptBySessionKey falls back to the sole session match when run IDs differ", () => {
   const pending = {
     sessionId: "session-1",
@@ -582,6 +618,153 @@ test("handleDeltaEvent suppresses NO_REPLY lead fragments and silent-only finals
   }
 
   assert.deepEqual(agent.connection.updates, []);
+});
+
+test("handleDeltaEvent suppresses thinking lead fragments and silent-only finals", async () => {
+  class FakeBaseAgent {
+    constructor() {
+      const updates = [];
+      this.connection = {
+        updates,
+        async sessionUpdate(payload) {
+          updates.push(payload);
+        },
+      };
+      this.pendingPrompts = new Map([
+        [
+          "session-1",
+          {
+            sessionId: "session-1",
+            sessionKey: "agent:main:spritz-acp:session-1",
+            idempotencyKey: "client-run-id",
+          },
+        ],
+      ]);
+    }
+
+    async handleDeltaEvent(sessionId, messageData) {
+      const content = messageData.content ?? [];
+      const pending = this.pendingPrompts.get(sessionId);
+      if (!pending) {
+        return;
+      }
+      const fullText = content
+        .filter((block) => block?.type === "text")
+        .map((block) => block.text ?? "")
+        .join("\n")
+        .trimEnd();
+      if (!fullText) {
+        return;
+      }
+      await this.connection.sessionUpdate({
+        sessionId,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: {
+            type: "text",
+            text: fullText,
+          },
+        },
+      });
+    }
+  }
+
+  const SpritzAgent = createSpritzAcpGatewayAgentClass(FakeBaseAgent, {});
+  const agent = new SpritzAgent();
+
+  for (const text of [
+    "<",
+    "<t",
+    "<th",
+    "<thi",
+    "<thin",
+    "<think",
+    "<think>",
+    "<thinking",
+    "<thinking>",
+    "<thinking>\ninternal reasoning\n</thinking>",
+  ]) {
+    await agent.handleDeltaEvent("session-1", {
+      content: [{ type: "text", text }],
+    });
+  }
+
+  assert.deepEqual(agent.connection.updates, []);
+});
+
+test("handleDeltaEvent strips a leading thinking block before visible text", async () => {
+  class FakeBaseAgent {
+    constructor() {
+      const updates = [];
+      this.connection = {
+        updates,
+        async sessionUpdate(payload) {
+          updates.push(payload);
+        },
+      };
+      this.pendingPrompts = new Map([
+        [
+          "session-1",
+          {
+            sessionId: "session-1",
+            sessionKey: "agent:main:spritz-acp:session-1",
+            idempotencyKey: "client-run-id",
+          },
+        ],
+      ]);
+    }
+
+    async handleDeltaEvent(sessionId, messageData) {
+      const content = messageData.content ?? [];
+      const pending = this.pendingPrompts.get(sessionId);
+      if (!pending) {
+        return;
+      }
+      const fullText = content
+        .filter((block) => block?.type === "text")
+        .map((block) => block.text ?? "")
+        .join("\n")
+        .trimEnd();
+      if (!fullText) {
+        return;
+      }
+      await this.connection.sessionUpdate({
+        sessionId,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: {
+            type: "text",
+            text: fullText,
+          },
+        },
+      });
+    }
+  }
+
+  const SpritzAgent = createSpritzAcpGatewayAgentClass(FakeBaseAgent, {});
+  const agent = new SpritzAgent();
+
+  await agent.handleDeltaEvent("session-1", {
+    content: [
+      {
+        type: "text",
+        text: "<thinking>\ninternal reasoning\n</thinking>\nVisible answer",
+      },
+    ],
+  });
+
+  assert.deepEqual(agent.connection.updates, [
+    {
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: {
+          type: "text",
+          text: "Visible answer",
+        },
+      },
+    },
+  ]);
 });
 
 test("handleDeltaEvent keeps normal NO-prefixed text", async () => {

--- a/images/examples/openclaw/acp-wrapper.ts
+++ b/images/examples/openclaw/acp-wrapper.ts
@@ -28,6 +28,7 @@ const DEFAULT_OPENCLAW_ACP_AGENT_INFO = {
   title: "OpenClaw ACP Gateway",
 };
 const SILENT_REPLY_TOKEN = "NO_REPLY";
+const SUPPRESSED_LEADING_ASSISTANT_TAG_NAMES = ["think", "thinking"];
 const UUIDISH_SESSION_ID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -110,6 +111,8 @@ const silentExactRegexByToken = new Map();
 const silentTrailingRegexByToken = new Map();
 const silentLeadingRegexByToken = new Map();
 const silentLeadingAttachedRegexByToken = new Map();
+const leadingSuppressedAssistantBlockRegexByTagSet = new Map();
+const leadingSuppressedAssistantTagPrefixesByTagSet = new Map();
 
 /**
  * Returns whether text is exactly the OpenClaw silent reply token.
@@ -198,6 +201,61 @@ function isSilentReplyPrefixText(text, token = SILENT_REPLY_TOKEN) {
   return tokenUpper === SILENT_REPLY_TOKEN && normalized === "NO";
 }
 
+function buildSuppressedAssistantTagKey(tagNames = SUPPRESSED_LEADING_ASSISTANT_TAG_NAMES) {
+  return tagNames.join("|").toLowerCase();
+}
+
+function getLeadingSuppressedAssistantBlockRegex(
+  tagNames = SUPPRESSED_LEADING_ASSISTANT_TAG_NAMES,
+) {
+  const key = buildSuppressedAssistantTagKey(tagNames);
+  let regex = leadingSuppressedAssistantBlockRegexByTagSet.get(key);
+  if (!regex) {
+    const tagPattern = tagNames.map((tag) => tag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|");
+    regex = new RegExp(
+      `^(?:\\s*<(?:${tagPattern})\\b[^>]*>[\\s\\S]*?<\\/(?:${tagPattern})>\\s*)+`,
+      "iu",
+    );
+    leadingSuppressedAssistantBlockRegexByTagSet.set(key, regex);
+  }
+  return regex;
+}
+
+function stripLeadingSuppressedAssistantBlocks(
+  text,
+  tagNames = SUPPRESSED_LEADING_ASSISTANT_TAG_NAMES,
+) {
+  return text.replace(getLeadingSuppressedAssistantBlockRegex(tagNames), "").trim();
+}
+
+function isSuppressedAssistantTagPrefixText(
+  text,
+  tagNames = SUPPRESSED_LEADING_ASSISTANT_TAG_NAMES,
+) {
+  if (!text) {
+    return false;
+  }
+  const normalized = text.trimStart().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  const key = buildSuppressedAssistantTagKey(tagNames);
+  let prefixes = leadingSuppressedAssistantTagPrefixesByTagSet.get(key);
+  if (!prefixes) {
+    prefixes = new Set(["<", "</"]);
+    for (const tagName of tagNames) {
+      for (const tagPrefix of [`<${tagName}`, `</${tagName}`]) {
+        for (let index = 1; index <= tagPrefix.length; index += 1) {
+          prefixes.add(tagPrefix.slice(0, index));
+        }
+        prefixes.add(`${tagPrefix}>`);
+      }
+    }
+    leadingSuppressedAssistantTagPrefixesByTagSet.set(key, prefixes);
+  }
+  return prefixes.has(normalized);
+}
+
 /**
  * Normalizes OpenClaw assistant text so silent control tokens never become
  * ACP-visible assistant output.
@@ -213,7 +271,15 @@ function normalizeAssistantTextForAcp(text, { suppressLeadFragments = false } = 
   if (isSilentReplyText(normalized)) {
     return "";
   }
-  if (suppressLeadFragments && isSilentReplyPrefixText(normalized)) {
+  if (
+    suppressLeadFragments &&
+    (isSilentReplyPrefixText(normalized) ||
+      isSuppressedAssistantTagPrefixText(normalized))
+  ) {
+    return "";
+  }
+  normalized = stripLeadingSuppressedAssistantBlocks(normalized);
+  if (!normalized) {
     return "";
   }
   if (startsWithSilentToken(normalized)) {


### PR DESCRIPTION
## Summary
- suppress leaked `<think>` / `<thinking>` lead fragments before ACP emits assistant text
- strip full leading thinking blocks while preserving any real answer that follows
- add regression coverage for history replay and live delta handling

## Validation
- cd /Users/onur/repos/spritz/cli && pnpm exec node --test --import tsx ../images/examples/openclaw/acp-wrapper.test.ts