### PR TITLE
test(ci): cover spritz local smoke

### DIFF
--- a/.github/workflows/e2e-unit-tests.yml
+++ b/.github/workflows/e2e-unit-tests.yml
@@ -26,3 +26,10 @@ jobs:
 
       - name: Run e2e unit tests
         run: node --test e2e/*.test.mjs
+
+      - name: Check ACP smoke scripts
+        run: |
+          node --check e2e/acp-smoke-lib.mjs
+          node --check e2e/acp-client.mjs
+          node --check e2e/instance-waiter.mjs
+          node --check e2e/acp-smoke.mjs

--- a/.github/workflows/local-smoke-tests.yml
+++ b/.github/workflows/local-smoke-tests.yml
@@ -1,0 +1,47 @@
+name: local-smoke-tests
+
+on:
+  pull_request:
+    paths:
+      - "api/**"
+      - "operator/**"
+      - "helm/**"
+      - "e2e/local-smoke.sh"
+      - ".github/workflows/local-smoke-tests.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "api/**"
+      - "operator/**"
+      - "helm/**"
+      - "e2e/local-smoke.sh"
+      - ".github/workflows/local-smoke-tests.yml"
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: api/go.mod
+          cache-dependency-path: |
+            api/go.sum
+            operator/go.sum
+
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: v1.30.0
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Run local smoke
+        env:
+          SPRITZ_E2E_API_WAIT_SECONDS: "120"
+        run: ./e2e/local-smoke.sh


### PR DESCRIPTION
## Summary
- add the ACP smoke script syntax checks to the e2e workflow
- run the checked-in local smoke harness in CI without changing the local script
- keep Peter's local flow unchanged while making the same smoke path enforceable in GitHub Actions

## Validation
- node --test e2e/*.test.mjs
- node --check e2e/acp-smoke-lib.mjs
- node --check e2e/acp-client.mjs
- node --check e2e/instance-waiter.mjs
- node --check e2e/acp-smoke.mjs
- ./e2e/local-smoke.sh