### PR TITLE
fix(slack): route install target lookup to backend fastapi

### DIFF
--- a/integrations/slack-gateway/.env.example
+++ b/integrations/slack-gateway/.env.example
@@ -17,6 +17,7 @@ SPRITZ_SLACK_BOT_SCOPES=app_mentions:read,channels:history,chat:write,im:history
 SPRITZ_SLACK_PRESET_ID=zeno
 
 SPRITZ_SLACK_BACKEND_BASE_URL=https://backend.example.com
+SPRITZ_SLACK_BACKEND_FASTAPI_BASE_URL=https://backend-fastapi.example.com
 SPRITZ_SLACK_BACKEND_INTERNAL_TOKEN=fill-me
 
 SPRITZ_SLACK_SPRITZ_BASE_URL=https://spritz.example.com

--- a/integrations/slack-gateway/backend_client.go
+++ b/integrations/slack-gateway/backend_client.go
@@ -225,7 +225,7 @@ func (g *slackGateway) listInstallTargets(ctx context.Context, installation *sla
 		"requestId": strings.TrimSpace(requestID),
 	}
 	var payload backendInstallTargetListResponse
-	if err := g.postBackendJSON(ctx, "/internal/v2/spritz/channel-install-targets/list", body, &payload); err != nil {
+	if err := g.postBackendFastAPIJSON(ctx, "/internal/v2/spritz/channel-install-targets/list", body, &payload); err != nil {
 		return nil, err
 	}
 	if payload.Status != "resolved" {
@@ -326,6 +326,14 @@ func (g *slackGateway) postSlackMessage(ctx context.Context, token, channel, tex
 
 func (g *slackGateway) postBackendJSON(ctx context.Context, path string, body any, target any) error {
 	return g.postJSON(ctx, g.cfg.BackendBaseURL+path, g.cfg.BackendInternalToken, body, target)
+}
+
+func (g *slackGateway) postBackendFastAPIJSON(ctx context.Context, path string, body any, target any) error {
+	baseURL := g.cfg.BackendFastAPIBaseURL
+	if strings.TrimSpace(baseURL) == "" {
+		baseURL = g.cfg.BackendBaseURL
+	}
+	return g.postJSON(ctx, baseURL+path, g.cfg.BackendInternalToken, body, target)
 }
 
 func (g *slackGateway) postSpritzJSON(ctx context.Context, method, path, bearer string, body any, target any, query map[string]string) error {

--- a/integrations/slack-gateway/backend_client_test.go
+++ b/integrations/slack-gateway/backend_client_test.go
@@ -11,6 +11,68 @@ import (
 	"time"
 )
 
+func TestListInstallTargetsUsesBackendFastAPIBaseURLWhenConfigured(t *testing.T) {
+	backendHits := 0
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		backendHits++
+		t.Fatalf("unexpected backend base request to %s", r.URL.Path)
+	}))
+	defer backend.Close()
+
+	fastapiHits := 0
+	fastapi := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/internal/v2/spritz/channel-install-targets/list" {
+			t.Fatalf("unexpected fastapi path %s", r.URL.Path)
+		}
+		fastapiHits++
+		writeJSON(w, http.StatusOK, map[string]any{
+			"status": "resolved",
+			"targets": []map[string]any{
+				{
+					"id": "ag_workspace",
+					"profile": map[string]any{
+						"name": "Workspace Helper",
+					},
+					"presetInputs": map[string]any{
+						"agentId": "ag_workspace",
+					},
+				},
+			},
+		})
+	}))
+	defer fastapi.Close()
+
+	gateway := newSlackGateway(config{
+		BackendBaseURL:        backend.URL,
+		BackendFastAPIBaseURL: fastapi.URL,
+		BackendInternalToken:  "backend-internal-token",
+		PresetID:              "zeno",
+		PrincipalID:           "shared-slack-gateway",
+		HTTPTimeout:           5 * time.Second,
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	targets, err := gateway.listInstallTargets(
+		context.Background(),
+		&slackInstallation{
+			TeamID:           "T_workspace_1",
+			InstallingUserID: "U_installer",
+		},
+		"req_install_1",
+	)
+	if err != nil {
+		t.Fatalf("list install targets: %v", err)
+	}
+	if backendHits != 0 {
+		t.Fatalf("expected backend base URL to be unused, got %d hits", backendHits)
+	}
+	if fastapiHits != 1 {
+		t.Fatalf("expected fastapi base URL to be hit once, got %d", fastapiHits)
+	}
+	if len(targets) != 1 || targets[0].ID != "ag_workspace" {
+		t.Fatalf("unexpected install targets: %#v", targets)
+	}
+}
+
 func TestUpsertChannelConversationOmitsImplicitDefaultCWD(t *testing.T) {
 	var upsertPayload map[string]any
 	spritz := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/integrations/slack-gateway/config.go
+++ b/integrations/slack-gateway/config.go
@@ -9,56 +9,58 @@ import (
 )
 
 type config struct {
-	Addr                 string
-	PublicURL            string
-	SlackClientID        string
-	SlackClientSecret    string
-	SlackSigningSecret   string
-	OAuthStateSecret     string
-	SlackAPIBaseURL      string
-	SlackBotScopes       []string
-	PresetID             string
-	BackendBaseURL       string
-	BackendInternalToken string
-	SpritzBaseURL        string
-	SpritzServiceToken   string
-	PrincipalID          string
-	HTTPTimeout          time.Duration
-	DedupeTTL            time.Duration
-	ProcessingTimeout    time.Duration
-	SessionRetryInterval time.Duration
-	StatusMessageDelay   time.Duration
-	RecoveryTimeout      time.Duration
-	PromptRetryInitial   time.Duration
-	PromptRetryMax       time.Duration
-	PromptRetryTimeout   time.Duration
+	Addr                  string
+	PublicURL             string
+	SlackClientID         string
+	SlackClientSecret     string
+	SlackSigningSecret    string
+	OAuthStateSecret      string
+	SlackAPIBaseURL       string
+	SlackBotScopes        []string
+	PresetID              string
+	BackendBaseURL        string
+	BackendFastAPIBaseURL string
+	BackendInternalToken  string
+	SpritzBaseURL         string
+	SpritzServiceToken    string
+	PrincipalID           string
+	HTTPTimeout           time.Duration
+	DedupeTTL             time.Duration
+	ProcessingTimeout     time.Duration
+	SessionRetryInterval  time.Duration
+	StatusMessageDelay    time.Duration
+	RecoveryTimeout       time.Duration
+	PromptRetryInitial    time.Duration
+	PromptRetryMax        time.Duration
+	PromptRetryTimeout    time.Duration
 }
 
 func loadConfig() (config, error) {
 	cfg := config{
-		Addr:                 envOrDefault("SPRITZ_SLACK_GATEWAY_ADDR", ":8080"),
-		PublicURL:            strings.TrimRight(strings.TrimSpace(os.Getenv("SPRITZ_SLACK_GATEWAY_PUBLIC_URL")), "/"),
-		SlackClientID:        strings.TrimSpace(os.Getenv("SPRITZ_SLACK_CLIENT_ID")),
-		SlackClientSecret:    strings.TrimSpace(os.Getenv("SPRITZ_SLACK_CLIENT_SECRET")),
-		SlackSigningSecret:   strings.TrimSpace(os.Getenv("SPRITZ_SLACK_SIGNING_SECRET")),
-		OAuthStateSecret:     strings.TrimSpace(os.Getenv("SPRITZ_SLACK_OAUTH_STATE_SECRET")),
-		SlackAPIBaseURL:      strings.TrimRight(envOrDefault("SPRITZ_SLACK_API_BASE_URL", "https://slack.com/api"), "/"),
-		SlackBotScopes:       splitCSV(envOrDefault("SPRITZ_SLACK_BOT_SCOPES", "app_mentions:read,channels:history,chat:write,im:history,mpim:history")),
-		PresetID:             strings.TrimSpace(envOrDefault("SPRITZ_SLACK_PRESET_ID", defaultSlackPresetID)),
-		BackendBaseURL:       strings.TrimRight(strings.TrimSpace(os.Getenv("SPRITZ_SLACK_BACKEND_BASE_URL")), "/"),
-		BackendInternalToken: strings.TrimSpace(os.Getenv("SPRITZ_SLACK_BACKEND_INTERNAL_TOKEN")),
-		SpritzBaseURL:        strings.TrimRight(strings.TrimSpace(os.Getenv("SPRITZ_SLACK_SPRITZ_BASE_URL")), "/"),
-		SpritzServiceToken:   strings.TrimSpace(os.Getenv("SPRITZ_SLACK_SPRITZ_SERVICE_TOKEN")),
-		PrincipalID:          strings.TrimSpace(os.Getenv("SPRITZ_SLACK_PRINCIPAL_ID")),
-		HTTPTimeout:          parseDurationEnv("SPRITZ_SLACK_HTTP_TIMEOUT", 15*time.Second),
-		DedupeTTL:            parseDurationEnv("SPRITZ_SLACK_DEDUPE_TTL", 10*time.Minute),
-		ProcessingTimeout:    parseDurationEnv("SPRITZ_SLACK_PROCESSING_TIMEOUT", 120*time.Second),
-		SessionRetryInterval: parseDurationEnv("SPRITZ_SLACK_SESSION_RETRY_INTERVAL", time.Second),
-		StatusMessageDelay:   parseDurationEnv("SPRITZ_SLACK_STATUS_MESSAGE_DELAY", 5*time.Second),
-		RecoveryTimeout:      parseDurationEnv("SPRITZ_SLACK_RECOVERY_TIMEOUT", 120*time.Second),
-		PromptRetryInitial:   parseDurationEnv("SPRITZ_SLACK_PROMPT_RETRY_INITIAL", 250*time.Millisecond),
-		PromptRetryMax:       parseDurationEnv("SPRITZ_SLACK_PROMPT_RETRY_MAX", 2*time.Second),
-		PromptRetryTimeout:   parseDurationEnv("SPRITZ_SLACK_PROMPT_RETRY_TIMEOUT", 8*time.Second),
+		Addr:                  envOrDefault("SPRITZ_SLACK_GATEWAY_ADDR", ":8080"),
+		PublicURL:             strings.TrimRight(strings.TrimSpace(os.Getenv("SPRITZ_SLACK_GATEWAY_PUBLIC_URL")), "/"),
+		SlackClientID:         strings.TrimSpace(os.Getenv("SPRITZ_SLACK_CLIENT_ID")),
+		SlackClientSecret:     strings.TrimSpace(os.Getenv("SPRITZ_SLACK_CLIENT_SECRET")),
+		SlackSigningSecret:    strings.TrimSpace(os.Getenv("SPRITZ_SLACK_SIGNING_SECRET")),
+		OAuthStateSecret:      strings.TrimSpace(os.Getenv("SPRITZ_SLACK_OAUTH_STATE_SECRET")),
+		SlackAPIBaseURL:       strings.TrimRight(envOrDefault("SPRITZ_SLACK_API_BASE_URL", "https://slack.com/api"), "/"),
+		SlackBotScopes:        splitCSV(envOrDefault("SPRITZ_SLACK_BOT_SCOPES", "app_mentions:read,channels:history,chat:write,im:history,mpim:history")),
+		PresetID:              strings.TrimSpace(envOrDefault("SPRITZ_SLACK_PRESET_ID", defaultSlackPresetID)),
+		BackendBaseURL:        strings.TrimRight(strings.TrimSpace(os.Getenv("SPRITZ_SLACK_BACKEND_BASE_URL")), "/"),
+		BackendFastAPIBaseURL: strings.TrimRight(strings.TrimSpace(os.Getenv("SPRITZ_SLACK_BACKEND_FASTAPI_BASE_URL")), "/"),
+		BackendInternalToken:  strings.TrimSpace(os.Getenv("SPRITZ_SLACK_BACKEND_INTERNAL_TOKEN")),
+		SpritzBaseURL:         strings.TrimRight(strings.TrimSpace(os.Getenv("SPRITZ_SLACK_SPRITZ_BASE_URL")), "/"),
+		SpritzServiceToken:    strings.TrimSpace(os.Getenv("SPRITZ_SLACK_SPRITZ_SERVICE_TOKEN")),
+		PrincipalID:           strings.TrimSpace(os.Getenv("SPRITZ_SLACK_PRINCIPAL_ID")),
+		HTTPTimeout:           parseDurationEnv("SPRITZ_SLACK_HTTP_TIMEOUT", 15*time.Second),
+		DedupeTTL:             parseDurationEnv("SPRITZ_SLACK_DEDUPE_TTL", 10*time.Minute),
+		ProcessingTimeout:     parseDurationEnv("SPRITZ_SLACK_PROCESSING_TIMEOUT", 120*time.Second),
+		SessionRetryInterval:  parseDurationEnv("SPRITZ_SLACK_SESSION_RETRY_INTERVAL", time.Second),
+		StatusMessageDelay:    parseDurationEnv("SPRITZ_SLACK_STATUS_MESSAGE_DELAY", 5*time.Second),
+		RecoveryTimeout:       parseDurationEnv("SPRITZ_SLACK_RECOVERY_TIMEOUT", 120*time.Second),
+		PromptRetryInitial:    parseDurationEnv("SPRITZ_SLACK_PROMPT_RETRY_INITIAL", 250*time.Millisecond),
+		PromptRetryMax:        parseDurationEnv("SPRITZ_SLACK_PROMPT_RETRY_MAX", 2*time.Second),
+		PromptRetryTimeout:    parseDurationEnv("SPRITZ_SLACK_PROMPT_RETRY_TIMEOUT", 8*time.Second),
 	}
 
 	if cfg.PublicURL == "" {
@@ -85,6 +87,9 @@ func loadConfig() (config, error) {
 	}
 	if cfg.BackendBaseURL == "" {
 		return config{}, fmt.Errorf("SPRITZ_SLACK_BACKEND_BASE_URL is required")
+	}
+	if cfg.BackendFastAPIBaseURL == "" {
+		cfg.BackendFastAPIBaseURL = cfg.BackendBaseURL
 	}
 	if cfg.BackendInternalToken == "" {
 		return config{}, fmt.Errorf("SPRITZ_SLACK_BACKEND_INTERNAL_TOKEN is required")

--- a/integrations/slack-gateway/gateway_test.go
+++ b/integrations/slack-gateway/gateway_test.go
@@ -6117,6 +6117,30 @@ func TestLoadConfigIncludesMPIMHistoryByDefault(t *testing.T) {
 	}
 }
 
+func TestLoadConfigDefaultsBackendFastAPIBaseURLToBackendBaseURL(t *testing.T) {
+	t.Setenv("SPRITZ_SLACK_GATEWAY_PUBLIC_URL", "https://gateway.example.test")
+	t.Setenv("SPRITZ_SLACK_CLIENT_ID", "client-id")
+	t.Setenv("SPRITZ_SLACK_CLIENT_SECRET", "client-secret")
+	t.Setenv("SPRITZ_SLACK_SIGNING_SECRET", "signing-secret")
+	t.Setenv("SPRITZ_SLACK_OAUTH_STATE_SECRET", "oauth-state-secret")
+	t.Setenv("SPRITZ_SLACK_BACKEND_BASE_URL", "https://backend.example.test")
+	t.Setenv("SPRITZ_SLACK_BACKEND_INTERNAL_TOKEN", "backend-internal-token")
+	t.Setenv("SPRITZ_SLACK_SPRITZ_BASE_URL", "https://spritz.example.test")
+	t.Setenv("SPRITZ_SLACK_SPRITZ_SERVICE_TOKEN", "spritz-service-token")
+	t.Setenv("SPRITZ_SLACK_PRINCIPAL_ID", "shared-slack-gateway")
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig failed: %v", err)
+	}
+	if cfg.BackendFastAPIBaseURL != "https://backend.example.test" {
+		t.Fatalf(
+			"expected backend fastapi base url fallback to match backend base url, got %q",
+			cfg.BackendFastAPIBaseURL,
+		)
+	}
+}
+
 func TestSpritzWebSocketURLPreservesBasePath(t *testing.T) {
 	gateway := newSlackGateway(
 		config{SpritzBaseURL: "https://spritz.example.test/prefix"},


### PR DESCRIPTION
## Summary\n- add an optional backend FastAPI base URL for the Slack gateway\n- use that base for the FastAPI-only install-target lookup route\n- cover config fallback and the FastAPI routing path with regression tests\n\n## Testing\n- go test .\n- go test . -run 'TestListInstallTargetsUsesBackendFastAPIBaseURLWhenConfigured|TestLoadConfigDefaultsBackendFastAPIBaseURLToBackendBaseURL|TestOAuthCallbackAutoSelectsSingleInstallTargetAndUpsertsRegistry|TestOAuthCallbackRendersInstallTargetPickerWhenMultipleTargetsAvailable'\n