### PR TITLE
feat(slack): add install target selection flow

### DIFF
--- a/docs/2026-04-17-channel-install-target-selection-architecture.md
+++ b/docs/2026-04-17-channel-install-target-selection-architecture.md
@@ -1,0 +1,386 @@
+---
+date: 2026-04-17
+author: Onur Solmaz <onur@textcortex.com>
+title: Channel Install Target Selection Architecture
+tags: [spritz, channel-gateway, install, targets, architecture, ui]
+---
+
+## Overview
+
+This document defines a provider-agnostic way for a shared channel install flow
+to ask the installer which deployment-owned target should back that workspace.
+
+The immediate use case is a Slack install where the user must choose which
+assistant to connect to the workspace. The design is intentionally generic so a
+deployment can expose any eligible target type, such as:
+
+- personal assistants
+- team-owned assistants that the installer administers
+- catalog entries
+- workflow templates
+
+Spritz should own the picker UX and the generic API contract. The deployment
+should own which targets are eligible, what the selected target means, and how
+that selection resolves into the final concierge binding.
+
+Related docs:
+
+- [Shared Channel Concierge Lifecycle Architecture](2026-03-31-shared-channel-concierge-lifecycle-architecture.md)
+- [Channel Install Result Surface](2026-04-02-channel-install-result-surface.md)
+- [Agent Profile API](2026-03-30-agent-profile-api.md)
+
+## Plain Language
+
+During install, Spritz should ask, "Which thing do you want this workspace to
+use?"
+
+Spritz should not know what that thing really is. It should ask the deployment
+for the list, render the options, save the chosen opaque payload, and send that
+payload back later when concierge creation or recovery needs it.
+
+## Problem
+
+Shared channel installs currently assume the deployment can finalize an
+installation without an extra user choice.
+
+That breaks down when one installer may have access to more than one valid
+target. In those cases, Spritz needs one explicit selection step, but it must
+not grow deployment-specific concepts such as:
+
+- "agent"
+- "organization admin"
+- deployment-specific ownership rules
+
+If Spritz bakes those concepts into core install APIs, the shared channel flow
+stops being reusable.
+
+## Goals
+
+- Add a generic install-time target picker to shared channel install flows.
+- Keep Spritz provider-agnostic and deployment-agnostic.
+- Reuse existing Spritz concepts where possible instead of inventing a new
+  domain model.
+- Persist the chosen target as part of the durable logical installation, not as
+  transient browser state.
+- Ensure runtime creation, replacement, and recovery can reapply the same
+  selection without asking the user again.
+
+## Non-Goals
+
+- Defining deployment-specific authorization rules for which targets are
+  visible.
+- Making Spritz understand deployment-specific target types.
+- Moving deployment-owned installation storage into Spritz core.
+- Replacing the existing per-instance `agentRef` and profile sync model.
+
+## Core Decision
+
+Spritz should model this as installation-time target selection.
+
+That means:
+
+- Spritz owns the browser flow and generic picker contract.
+- The deployment owns the list of eligible targets.
+- The deployment also owns the meaning of the chosen target.
+- The chosen target is stored as opaque `presetInputs`, not as a Spritz-level
+  `agentId` or other deployment-specific foreign key.
+
+This is the same boundary used elsewhere in Spritz:
+
+- Spritz understands stable generic fields.
+- Deployments own business semantics behind those fields.
+
+## Pinned V1 Decisions
+
+The following decisions are intentionally locked for the first production
+implementation.
+
+### Contract
+
+- Spritz defines one generic list operation:
+  - `channel.install.targets.list`
+- Spritz does not define a target taxonomy.
+- Spritz does not add a core `agentId`, `targetType`, or deployment-specific
+  enum to this contract.
+- The install option shape is minimal and stable:
+  - `id`
+  - `profile.name`
+  - optional `profile.imageUrl`
+  - optional `ownerLabel`
+  - `presetInputs`
+- Spritz treats `presetInputs` as fully opaque and only round-trips it.
+
+### UX
+
+- If the deployment returns zero targets, install fails with a typed product
+  error.
+- If the deployment returns one target, Spritz auto-selects it and continues.
+- If the deployment returns two or more targets, Spritz shows a picker.
+- The picker remains intentionally simple in v1:
+  - avatar
+  - name
+  - owner label
+- Spritz does not add search, filtering, tabs, or target categories in v1.
+
+### Persistence and binding
+
+- Spritz does not persist the chosen target in Spritz core state.
+- The deployment persists the chosen `presetInputs` on its own durable
+  installation record.
+- The same saved `presetInputs` must be reused for:
+  - first provisioning
+  - reprovisioning
+  - recovery
+  - repair
+
+### Validation
+
+- The deployment must validate the chosen `presetInputs` when install is
+  finalized.
+- The deployment must validate again when replaying the saved selection during
+  recovery or reprovisioning.
+- Spritz must never trust browser-submitted selection data on its own.
+
+### Errors
+
+- `install_targets_unavailable`
+- `install_targets_empty`
+- `install_target_invalid`
+- `install_target_forbidden`
+- `install_target_conflict`
+
+These codes are generic enough for Spritz while still mapping cleanly onto
+deployment-owned policy and validation failures.
+
+## Why `presetInputs` Is The Right Payload
+
+Spritz already has a generic way to pass deployment-owned create-time selector
+data into preset resolution: `presetInputs`.
+
+That is the preferred payload for install target selection as well.
+
+Reasons:
+
+- it is already part of the create-admission model
+- Spritz does not need to understand the inner fields
+- deployments can map it to whatever target type they use
+- the same payload can be reused during initial create and later recovery
+
+The chosen opaque `presetInputs` should therefore be persisted on the durable
+installation object that the deployment already owns, not in Spritz core state.
+
+## Why Existing `agentRef` Is Not Enough
+
+The existing [Agent Profile API](2026-03-30-agent-profile-api.md) is for a
+bound instance that already points at one external identity.
+
+That model is useful here only for presentation patterns:
+
+- `name`
+- `imageUrl`
+
+It is not the right install contract by itself because install-time choice is a
+list-selection problem, not a per-instance bound-identity problem.
+
+In other words:
+
+- `agentRef` is for "this running instance points at that external thing"
+- install target selection is for "show the user eligible options, then save
+  the chosen opaque selector"
+
+## UX Flow
+
+Recommended browser flow:
+
+1. The user starts a shared channel install such as Slack.
+2. Provider OAuth completes and returns to Spritz.
+3. Spritz resolves the installer identity and install context.
+4. Spritz calls a deployment-owned target-listing contract.
+5. Spritz renders the returned options in a picker.
+6. The user chooses one option.
+7. Spritz submits the chosen option's `presetInputs` during install
+   finalization.
+8. The deployment validates the choice again, persists it on the installation
+   record, and provisions or reuses the logical concierge binding.
+
+Rules:
+
+- Spritz must not trust a client-supplied choice without deployment-side
+  revalidation.
+- If zero targets are returned, Spritz must stop the install with a typed
+  product error.
+- If exactly one target is returned, Spritz should auto-select it.
+- If more than one target is returned, Spritz should show the picker.
+- The picker should render only the minimal display fields needed for a clear
+  choice:
+  - avatar
+  - name
+  - owner label
+- If the install later recreates or repairs the runtime, the saved
+  `presetInputs` must be reused.
+- Existing installs without saved `presetInputs` may keep their current
+  deployment-defined fallback behavior until reconfigured.
+
+## Generic Contract
+
+### 1. List install targets
+
+Spritz should define one generic deployment contract for listing install
+targets. One possible operation name is:
+
+- `channel.install.targets.list`
+
+The exact transport can follow the existing deployment adapter pattern, but the
+contract should be stable and generic.
+
+The request should include only install facts Spritz already knows, for
+example:
+
+```json
+{
+  "version": "v1",
+  "type": "resolver",
+  "operation": "channel.install.targets.list",
+  "requestId": "req_123",
+  "context": {
+    "principalId": "shared-channel-gateway",
+    "provider": "slack",
+    "externalScopeType": "workspace",
+    "externalTenantId": "T123456",
+    "presetId": "channel-concierge"
+  },
+  "input": {
+    "installer": {
+      "type": "external",
+      "provider": "slack",
+      "subject": "U123456"
+    }
+  }
+}
+```
+
+The deployment response should return display-ready options plus opaque
+`presetInputs`:
+
+```json
+{
+  "status": "resolved",
+  "output": {
+    "targets": [
+      {
+        "id": "personal-assistant",
+        "profile": {
+          "name": "Research Assistant",
+          "imageUrl": "https://console.example.com/assets/research-assistant.png"
+        },
+        "ownerLabel": "Personal",
+        "presetInputs": {
+          "targetId": "assistant-123"
+        }
+      },
+      {
+        "id": "team-support",
+        "profile": {
+          "name": "Support Concierge",
+          "imageUrl": "https://console.example.com/assets/support-concierge.png"
+        },
+        "ownerLabel": "Example Team",
+        "presetInputs": {
+          "targetId": "assistant-456"
+        }
+      }
+    ]
+  }
+}
+```
+
+Contract rules:
+
+- `targets[].id` is a stable client key only
+- `targets[].profile` is for display only
+- `targets[].profile.name` is required
+- `targets[].profile.imageUrl` is optional
+- `targets[].ownerLabel` is optional
+- `targets[].presetInputs` is opaque to Spritz
+- Spritz must round-trip `presetInputs` unchanged
+- the deployment may return zero, one, or many targets
+- Spritz must not infer target type or business meaning from any returned field
+
+### 2. Finalize install with chosen target
+
+When the user submits the picker, Spritz should send the chosen `presetInputs`
+through the normal install finalization path.
+
+Spritz should not extract or reinterpret inner fields.
+
+The deployment must:
+
+- validate that the selection is still allowed
+- reject tampered or stale selections
+- persist the validated `presetInputs` on the durable installation record it
+  already owns
+
+### 3. Use the saved target during provisioning and recovery
+
+Whenever the logical installation provisions, reprovisions, or repairs its live
+runtime, the deployment should feed the saved `presetInputs` back into normal
+preset resolution.
+
+That keeps install-time selection and runtime binding on the same path.
+
+## Scope Split
+
+### Spritz owns
+
+- the install picker step
+- the generic target-listing contract
+- the browser-facing rendering of options
+- collection and round-tripping of the chosen `presetInputs`
+- typed install-result handling when target listing or target submission fails
+
+### Deployment-owned integration owns
+
+- resolving the installer's identity
+- deciding which targets are eligible
+- deciding whether eligibility depends on personal ownership, team admin
+  rights, or any other policy
+- validating the selected target
+- persisting the chosen `presetInputs`
+- mapping that selection to the real concierge binding
+
+## Error Handling
+
+The picker flow should follow the same normalized install-result model as the
+rest of channel install.
+
+Recommended cases:
+
+- `install_targets_unavailable`
+- `install_targets_empty`
+- `install_target_invalid`
+- `install_target_forbidden`
+- `install_target_conflict`
+
+Spritz should render those as product outcomes on the install result surface,
+not as raw upstream failures.
+
+## Validation
+
+Minimum validation for this model:
+
+- a user with one eligible target can finish install successfully
+- a user with multiple eligible targets sees a picker and the chosen target is
+  the one that is bound
+- a tampered `presetInputs` submission is rejected by the deployment
+- runtime replacement reuses the saved `presetInputs`
+- installs without saved `presetInputs` preserve existing fallback behavior
+  until explicitly reconfigured
+- the UI renders from the returned display fields without needing deployment
+  knowledge in the browser
+
+## Follow-Ups
+
+- define the exact Spritz route and UI component for the picker step
+- wire the shared channel gateway callback to the target-listing contract
+- extend deployment-owned installation finalizers to persist `presetInputs`
+- reuse the same pattern for future shared channel providers beyond Slack

--- a/integrations/slack-gateway/backend_client.go
+++ b/integrations/slack-gateway/backend_client.go
@@ -54,6 +54,23 @@ type backendInstallationUpsertResponse struct {
 	} `json:"installation"`
 }
 
+type backendInstallTargetProfile struct {
+	Name     string `json:"name"`
+	ImageURL string `json:"imageUrl,omitempty"`
+}
+
+type backendInstallTarget struct {
+	ID           string                      `json:"id"`
+	Profile      backendInstallTargetProfile `json:"profile"`
+	OwnerLabel   string                      `json:"ownerLabel,omitempty"`
+	PresetInputs map[string]any              `json:"presetInputs"`
+}
+
+type backendInstallTargetListResponse struct {
+	Status  string                 `json:"status"`
+	Targets []backendInstallTarget `json:"targets"`
+}
+
 type spritzConversationUpsertResponse struct {
 	Status string `json:"status"`
 	Data   struct {
@@ -187,6 +204,34 @@ func (g *slackGateway) exchangeChannelSession(ctx context.Context, teamID string
 		InstanceID:   payload.Session.InstanceID,
 		ProviderAuth: payload.Session.ProviderAuth,
 	}, nil
+}
+
+func (g *slackGateway) listInstallTargets(ctx context.Context, installation *slackInstallation, requestID string) ([]backendInstallTarget, error) {
+	if installation == nil {
+		return nil, fmt.Errorf("installation is required")
+	}
+	body := map[string]any{
+		"principalId":       g.cfg.PrincipalID,
+		"provider":          slackProvider,
+		"externalScopeType": slackWorkspaceScope,
+		"externalTenantId":  installation.TeamID,
+		"presetId":          g.presetID(),
+		"ownerRef": map[string]any{
+			"type":     "external",
+			"provider": slackProvider,
+			"subject":  installation.InstallingUserID,
+			"tenant":   installation.TeamID,
+		},
+		"requestId": strings.TrimSpace(requestID),
+	}
+	var payload backendInstallTargetListResponse
+	if err := g.postBackendJSON(ctx, "/internal/v2/spritz/channel-install-targets/list", body, &payload); err != nil {
+		return nil, err
+	}
+	if payload.Status != "resolved" {
+		return nil, fmt.Errorf("channel install targets were not resolved")
+	}
+	return payload.Targets, nil
 }
 
 func (g *slackGateway) upsertChannelConversation(ctx context.Context, session channelSession, event slackEventInner, teamID, conversationID, externalConversationID string, lookupExternalConversationIDs []string) (string, error) {

--- a/integrations/slack-gateway/gateway.go
+++ b/integrations/slack-gateway/gateway.go
@@ -73,6 +73,7 @@ func (g *slackGateway) routes() http.Handler {
 	mux := http.NewServeMux()
 	g.registerRoute(mux, "/healthz", g.handleHealthz)
 	g.registerRoute(mux, "/slack/install", g.handleInstallRedirect)
+	g.registerRoute(mux, "/slack/install/select", g.handleInstallTargetSelection)
 	g.registerRoute(mux, "/slack/install/result", g.handleInstallResult)
 	g.registerRoute(mux, "/slack/oauth/callback", g.handleOAuthCallback)
 	g.registerRoute(mux, "/slack/events", g.handleSlackEvents)

--- a/integrations/slack-gateway/gateway_test.go
+++ b/integrations/slack-gateway/gateway_test.go
@@ -23,21 +23,41 @@ import (
 	"spritz.sh/acptext"
 )
 
-func TestOAuthCallbackStoresInstallationAndUpsertsRegistry(t *testing.T) {
+func TestOAuthCallbackAutoSelectsSingleInstallTargetAndUpsertsRegistry(t *testing.T) {
 	var upsertPayload map[string]any
+	listHits := 0
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/internal/v1/spritz/channel-installations/upsert" {
+		switch r.URL.Path {
+		case "/internal/v2/spritz/channel-install-targets/list":
+			listHits++
+			writeJSON(w, http.StatusOK, map[string]any{
+				"status": "resolved",
+				"targets": []map[string]any{
+					{
+						"id": "ag_123",
+						"profile": map[string]any{
+							"name": "Workspace Helper",
+						},
+						"ownerLabel": "Personal",
+						"presetInputs": map[string]any{
+							"agentId": "ag_123",
+						},
+					},
+				},
+			})
+		case "/internal/v1/spritz/channel-installations/upsert":
+			if err := json.NewDecoder(r.Body).Decode(&upsertPayload); err != nil {
+				t.Fatalf("decode backend payload: %v", err)
+			}
+			writeJSON(w, http.StatusOK, map[string]any{
+				"status": "resolved",
+				"installation": map[string]any{
+					"providerInstallRef": "cred_slack_workspace_1",
+				},
+			})
+		default:
 			t.Fatalf("unexpected backend path %s", r.URL.Path)
 		}
-		if err := json.NewDecoder(r.Body).Decode(&upsertPayload); err != nil {
-			t.Fatalf("decode backend payload: %v", err)
-		}
-		writeJSON(w, http.StatusOK, map[string]any{
-			"status": "resolved",
-			"installation": map[string]any{
-				"providerInstallRef": "cred_slack_workspace_1",
-			},
-		})
 	}))
 	defer backend.Close()
 
@@ -149,6 +169,16 @@ func TestOAuthCallbackStoresInstallationAndUpsertsRegistry(t *testing.T) {
 	if upsertPayload["requestId"] != requestID {
 		t.Fatalf("expected requestId to propagate to backend, got %#v", upsertPayload["requestId"])
 	}
+	presetInputs, ok := upsertPayload["presetInputs"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected presetInputs object, got %#v", upsertPayload["presetInputs"])
+	}
+	if presetInputs["agentId"] != "ag_123" {
+		t.Fatalf("expected selected agentId ag_123, got %#v", presetInputs["agentId"])
+	}
+	if listHits != 1 {
+		t.Fatalf("expected install targets to be listed once, got %d", listHits)
+	}
 
 	resultReq := httptest.NewRequest(http.MethodGet, redirectURL.RequestURI(), nil)
 	resultRec := httptest.NewRecorder()
@@ -166,6 +196,187 @@ func TestOAuthCallbackStoresInstallationAndUpsertsRegistry(t *testing.T) {
 	}
 	if !strings.Contains(body, requestID) {
 		t.Fatalf("expected request id in result page, got %q", body)
+	}
+}
+
+func TestOAuthCallbackRendersInstallTargetPickerWhenMultipleTargetsAvailable(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/internal/v2/spritz/channel-install-targets/list":
+			writeJSON(w, http.StatusOK, map[string]any{
+				"status": "resolved",
+				"targets": []map[string]any{
+					{
+						"id": "ag_123",
+						"profile": map[string]any{
+							"name": "Personal Helper",
+						},
+						"ownerLabel": "Personal",
+						"presetInputs": map[string]any{
+							"agentId": "ag_123",
+						},
+					},
+					{
+						"id": "ag_456",
+						"profile": map[string]any{
+							"name": "Org Helper",
+						},
+						"ownerLabel": "Acme Workspace",
+						"presetInputs": map[string]any{
+							"agentId": "ag_456",
+						},
+					},
+				},
+			})
+		case "/internal/v1/spritz/channel-installations/upsert":
+			t.Fatal("upsert should not happen before the picker selection")
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer backend.Close()
+
+	slackAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"ok":           true,
+			"app_id":       "A_app_1",
+			"scope":        "chat:write",
+			"access_token": "xoxb-installed",
+			"bot_user_id":  "U_bot",
+			"team":         map[string]any{"id": "T_workspace_1"},
+			"authed_user":  map[string]any{"id": "U_installer"},
+		})
+	}))
+	defer slackAPI.Close()
+
+	gateway := newSlackGateway(config{
+		PublicURL:            "https://gateway.example.test",
+		SlackClientID:        "client-id",
+		SlackClientSecret:    "client-secret",
+		SlackSigningSecret:   "signing-secret",
+		OAuthStateSecret:     "oauth-state-secret",
+		SlackAPIBaseURL:      slackAPI.URL,
+		SlackBotScopes:       []string{"chat:write"},
+		BackendBaseURL:       backend.URL,
+		BackendInternalToken: "backend-internal-token",
+		SpritzBaseURL:        "https://spritz.example.test",
+		SpritzServiceToken:   "spritz-service-token",
+		PrincipalID:          "shared-slack-gateway",
+		HTTPTimeout:          5 * time.Second,
+		DedupeTTL:            time.Minute,
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	state, err := gateway.state.generate()
+	if err != nil {
+		t.Fatalf("state generate failed: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/slack/oauth/callback?code=test-code&state="+url.QueryEscape(state), nil)
+	rec := httptest.NewRecorder()
+	gateway.handleOAuthCallback(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected picker page 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "Choose an install target") {
+		t.Fatalf("expected picker title, got %q", body)
+	}
+	if !strings.Contains(body, "Personal Helper") || !strings.Contains(body, "Org Helper") {
+		t.Fatalf("expected picker targets, got %q", body)
+	}
+	if !strings.Contains(body, `/slack/install/select`) {
+		t.Fatalf("expected picker form action, got %q", body)
+	}
+	if strings.Contains(body, "xoxb-installed") {
+		t.Fatalf("expected picker state to keep bot token encrypted, got %q", body)
+	}
+}
+
+func TestInstallTargetSelectionUsesSelectedPresetInputs(t *testing.T) {
+	var upsertPayload map[string]any
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/internal/v1/spritz/channel-installations/upsert" {
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&upsertPayload); err != nil {
+			t.Fatalf("decode backend payload: %v", err)
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"status": "resolved",
+			"installation": map[string]any{
+				"providerInstallRef": "cred_slack_workspace_1",
+			},
+		})
+	}))
+	defer backend.Close()
+
+	gateway := newSlackGateway(config{
+		PublicURL:            "https://gateway.example.test",
+		SlackClientID:        "client-id",
+		SlackClientSecret:    "client-secret",
+		SlackSigningSecret:   "signing-secret",
+		OAuthStateSecret:     "oauth-state-secret",
+		SlackAPIBaseURL:      "https://slack.example.test/api",
+		SlackBotScopes:       []string{"chat:write"},
+		BackendBaseURL:       backend.URL,
+		BackendInternalToken: "backend-internal-token",
+		SpritzBaseURL:        "https://spritz.example.test",
+		SpritzServiceToken:   "spritz-service-token",
+		PrincipalID:          "shared-slack-gateway",
+		HTTPTimeout:          5 * time.Second,
+		DedupeTTL:            time.Minute,
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	pendingState, err := gateway.state.generatePendingInstall(pendingInstallState{
+		RequestID: "install-request-1",
+		Installation: slackInstallation{
+			TeamID:           "T_workspace_1",
+			InstallingUserID: "U_installer",
+			BotAccessToken:   "xoxb-installed",
+			BotUserID:        "U_bot",
+			APIAppID:         "A_app_1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("generate pending install state failed: %v", err)
+	}
+	encodedTarget, err := encodeInstallTargetSelection(map[string]any{"agentId": "ag_456"})
+	if err != nil {
+		t.Fatalf("encode target selection failed: %v", err)
+	}
+
+	form := url.Values{}
+	form.Set("state", pendingState)
+	form.Set("target", encodedTarget)
+	form.Set("requestId", "install-request-1")
+	req := httptest.NewRequest(http.MethodPost, "/slack/install/select", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	gateway.handleInstallTargetSelection(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303 after selection submit, got %d: %s", rec.Code, rec.Body.String())
+	}
+	redirectURL, err := url.Parse(rec.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse callback redirect: %v", err)
+	}
+	if redirectURL.Query().Get("code") != "installed" {
+		t.Fatalf("expected installed code, got %q", redirectURL.Query().Get("code"))
+	}
+	presetInputs, ok := upsertPayload["presetInputs"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected presetInputs object, got %#v", upsertPayload["presetInputs"])
+	}
+	if presetInputs["agentId"] != "ag_456" {
+		t.Fatalf("expected selected agentId ag_456, got %#v", presetInputs["agentId"])
+	}
+	providerAuth, ok := upsertPayload["providerAuth"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected providerAuth object, got %#v", upsertPayload["providerAuth"])
+	}
+	if providerAuth["botAccessToken"] != "xoxb-installed" {
+		t.Fatalf("expected stored provider auth to round-trip, got %#v", providerAuth["botAccessToken"])
 	}
 }
 
@@ -245,7 +456,27 @@ func TestRoutesServeSlackEndpointsUnderConfiguredPublicURLPathPrefix(t *testing.
 
 func TestOAuthCallbackRedirectsToControlledRetryableErrorWhenBackendUpsertFails(t *testing.T) {
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "backend unavailable", http.StatusServiceUnavailable)
+		switch r.URL.Path {
+		case "/internal/v2/spritz/channel-install-targets/list":
+			writeJSON(w, http.StatusOK, map[string]any{
+				"status": "resolved",
+				"targets": []map[string]any{
+					{
+						"id": "ag_123",
+						"profile": map[string]any{
+							"name": "Workspace Helper",
+						},
+						"presetInputs": map[string]any{
+							"agentId": "ag_123",
+						},
+					},
+				},
+			})
+		case "/internal/v1/spritz/channel-installations/upsert":
+			http.Error(w, "backend unavailable", http.StatusServiceUnavailable)
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
 	}))
 	defer backend.Close()
 

--- a/integrations/slack-gateway/install_result.go
+++ b/integrations/slack-gateway/install_result.go
@@ -31,6 +31,11 @@ const (
 	installResultCodeIdentityUnresolved  installResultCode = "identity.unresolved"
 	installResultCodeIdentityForbidden   installResultCode = "identity.forbidden"
 	installResultCodeIdentityAmbiguous   installResultCode = "identity.ambiguous"
+	installResultCodeTargetsEmpty        installResultCode = "install.targets.empty"
+	installResultCodeTargetsUnavailable  installResultCode = "install.targets.unavailable"
+	installResultCodeTargetInvalid       installResultCode = "install.target.invalid"
+	installResultCodeTargetForbidden     installResultCode = "install.target.forbidden"
+	installResultCodeTargetConflict      installResultCode = "install.target.conflict"
 	installResultCodeRegistryConflict    installResultCode = "registry.conflict"
 	installResultCodeResolverUnavailable installResultCode = "resolver.unavailable"
 	installResultCodeRuntimeUnavailable  installResultCode = "runtime.unavailable"
@@ -251,6 +256,42 @@ func installResultDescriptorFor(code installResultCode, installURL string) insta
 			ActionLabel: "Start install again",
 			ActionHref:  installURL,
 		}
+	case installResultCodeTargetsEmpty:
+		return installResultDescriptor{
+			Title:       "No install targets are available",
+			Message:     "This account does not have any eligible targets for this workspace install yet.",
+			ActionLabel: "Start install again",
+			ActionHref:  installURL,
+		}
+	case installResultCodeTargetsUnavailable:
+		return installResultDescriptor{
+			Title:       "Install targets are unavailable",
+			Message:     "The install target picker could not be loaded right now. Please try again shortly.",
+			Retryable:   true,
+			ActionLabel: "Start install again",
+			ActionHref:  installURL,
+		}
+	case installResultCodeTargetInvalid:
+		return installResultDescriptor{
+			Title:       "Selected install target is invalid",
+			Message:     "The chosen install target is no longer valid. Start the install again and pick a current target.",
+			ActionLabel: "Start install again",
+			ActionHref:  installURL,
+		}
+	case installResultCodeTargetForbidden:
+		return installResultDescriptor{
+			Title:       "Selected install target is not allowed",
+			Message:     "This install target is not available for the current installer.",
+			ActionLabel: "Start install again",
+			ActionHref:  installURL,
+		}
+	case installResultCodeTargetConflict:
+		return installResultDescriptor{
+			Title:       "Install target selection is ambiguous",
+			Message:     "The requested install target could not be resolved uniquely. Start the install again and choose a specific target.",
+			ActionLabel: "Start install again",
+			ActionHref:  installURL,
+		}
 	case installResultCodeRegistryConflict:
 		return installResultDescriptor{
 			Title:       "Install conflicts with existing state",
@@ -295,6 +336,11 @@ func normalizeInstallResultCode(raw string) installResultCode {
 		installResultCodeIdentityUnresolved,
 		installResultCodeIdentityForbidden,
 		installResultCodeIdentityAmbiguous,
+		installResultCodeTargetsEmpty,
+		installResultCodeTargetsUnavailable,
+		installResultCodeTargetInvalid,
+		installResultCodeTargetForbidden,
+		installResultCodeTargetConflict,
 		installResultCodeRegistryConflict,
 		installResultCodeResolverUnavailable,
 		installResultCodeRuntimeUnavailable,
@@ -314,6 +360,16 @@ func normalizeInstallResultCode(raw string) installResultCode {
 		return installResultCodeIdentityForbidden
 	case "external_identity_ambiguous":
 		return installResultCodeIdentityAmbiguous
+	case "install_targets_empty":
+		return installResultCodeTargetsEmpty
+	case "install_targets_unavailable":
+		return installResultCodeTargetsUnavailable
+	case "install_target_invalid":
+		return installResultCodeTargetInvalid
+	case "install_target_forbidden":
+		return installResultCodeTargetForbidden
+	case "install_target_conflict":
+		return installResultCodeTargetConflict
 	case "installation_conflict":
 		return installResultCodeRegistryConflict
 	case "installation_registry_unavailable":

--- a/integrations/slack-gateway/install_result_test.go
+++ b/integrations/slack-gateway/install_result_test.go
@@ -30,3 +30,16 @@ func TestClassifyInstallUpsertErrorMapsLegacyOwnerRefUnresolvedPayloads(t *testi
 		t.Fatalf("expected external identity unresolved, got %q", got)
 	}
 }
+
+func TestClassifyInstallUpsertErrorMapsInstallTargetCodes(t *testing.T) {
+	err := &httpStatusError{
+		method:     http.MethodPost,
+		endpoint:   "/internal/installations/upsert",
+		statusCode: http.StatusNotFound,
+		body:       `{"error":"install_targets_empty"}`,
+	}
+
+	if got := classifyInstallUpsertError(err); got != installResultCodeTargetsEmpty {
+		t.Fatalf("expected install target empty code, got %q", got)
+	}
+}

--- a/integrations/slack-gateway/install_target_picker.go
+++ b/integrations/slack-gateway/install_target_picker.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"net/http"
+	"strings"
+)
+
+type installTargetPickerOption struct {
+	Name               string
+	ImageURL           string
+	OwnerLabel         string
+	EncodedPresetInput string
+}
+
+type installTargetPickerPageData struct {
+	RequestID  string
+	FormAction string
+	StateToken string
+	Options    []installTargetPickerOption
+}
+
+var installTargetPickerTemplate = template.Must(template.New("install-target-picker").Parse(`<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Choose an install target</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f4f1ea;
+        --surface: #fffdf9;
+        --border: #ddd5c8;
+        --text: #1f1b16;
+        --muted: #675d50;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: linear-gradient(180deg, var(--bg), #ebe4d7);
+        color: var(--text);
+        display: grid;
+        place-items: center;
+        padding: 24px;
+      }
+      main {
+        width: min(680px, 100%);
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 24px;
+        padding: 28px;
+        box-shadow: 0 24px 80px rgba(31, 27, 22, 0.08);
+      }
+      h1 {
+        margin: 0 0 10px;
+        font-size: 30px;
+        line-height: 1.1;
+      }
+      p {
+        margin: 0 0 22px;
+        color: var(--muted);
+        line-height: 1.6;
+      }
+      form {
+        display: grid;
+        gap: 12px;
+      }
+      label {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 14px;
+        align-items: center;
+        padding: 14px 16px;
+        border: 1px solid var(--border);
+        border-radius: 18px;
+        cursor: pointer;
+      }
+      input[type="radio"] {
+        margin: 0;
+      }
+      .row {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+      .avatar {
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        overflow: hidden;
+        background: #ede6da;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 14px;
+        color: var(--muted);
+      }
+      .avatar img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
+      }
+      .name {
+        font-weight: 600;
+      }
+      .owner {
+        color: var(--muted);
+        font-size: 14px;
+      }
+      button {
+        margin-top: 8px;
+        border: 0;
+        border-radius: 999px;
+        padding: 12px 18px;
+        background: var(--text);
+        color: #fff;
+        font-weight: 600;
+        cursor: pointer;
+      }
+      .meta {
+        margin-top: 18px;
+        padding-top: 18px;
+        border-top: 1px solid var(--border);
+        color: var(--muted);
+        font-size: 13px;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Choose an install target</h1>
+      <p>Select which target this Slack workspace should use.</p>
+      <form method="post" action="{{ .FormAction }}">
+        <input type="hidden" name="state" value="{{ .StateToken }}">
+        <input type="hidden" name="requestId" value="{{ .RequestID }}">
+        {{ range $index, $option := .Options }}
+        <label>
+          <input type="radio" name="target" value="{{ $option.EncodedPresetInput }}" {{ if eq $index 0 }}checked{{ end }}>
+          <span class="row">
+            <span class="avatar">
+              {{ if $option.ImageURL }}
+              <img src="{{ $option.ImageURL }}" alt="">
+              {{ else }}
+              {{ slice $option.Name 0 1 }}
+              {{ end }}
+            </span>
+            <span>
+              <div class="name">{{ $option.Name }}</div>
+              {{ if $option.OwnerLabel }}
+              <div class="owner">{{ $option.OwnerLabel }}</div>
+              {{ end }}
+            </span>
+          </span>
+        </label>
+        {{ end }}
+        <button type="submit">Continue</button>
+      </form>
+      {{ if .RequestID }}
+      <div class="meta">Request ID: <code>{{ .RequestID }}</code></div>
+      {{ end }}
+    </main>
+  </body>
+</html>`))
+
+func encodeInstallTargetSelection(presetInputs map[string]any) (string, error) {
+	if len(presetInputs) == 0 {
+		return "", fmt.Errorf("preset inputs are required")
+	}
+	encoded, err := json.Marshal(presetInputs)
+	if err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(encoded), nil
+}
+
+func decodeInstallTargetSelection(raw string) (map[string]any, error) {
+	decoded, err := base64.RawURLEncoding.DecodeString(strings.TrimSpace(raw))
+	if err != nil {
+		return nil, err
+	}
+	var presetInputs map[string]any
+	if err := json.Unmarshal(decoded, &presetInputs); err != nil {
+		return nil, err
+	}
+	if len(presetInputs) == 0 {
+		return nil, fmt.Errorf("preset inputs are required")
+	}
+	return presetInputs, nil
+}
+
+func (g *slackGateway) renderInstallTargetPicker(w http.ResponseWriter, stateToken, requestID string, targets []backendInstallTarget) {
+	options := make([]installTargetPickerOption, 0, len(targets))
+	for _, target := range targets {
+		encodedPresetInput, err := encodeInstallTargetSelection(target.PresetInputs)
+		if err != nil {
+			http.Error(w, "install target is invalid", http.StatusInternalServerError)
+			return
+		}
+		options = append(options, installTargetPickerOption{
+			Name:               strings.TrimSpace(target.Profile.Name),
+			ImageURL:           strings.TrimSpace(target.Profile.ImageURL),
+			OwnerLabel:         strings.TrimSpace(target.OwnerLabel),
+			EncodedPresetInput: encodedPresetInput,
+		})
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_ = installTargetPickerTemplate.Execute(w, installTargetPickerPageData{
+		RequestID:  requestID,
+		FormAction: g.selectInstallTargetPath(),
+		StateToken: stateToken,
+		Options:    options,
+	})
+}

--- a/integrations/slack-gateway/slack_oauth.go
+++ b/integrations/slack-gateway/slack_oauth.go
@@ -154,7 +154,71 @@ func (g *slackGateway) handleOAuthCallback(w http.ResponseWriter, r *http.Reques
 		})
 		return
 	}
-	if err := g.upsertInstallation(r.Context(), &installation, requestID); err != nil {
+	targets, err := g.listInstallTargets(r.Context(), &installation, requestID)
+	if err != nil {
+		g.logger.ErrorContext(
+			r.Context(),
+			"slack oauth callback install target lookup failed",
+			"err",
+			err,
+			"team_id",
+			installation.TeamID,
+			"installing_user_id",
+			installation.InstallingUserID,
+			"request_id",
+			requestID,
+		)
+		g.redirectToInstallResult(w, r, installResult{
+			Status:    installResultStatusError,
+			Code:      classifyInstallUpsertError(err),
+			Operation: installResultOperationChannelInstall,
+			Provider:  slackProvider,
+			RequestID: requestID,
+			TeamID:    installation.TeamID,
+		})
+		return
+	}
+	if len(targets) == 0 {
+		g.redirectToInstallResult(w, r, installResult{
+			Status:    installResultStatusError,
+			Code:      installResultCodeTargetsEmpty,
+			Operation: installResultOperationChannelInstall,
+			Provider:  slackProvider,
+			RequestID: requestID,
+			TeamID:    installation.TeamID,
+		})
+		return
+	}
+	if len(targets) > 1 {
+		pendingState, stateErr := g.state.generatePendingInstall(pendingInstallState{
+			RequestID:    requestID,
+			Installation: installation,
+		})
+		if stateErr != nil {
+			g.logger.ErrorContext(
+				r.Context(),
+				"slack oauth callback pending install state generation failed",
+				"err",
+				stateErr,
+				"team_id",
+				installation.TeamID,
+				"request_id",
+				requestID,
+			)
+			g.redirectToInstallResult(w, r, installResult{
+				Status:    installResultStatusError,
+				Code:      installResultCodeInternalError,
+				Operation: installResultOperationChannelInstall,
+				Provider:  slackProvider,
+				RequestID: requestID,
+				TeamID:    installation.TeamID,
+			})
+			return
+		}
+		g.renderInstallTargetPicker(w, pendingState, requestID, targets)
+		return
+	}
+	if err := g.upsertInstallation(r.Context(), &installation, requestID, targets[0].PresetInputs); err != nil {
 		g.logger.ErrorContext(
 			r.Context(),
 			"slack oauth callback installation upsert failed",
@@ -197,6 +261,10 @@ func (g *slackGateway) handleOAuthCallback(w http.ResponseWriter, r *http.Reques
 
 func (g *slackGateway) oauthCallbackURL() string {
 	return g.cfg.PublicURL + "/slack/oauth/callback"
+}
+
+func (g *slackGateway) selectInstallTargetPath() string {
+	return g.publicPathPrefix() + "/slack/install/select"
 }
 
 func (g *slackGateway) exchangeSlackOAuthCode(ctx context.Context, code string) (slackInstallation, error) {
@@ -242,7 +310,80 @@ func (g *slackGateway) exchangeSlackOAuthCode(ctx context.Context, code string) 
 	return record, nil
 }
 
-func (g *slackGateway) upsertInstallation(ctx context.Context, installation *slackInstallation, requestID string) error {
+func (g *slackGateway) handleInstallTargetSelection(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		g.redirectToInstallResult(w, r, installResult{
+			Status:    installResultStatusError,
+			Code:      installResultCodeTargetInvalid,
+			Operation: installResultOperationChannelInstall,
+			Provider:  slackProvider,
+		})
+		return
+	}
+
+	pendingInstall, err := g.state.parsePendingInstall(strings.TrimSpace(r.FormValue("state")))
+	if err != nil {
+		resultCode := installResultCodeStateInvalid
+		if strings.Contains(strings.ToLower(err.Error()), "expired") {
+			resultCode = installResultCodeStateExpired
+		}
+		g.redirectToInstallResult(w, r, installResult{
+			Status:    installResultStatusError,
+			Code:      resultCode,
+			Operation: installResultOperationChannelInstall,
+			Provider:  slackProvider,
+		})
+		return
+	}
+
+	selectedPresetInputs, err := decodeInstallTargetSelection(strings.TrimSpace(r.FormValue("target")))
+	if err != nil {
+		g.redirectToInstallResult(w, r, installResult{
+			Status:    installResultStatusError,
+			Code:      installResultCodeTargetInvalid,
+			Operation: installResultOperationChannelInstall,
+			Provider:  slackProvider,
+			RequestID: pendingInstall.RequestID,
+			TeamID:    pendingInstall.Installation.TeamID,
+		})
+		return
+	}
+
+	requestID := firstNonEmpty(strings.TrimSpace(r.FormValue("requestId")), pendingInstall.RequestID)
+	installation := pendingInstall.Installation
+	if err := g.upsertInstallation(r.Context(), &installation, requestID, selectedPresetInputs); err != nil {
+		g.logger.ErrorContext(
+			r.Context(),
+			"slack install target selection upsert failed",
+			"err",
+			err,
+			"team_id",
+			installation.TeamID,
+			"request_id",
+			requestID,
+		)
+		g.redirectToInstallResult(w, r, installResult{
+			Status:    installResultStatusError,
+			Code:      classifyInstallUpsertError(err),
+			Operation: installResultOperationChannelInstall,
+			Provider:  slackProvider,
+			RequestID: requestID,
+			TeamID:    installation.TeamID,
+		})
+		return
+	}
+
+	g.redirectToInstallResult(w, r, installResult{
+		Status:    installResultStatusSuccess,
+		Code:      installResultCodeInstalled,
+		Operation: installResultOperationChannelInstall,
+		Provider:  slackProvider,
+		RequestID: requestID,
+		TeamID:    installation.TeamID,
+	})
+}
+
+func (g *slackGateway) upsertInstallation(ctx context.Context, installation *slackInstallation, requestID string, presetInputs map[string]any) error {
 	if installation == nil {
 		return fmt.Errorf("installation is required")
 	}
@@ -268,6 +409,9 @@ func (g *slackGateway) upsertInstallation(ctx context.Context, installation *sla
 			"scopeSet":         installation.ScopeSet,
 		},
 		"requestId": strings.TrimSpace(requestID),
+	}
+	if len(presetInputs) > 0 {
+		body["presetInputs"] = presetInputs
 	}
 	var payload backendInstallationUpsertResponse
 	if err := g.postBackendJSON(ctx, "/internal/v1/spritz/channel-installations/upsert", body, &payload); err != nil {

--- a/integrations/slack-gateway/state.go
+++ b/integrations/slack-gateway/state.go
@@ -1,7 +1,8 @@
 package main
 
 import (
-	"crypto/hmac"
+	"crypto/aes"
+	"crypto/cipher"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
@@ -19,9 +20,23 @@ type oauthStateManager struct {
 	now    func() time.Time
 }
 
+type statePayloadType string
+
+const (
+	statePayloadTypeOAuth          statePayloadType = "oauth"
+	statePayloadTypePendingInstall statePayloadType = "pending_install"
+)
+
+type pendingInstallState struct {
+	RequestID    string            `json:"requestId"`
+	Installation slackInstallation `json:"installation"`
+}
+
 type oauthStatePayload struct {
-	IssuedAt int64  `json:"iat"`
-	Nonce    string `json:"nonce"`
+	Type           statePayloadType     `json:"type"`
+	IssuedAt       int64                `json:"iat"`
+	Nonce          string               `json:"nonce"`
+	PendingInstall *pendingInstallState `json:"pendingInstall,omitempty"`
 }
 
 func newOAuthStateManager(secret string, ttl time.Duration) *oauthStateManager {
@@ -33,50 +48,104 @@ func newOAuthStateManager(secret string, ttl time.Duration) *oauthStateManager {
 }
 
 func (m *oauthStateManager) generate() (string, error) {
+	return m.generatePayload(oauthStatePayload{Type: statePayloadTypeOAuth})
+}
+
+func (m *oauthStateManager) generatePendingInstall(state pendingInstallState) (string, error) {
+	return m.generatePayload(oauthStatePayload{
+		Type:           statePayloadTypePendingInstall,
+		PendingInstall: &state,
+	})
+}
+
+func (m *oauthStateManager) generatePayload(payload oauthStatePayload) (string, error) {
 	nonceBytes := make([]byte, 16)
 	if _, err := rand.Read(nonceBytes); err != nil {
 		return "", err
 	}
-	payload := oauthStatePayload{
-		IssuedAt: m.now().UTC().Unix(),
-		Nonce:    hex.EncodeToString(nonceBytes),
+	payload.IssuedAt = m.now().UTC().Unix()
+	payload.Nonce = hex.EncodeToString(nonceBytes)
+	if payload.Type == "" {
+		payload.Type = statePayloadTypeOAuth
 	}
+
 	encoded, err := json.Marshal(payload)
 	if err != nil {
 		return "", err
 	}
-	blob := base64.RawURLEncoding.EncodeToString(encoded)
-	mac := hmac.New(sha256.New, m.secret)
-	_, _ = mac.Write([]byte(blob))
-	signature := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
-	return blob + "." + signature, nil
+	block, err := aes.NewCipher(m.key())
+	if err != nil {
+		return "", err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+	sealNonce := make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(sealNonce); err != nil {
+		return "", err
+	}
+	ciphertext := gcm.Seal(nil, sealNonce, encoded, nil)
+	token := append(sealNonce, ciphertext...)
+	return base64.RawURLEncoding.EncodeToString(token), nil
 }
 
 func (m *oauthStateManager) validate(raw string) error {
-	parts := strings.Split(strings.TrimSpace(raw), ".")
-	if len(parts) != 2 {
-		return errors.New("state is invalid")
-	}
-	mac := hmac.New(sha256.New, m.secret)
-	_, _ = mac.Write([]byte(parts[0]))
-	expected := mac.Sum(nil)
-	actual, err := base64.RawURLEncoding.DecodeString(parts[1])
-	if err != nil || !hmac.Equal(expected, actual) {
-		return errors.New("state signature is invalid")
-	}
-	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[0])
+	payload, err := m.parse(raw)
 	if err != nil {
-		return errors.New("state payload is invalid")
+		return err
+	}
+	if payload.Type != statePayloadTypeOAuth {
+		return errors.New("state type is invalid")
+	}
+	return nil
+}
+
+func (m *oauthStateManager) parsePendingInstall(raw string) (pendingInstallState, error) {
+	payload, err := m.parse(raw)
+	if err != nil {
+		return pendingInstallState{}, err
+	}
+	if payload.Type != statePayloadTypePendingInstall || payload.PendingInstall == nil {
+		return pendingInstallState{}, errors.New("state type is invalid")
+	}
+	return *payload.PendingInstall, nil
+}
+
+func (m *oauthStateManager) parse(raw string) (oauthStatePayload, error) {
+	token, err := base64.RawURLEncoding.DecodeString(strings.TrimSpace(raw))
+	if err != nil {
+		return oauthStatePayload{}, errors.New("state is invalid")
+	}
+	block, err := aes.NewCipher(m.key())
+	if err != nil {
+		return oauthStatePayload{}, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return oauthStatePayload{}, err
+	}
+	if len(token) < gcm.NonceSize() {
+		return oauthStatePayload{}, errors.New("state is invalid")
+	}
+	payloadBytes, err := gcm.Open(nil, token[:gcm.NonceSize()], token[gcm.NonceSize():], nil)
+	if err != nil {
+		return oauthStatePayload{}, errors.New("state is invalid")
 	}
 	var payload oauthStatePayload
 	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
-		return errors.New("state payload is invalid")
+		return oauthStatePayload{}, errors.New("state payload is invalid")
 	}
-	if payload.IssuedAt <= 0 || strings.TrimSpace(payload.Nonce) == "" {
-		return errors.New("state payload is incomplete")
+	if payload.IssuedAt <= 0 || strings.TrimSpace(payload.Nonce) == "" || payload.Type == "" {
+		return oauthStatePayload{}, errors.New("state payload is incomplete")
 	}
 	if issuedAt := time.Unix(payload.IssuedAt, 0).UTC(); m.now().UTC().Sub(issuedAt) > m.ttl {
-		return fmt.Errorf("state has expired")
+		return oauthStatePayload{}, fmt.Errorf("state has expired")
 	}
-	return nil
+	return payload, nil
+}
+
+func (m *oauthStateManager) key() []byte {
+	sum := sha256.Sum256(m.secret)
+	return sum[:]
 }

--- a/integrations/slack-gateway/state_test.go
+++ b/integrations/slack-gateway/state_test.go
@@ -22,3 +22,39 @@ func TestOAuthStateRoundTrip(t *testing.T) {
 		t.Fatalf("expected expired state to fail")
 	}
 }
+
+func TestPendingInstallStateRoundTrip(t *testing.T) {
+	manager := newOAuthStateManager("secret-key", 15*time.Minute)
+	fixed := time.Date(2026, 3, 24, 12, 0, 0, 0, time.UTC)
+	manager.now = func() time.Time { return fixed }
+
+	state, err := manager.generatePendingInstall(pendingInstallState{
+		RequestID: "install-request-1",
+		Installation: slackInstallation{
+			TeamID:           "T_workspace_1",
+			InstallingUserID: "U_installer",
+			BotAccessToken:   "xoxb-secret",
+		},
+	})
+	if err != nil {
+		t.Fatalf("generatePendingInstall failed: %v", err)
+	}
+	if state == "" {
+		t.Fatal("expected encrypted pending install token")
+	}
+	if state == "xoxb-secret" {
+		t.Fatal("pending install token must not expose installation secrets")
+	}
+
+	manager.now = func() time.Time { return fixed.Add(5 * time.Minute) }
+	parsed, err := manager.parsePendingInstall(state)
+	if err != nil {
+		t.Fatalf("parsePendingInstall failed: %v", err)
+	}
+	if parsed.RequestID != "install-request-1" {
+		t.Fatalf("expected request id to round-trip, got %q", parsed.RequestID)
+	}
+	if parsed.Installation.BotAccessToken != "xoxb-secret" {
+		t.Fatalf("expected installation payload to round-trip, got %#v", parsed.Installation)
+	}
+}

--- a/operator/controllers/spritz_binding_controller.go
+++ b/operator/controllers/spritz_binding_controller.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -193,6 +194,45 @@ func (r *SpritzBindingReconciler) reconcileBinding(ctx context.Context, binding 
 	}
 
 	desiredRevision := strings.TrimSpace(binding.Spec.DesiredRevision)
+	activeMatchesDesiredSpec := true
+	if binding.Status.ActiveInstanceRef != nil && active != nil {
+		var matchErr error
+		activeMatchesDesiredSpec, matchErr = r.runtimeMatchesBindingSpec(binding, active)
+		if matchErr != nil {
+			return r.updateFailureStatusAndRetry(
+				ctx,
+				binding,
+				&now,
+				spritzv1.BindingPhaseFailed,
+				"candidate_create_failed",
+				matchErr,
+			)
+		}
+	}
+	candidateMatchesDesiredSpec := true
+	if binding.Status.CandidateInstanceRef != nil && candidate != nil {
+		var matchErr error
+		candidateMatchesDesiredSpec, matchErr = r.runtimeMatchesBindingSpec(binding, candidate)
+		if matchErr != nil {
+			return r.updateFailureStatusAndRetry(
+				ctx,
+				binding,
+				&now,
+				spritzv1.BindingPhaseFailed,
+				"candidate_create_failed",
+				matchErr,
+			)
+		}
+	}
+	if binding.Status.CandidateInstanceRef != nil && candidate != nil && !candidateMatchesDesiredSpec && binding.Status.CleanupInstanceRef == nil {
+		binding.Status.CleanupInstanceRef = cleanupRefFromRuntime(
+			binding.Status.CandidateInstanceRef,
+			candidate,
+		)
+		binding.Status.CandidateInstanceRef = nil
+		candidate = nil
+		candidateMatchesDesiredSpec = true
+	}
 
 	if binding.Status.ActiveInstanceRef == nil {
 		if binding.Status.CandidateInstanceRef == nil {
@@ -211,18 +251,26 @@ func (r *SpritzBindingReconciler) reconcileBinding(ctx context.Context, binding 
 			r.setProgressingStatus(binding, &now, spritzv1.BindingPhaseCreating, "candidate_creating", "creating initial runtime")
 			return r.updateBindingStatus(ctx, binding)
 		}
-		if candidate != nil && runtimeIsReady(candidate) {
+		if candidate != nil && runtimeIsReady(candidate) && candidateMatchesDesiredSpec {
 			binding.Status.ActiveInstanceRef = binding.Status.CandidateInstanceRef.DeepCopy()
 			binding.Status.CandidateInstanceRef = nil
 			binding.Status.ObservedRevision = resolveInstanceRevision(binding.Status.ActiveInstanceRef, candidate, desiredRevision)
 			r.setReadyStatus(binding, &now, spritzv1.BindingPhaseReady)
 			return r.updateBindingStatus(ctx, binding)
 		}
+		if candidate != nil && !candidateMatchesDesiredSpec {
+			r.setProgressingStatus(binding, &now, spritzv1.BindingPhaseCleaningUp, "candidate_outdated", "cleaning up outdated candidate runtime")
+			return r.updateBindingStatus(ctx, binding)
+		}
 		r.setProgressingStatus(binding, &now, spritzv1.BindingPhaseWaitingReady, "candidate_not_ready", "waiting for initial candidate to become ready")
 		return r.updateBindingStatus(ctx, binding)
 	}
 
-	if desiredRevision != "" && strings.TrimSpace(binding.Status.ObservedRevision) != desiredRevision {
+	replacementNeeded := desiredRevision != "" && strings.TrimSpace(binding.Status.ObservedRevision) != desiredRevision
+	if binding.Status.ActiveInstanceRef != nil && active != nil && !activeMatchesDesiredSpec {
+		replacementNeeded = true
+	}
+	if replacementNeeded {
 		if binding.Status.CandidateInstanceRef == nil {
 			nextRef, err := r.ensureCandidateRuntime(ctx, binding, desiredRevision)
 			if err != nil {
@@ -239,13 +287,17 @@ func (r *SpritzBindingReconciler) reconcileBinding(ctx context.Context, binding 
 			r.setProgressingStatus(binding, &now, spritzv1.BindingPhaseCreating, "candidate_creating", "creating replacement runtime")
 			return r.updateBindingStatus(ctx, binding)
 		}
-		if candidate != nil && runtimeIsReady(candidate) {
+		if candidate != nil && runtimeIsReady(candidate) && candidateMatchesDesiredSpec {
 			previousActiveRef := binding.Status.ActiveInstanceRef.DeepCopy()
 			binding.Status.ActiveInstanceRef = binding.Status.CandidateInstanceRef.DeepCopy()
 			binding.Status.CandidateInstanceRef = nil
 			binding.Status.CleanupInstanceRef = previousActiveRef
 			binding.Status.ObservedRevision = resolveInstanceRevision(binding.Status.ActiveInstanceRef, candidate, desiredRevision)
 			r.setProgressingStatus(binding, &now, spritzv1.BindingPhaseCleaningUp, "cleanup_pending", "cleaning up replaced runtime")
+			return r.updateBindingStatus(ctx, binding)
+		}
+		if candidate != nil && !candidateMatchesDesiredSpec {
+			r.setProgressingStatus(binding, &now, spritzv1.BindingPhaseCleaningUp, "candidate_outdated", "cleaning up outdated candidate runtime")
 			return r.updateBindingStatus(ctx, binding)
 		}
 		r.setProgressingStatus(binding, &now, spritzv1.BindingPhaseWaitingReady, "candidate_not_ready", "waiting for replacement runtime to become ready")
@@ -335,14 +387,9 @@ func (r *SpritzBindingReconciler) buildRuntimeFromBinding(
 	desiredRevision string,
 	role string,
 ) (*spritzv1.Spritz, error) {
-	var spec spritzv1.SpritzSpec
-	binding.Spec.Template.Spec.DeepCopyInto(&spec)
-	applyBindingIngressDefaults(&spec, name, binding.Namespace, r.IngressDefaults)
-	if spec.Ingress != nil && strings.EqualFold(spec.Ingress.Mode, "gateway") && strings.TrimSpace(spec.Ingress.Host) == "" {
-		return nil, fmt.Errorf("spec.ingress.host is required when spec.ingress.mode=gateway")
-	}
-	if spec.Ingress != nil && strings.EqualFold(spec.Ingress.Mode, "gateway") && strings.TrimSpace(spec.Ingress.GatewayName) == "" {
-		return nil, fmt.Errorf("spec.ingress.gatewayName is required when spec.ingress.mode=gateway")
+	spec, err := r.desiredRuntimeSpec(binding, name)
+	if err != nil {
+		return nil, err
 	}
 
 	labels := cloneStringMap(binding.Spec.Template.Labels)
@@ -379,6 +426,36 @@ func (r *SpritzBindingReconciler) buildRuntimeFromBinding(
 		return nil, err
 	}
 	return spritz, nil
+}
+
+func (r *SpritzBindingReconciler) desiredRuntimeSpec(
+	binding *spritzv1.SpritzBinding,
+	name string,
+) (spritzv1.SpritzSpec, error) {
+	var spec spritzv1.SpritzSpec
+	binding.Spec.Template.Spec.DeepCopyInto(&spec)
+	applyBindingIngressDefaults(&spec, name, binding.Namespace, r.IngressDefaults)
+	if spec.Ingress != nil && strings.EqualFold(spec.Ingress.Mode, "gateway") && strings.TrimSpace(spec.Ingress.Host) == "" {
+		return spritzv1.SpritzSpec{}, fmt.Errorf("spec.ingress.host is required when spec.ingress.mode=gateway")
+	}
+	if spec.Ingress != nil && strings.EqualFold(spec.Ingress.Mode, "gateway") && strings.TrimSpace(spec.Ingress.GatewayName) == "" {
+		return spritzv1.SpritzSpec{}, fmt.Errorf("spec.ingress.gatewayName is required when spec.ingress.mode=gateway")
+	}
+	return spec, nil
+}
+
+func (r *SpritzBindingReconciler) runtimeMatchesBindingSpec(
+	binding *spritzv1.SpritzBinding,
+	runtime *spritzv1.Spritz,
+) (bool, error) {
+	if runtime == nil {
+		return false, nil
+	}
+	expectedSpec, err := r.desiredRuntimeSpec(binding, runtime.Name)
+	if err != nil {
+		return false, err
+	}
+	return apiequality.Semantic.DeepEqual(expectedSpec, runtime.Spec), nil
 }
 
 func (r *SpritzBindingReconciler) resolveRuntimeRef(

--- a/operator/controllers/spritz_binding_controller_test.go
+++ b/operator/controllers/spritz_binding_controller_test.go
@@ -81,6 +81,12 @@ func newBindingReconcilerForTest(t *testing.T, objects ...runtime.Object) (*Spri
 	}, k8sClient
 }
 
+func bindingRuntimeSpec(binding *spritzv1.SpritzBinding) spritzv1.SpritzSpec {
+	var spec spritzv1.SpritzSpec
+	binding.Spec.Template.Spec.DeepCopyInto(&spec)
+	return spec
+}
+
 func TestReconcileBindingCreatesInitialCandidateRuntime(t *testing.T) {
 	binding := newBindingTestBinding()
 	reconciler, k8sClient := newBindingReconcilerForTest(t, binding)
@@ -130,6 +136,7 @@ func TestReconcileBindingPromotesReadyInitialCandidate(t *testing.T) {
 				bindingTargetRevisionAnnotationKey: binding.Spec.DesiredRevision,
 			},
 		},
+		Spec:   bindingRuntimeSpec(binding),
 		Status: spritzv1.SpritzStatus{Phase: "Ready"},
 	}
 	binding.Status.CandidateInstanceRef = &spritzv1.SpritzBindingInstanceRef{
@@ -175,6 +182,7 @@ func TestReconcileBindingCutsOverReadyReplacementAndCleansUpOldRuntime(t *testin
 				bindingTargetRevisionAnnotationKey: "sha256:rev-1",
 			},
 		},
+		Spec:   bindingRuntimeSpec(binding),
 		Status: spritzv1.SpritzStatus{Phase: "Ready"},
 	}
 	newRuntime := &spritzv1.Spritz{
@@ -185,6 +193,7 @@ func TestReconcileBindingCutsOverReadyReplacementAndCleansUpOldRuntime(t *testin
 				bindingTargetRevisionAnnotationKey: "sha256:rev-2",
 			},
 		},
+		Spec:   bindingRuntimeSpec(binding),
 		Status: spritzv1.SpritzStatus{Phase: "Ready"},
 	}
 	binding.Spec.DesiredRevision = "sha256:rev-2"
@@ -290,6 +299,7 @@ func TestReconcileBindingKeepsCleanupRefWhileDeletionIsStillInFlight(t *testing.
 				bindingTargetRevisionAnnotationKey: "sha256:rev-2",
 			},
 		},
+		Spec:   bindingRuntimeSpec(binding),
 		Status: spritzv1.SpritzStatus{Phase: "Ready"},
 	}
 	cleanupRuntime := &spritzv1.Spritz{
@@ -300,6 +310,7 @@ func TestReconcileBindingKeepsCleanupRefWhileDeletionIsStillInFlight(t *testing.
 				bindingTargetRevisionAnnotationKey: "sha256:rev-1",
 			},
 		},
+		Spec:   bindingRuntimeSpec(binding),
 		Status: spritzv1.SpritzStatus{Phase: "Ready"},
 	}
 	binding.Spec.DesiredRevision = "sha256:rev-2"
@@ -350,6 +361,7 @@ func TestReconcileBindingMovesTerminalCandidateIntoCleanup(t *testing.T) {
 				bindingTargetRevisionAnnotationKey: "sha256:rev-1",
 			},
 		},
+		Spec:   bindingRuntimeSpec(binding),
 		Status: spritzv1.SpritzStatus{Phase: "Ready"},
 	}
 	terminalCandidate := &spritzv1.Spritz{
@@ -360,6 +372,7 @@ func TestReconcileBindingMovesTerminalCandidateIntoCleanup(t *testing.T) {
 				bindingTargetRevisionAnnotationKey: "sha256:rev-2",
 			},
 		},
+		Spec:   bindingRuntimeSpec(binding),
 		Status: spritzv1.SpritzStatus{Phase: "Error"},
 	}
 	binding.Spec.DesiredRevision = "sha256:rev-2"
@@ -395,5 +408,127 @@ func TestReconcileBindingMovesTerminalCandidateIntoCleanup(t *testing.T) {
 	}
 	if storedBinding.Status.CandidateInstanceRef.Name == terminalCandidate.Name {
 		t.Fatalf("expected a new candidate identity, got %#v", storedBinding.Status)
+	}
+}
+
+func TestReconcileBindingCreatesReplacementWhenTemplateSpecChangesWithoutRevisionChange(t *testing.T) {
+	binding := newBindingTestBinding()
+	activeRuntime := &spritzv1.Spritz{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      bindingRuntimeName(binding, 1),
+			Namespace: binding.Namespace,
+			Annotations: map[string]string{
+				bindingTargetRevisionAnnotationKey: binding.Spec.DesiredRevision,
+			},
+		},
+		Spec: spritzv1.SpritzSpec{
+			Image: "example.com/openclaw:previous",
+			Owner: spritzv1.SpritzOwner{ID: "user-1"},
+		},
+		Status: spritzv1.SpritzStatus{Phase: "Ready"},
+	}
+	binding.Status.ObservedRevision = binding.Spec.DesiredRevision
+	binding.Status.ActiveInstanceRef = &spritzv1.SpritzBindingInstanceRef{
+		Namespace: binding.Namespace,
+		Name:      activeRuntime.Name,
+		Revision:  binding.Spec.DesiredRevision,
+		Phase:     "Ready",
+	}
+	binding.Status.NextRuntimeSequence = 1
+	reconciler, k8sClient := newBindingReconcilerForTest(t, binding, activeRuntime)
+
+	if err := reconciler.reconcileBinding(context.Background(), binding); err != nil {
+		t.Fatalf("reconcileBinding returned error: %v", err)
+	}
+
+	var storedBinding spritzv1.SpritzBinding
+	if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(binding), &storedBinding); err != nil {
+		t.Fatalf("failed to load binding: %v", err)
+	}
+	if storedBinding.Status.CandidateInstanceRef == nil {
+		t.Fatalf("expected replacement candidate after spec drift, got %#v", storedBinding.Status)
+	}
+	if storedBinding.Status.ActiveInstanceRef == nil || storedBinding.Status.ActiveInstanceRef.Name != activeRuntime.Name {
+		t.Fatalf("expected active runtime to remain live during replacement, got %#v", storedBinding.Status)
+	}
+	if storedBinding.Status.Phase != spritzv1.BindingPhaseCreating {
+		t.Fatalf("expected creating phase for replacement candidate, got %#v", storedBinding.Status)
+	}
+
+	var candidate spritzv1.Spritz
+	if err := k8sClient.Get(
+		context.Background(),
+		client.ObjectKey{Namespace: binding.Namespace, Name: storedBinding.Status.CandidateInstanceRef.Name},
+		&candidate,
+	); err != nil {
+		t.Fatalf("failed to load replacement candidate: %v", err)
+	}
+	if candidate.Spec.Image != binding.Spec.Template.Spec.Image {
+		t.Fatalf("expected replacement candidate to use current template image, got %#v", candidate.Spec)
+	}
+}
+
+func TestReconcileBindingReplacesOutdatedCandidateWhenTemplateSpecChangesMidRollout(t *testing.T) {
+	binding := newBindingTestBinding()
+	activeRuntime := &spritzv1.Spritz{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      bindingRuntimeName(binding, 1),
+			Namespace: binding.Namespace,
+			Annotations: map[string]string{
+				bindingTargetRevisionAnnotationKey: binding.Spec.DesiredRevision,
+			},
+		},
+		Spec: spritzv1.SpritzSpec{
+			Image: "example.com/openclaw:previous",
+			Owner: spritzv1.SpritzOwner{ID: "user-1"},
+		},
+		Status: spritzv1.SpritzStatus{Phase: "Ready"},
+	}
+	staleCandidate := &spritzv1.Spritz{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      bindingRuntimeName(binding, 2),
+			Namespace: binding.Namespace,
+			Annotations: map[string]string{
+				bindingTargetRevisionAnnotationKey: binding.Spec.DesiredRevision,
+			},
+		},
+		Spec: spritzv1.SpritzSpec{
+			Image: "example.com/openclaw:stale",
+			Owner: spritzv1.SpritzOwner{ID: "user-1"},
+		},
+		Status: spritzv1.SpritzStatus{Phase: "Provisioning"},
+	}
+	binding.Status.ObservedRevision = binding.Spec.DesiredRevision
+	binding.Status.ActiveInstanceRef = &spritzv1.SpritzBindingInstanceRef{
+		Namespace: binding.Namespace,
+		Name:      activeRuntime.Name,
+		Revision:  binding.Spec.DesiredRevision,
+		Phase:     "Ready",
+	}
+	binding.Status.CandidateInstanceRef = &spritzv1.SpritzBindingInstanceRef{
+		Namespace: binding.Namespace,
+		Name:      staleCandidate.Name,
+		Revision:  binding.Spec.DesiredRevision,
+		Phase:     "Provisioning",
+	}
+	binding.Status.NextRuntimeSequence = 2
+	reconciler, k8sClient := newBindingReconcilerForTest(t, binding, activeRuntime, staleCandidate)
+
+	if err := reconciler.reconcileBinding(context.Background(), binding); err != nil {
+		t.Fatalf("reconcileBinding returned error: %v", err)
+	}
+
+	var storedBinding spritzv1.SpritzBinding
+	if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(binding), &storedBinding); err != nil {
+		t.Fatalf("failed to load binding: %v", err)
+	}
+	if storedBinding.Status.CleanupInstanceRef == nil || storedBinding.Status.CleanupInstanceRef.Name != staleCandidate.Name {
+		t.Fatalf("expected outdated candidate to move into cleanup, got %#v", storedBinding.Status)
+	}
+	if storedBinding.Status.CandidateInstanceRef == nil {
+		t.Fatalf("expected a fresh replacement candidate, got %#v", storedBinding.Status)
+	}
+	if storedBinding.Status.CandidateInstanceRef.Name == staleCandidate.Name {
+		t.Fatalf("expected stale candidate to be replaced, got %#v", storedBinding.Status)
 	}
 }


### PR DESCRIPTION
## TL;DR
This teaches the Slack install flow to ask the deployment which eligible targets are available, render a picker when needed, and round-trip the chosen opaque `presetInputs` back during installation. It also makes binding rollout replace runtimes when the effective template spec drifts, not only when the desired revision string changes.

## Summary
- call the deployment list-targets contract after Slack OAuth and auto-select or render a picker based on the result
- encrypt pending install state so Slack bot credentials do not round-trip through browser-visible state payloads
- propagate selected `presetInputs` into installation upsert requests and map new install-result error codes
- replace stale binding runtimes when the desired spec changes mid-rollout even without a revision bump
- document the provider-agnostic architecture for install target selection

## Review focus
- picker flow and opaque `presetInputs` round-trip behavior
- pending install state handling and token exposure boundaries
- binding replacement semantics when template spec drifts without a revision change

## Test plan
- `go test ./...` in `integrations/slack-gateway`
- `GOTMPDIR=/Users/onur/repos/spritz/.tmp/go-build GOCACHE=/Users/onur/repos/spritz/.tmp/go-cache go test ./...` in `operator`
