### PR TITLE
feat(slack-gateway): add workspace synthetic tests

### DIFF
--- a/integrations/slack-gateway/gateway.go
+++ b/integrations/slack-gateway/gateway.go
@@ -83,6 +83,7 @@ func (g *slackGateway) routes() http.Handler {
 	g.registerRoute(mux, "/slack/install/result", g.handleInstallResult)
 	g.registerRoute(mux, "/slack/workspaces", g.handleWorkspaceManagement)
 	g.registerRoute(mux, "/slack/workspaces/target", g.handleWorkspaceTarget)
+	g.registerRoute(mux, "/slack/workspaces/test", g.handleWorkspaceTest)
 	g.registerRoute(mux, "/slack/workspaces/disconnect", g.handleWorkspaceDisconnect)
 	g.registerRoute(mux, "/slack/oauth/callback", g.handleOAuthCallback)
 	g.registerRoute(mux, "/slack/events", g.handleSlackEvents)

--- a/integrations/slack-gateway/gateway_test.go
+++ b/integrations/slack-gateway/gateway_test.go
@@ -364,6 +364,9 @@ func TestWorkspaceManagementRendersManagedInstallations(t *testing.T) {
 	if !strings.Contains(body, "Workspace Helper") {
 		t.Fatalf("expected current target on page, got %q", body)
 	}
+	if !strings.Contains(body, "Send test") {
+		t.Fatalf("expected workspace test action on page, got %q", body)
+	}
 }
 
 func TestWorkspaceManagementAcceptsConfiguredBrowserAuthHeaders(t *testing.T) {
@@ -551,6 +554,410 @@ func TestWorkspaceDisconnectRedirectsOnSuccess(t *testing.T) {
 	location := rec.Header().Get("Location")
 	if !strings.Contains(location, "notice=workspace-disconnected") {
 		t.Fatalf("expected disconnect redirect notice, got %q", location)
+	}
+}
+
+func TestWorkspaceTestRequiresBrowserPrincipal(t *testing.T) {
+	gateway := newSlackGateway(config{
+		BackendFastAPIBaseURL: "https://backend.example.test",
+		BackendInternalToken:  "backend-internal-token",
+		PrincipalID:           "shared-slack-gateway",
+		HTTPTimeout:           5 * time.Second,
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	req := httptest.NewRequest(http.MethodGet, "/slack/workspaces/test?teamId=T_workspace_1", nil)
+	rec := httptest.NewRecorder()
+	gateway.routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestWorkspaceTestFormRendersForManageableWorkspace(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/internal/v2/spritz/channel-installations/list" {
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"status": "resolved",
+			"installations": []map[string]any{
+				{
+					"route": map[string]any{
+						"principalId":       "shared-slack-gateway",
+						"provider":          "slack",
+						"externalScopeType": "workspace",
+						"externalTenantId":  "T_workspace_1",
+					},
+					"state": "ready",
+					"currentTarget": map[string]any{
+						"id": "ag_workspace",
+						"profile": map[string]any{
+							"name": "Workspace Helper",
+						},
+					},
+					"allowedActions": []string{"changeTarget", "disconnect"},
+				},
+			},
+		})
+	}))
+	defer backend.Close()
+
+	gateway := newSlackGateway(config{
+		BackendFastAPIBaseURL: backend.URL,
+		BackendInternalToken:  "backend-internal-token",
+		PrincipalID:           "shared-slack-gateway",
+		HTTPTimeout:           5 * time.Second,
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	req := httptest.NewRequest(http.MethodGet, "/slack/workspaces/test?teamId=T_workspace_1", nil)
+	req.Header.Set("X-Spritz-User-Id", "user-1")
+	rec := httptest.NewRecorder()
+	gateway.routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "Send a synthetic Slack test message") {
+		t.Fatalf("expected synthetic test title, got %q", body)
+	}
+	if !strings.Contains(body, "Workspace Helper") {
+		t.Fatalf("expected current target name on form, got %q", body)
+	}
+}
+
+func TestWorkspaceTestSubmitDryRunSkipsSlackPostAndMarksPromptSynthetic(t *testing.T) {
+	var promptPayload map[string]any
+	slackPostHits := 0
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/internal/v2/spritz/channel-installations/list":
+			writeJSON(w, http.StatusOK, map[string]any{
+				"status": "resolved",
+				"installations": []map[string]any{
+					{
+						"route": map[string]any{
+							"principalId":       "shared-slack-gateway",
+							"provider":          "slack",
+							"externalScopeType": "workspace",
+							"externalTenantId":  "T_workspace_1",
+						},
+						"state": "ready",
+						"currentTarget": map[string]any{
+							"id": "ag_workspace",
+							"profile": map[string]any{
+								"name": "Workspace Helper",
+							},
+						},
+						"allowedActions": []string{"changeTarget", "disconnect"},
+					},
+				},
+			})
+		case "/internal/v1/spritz/channel-sessions/exchange":
+			writeJSON(w, http.StatusOK, map[string]any{
+				"status": "resolved",
+				"session": map[string]any{
+					"accessToken": "owner-token",
+					"ownerAuthId": "owner-123",
+					"namespace":   "spritz-staging",
+					"instanceId":  "zeno-acme",
+					"providerAuth": map[string]any{
+						"teamId":         "T_workspace_1",
+						"botUserId":      "U_bot",
+						"botAccessToken": "xoxb-installed",
+					},
+				},
+			})
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer backend.Close()
+
+	slackAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		slackPostHits++
+		t.Fatalf("dry-run synthetic test must not post to slack")
+	}))
+	defer slackAPI.Close()
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	spritz := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/channel-conversations/upsert":
+			writeJSON(w, http.StatusCreated, map[string]any{
+				"status": "success",
+				"data": map[string]any{
+					"conversation": map[string]any{
+						"metadata": map[string]any{"name": "conv-1"},
+					},
+				},
+			})
+		case "/api/acp/conversations/conv-1/bootstrap":
+			writeJSON(w, http.StatusOK, map[string]any{
+				"status": "success",
+				"data": map[string]any{
+					"effectiveSessionId": "session-1",
+					"effectiveCwd":       "/home/dev",
+				},
+			})
+		case "/api/acp/conversations/conv-1/connect":
+			conn, err := upgrader.Upgrade(w, r, nil)
+			if err != nil {
+				t.Fatalf("upgrade failed: %v", err)
+			}
+			defer conn.Close()
+			for {
+				_, payload, err := conn.ReadMessage()
+				if err != nil {
+					return
+				}
+				var message map[string]any
+				if err := json.Unmarshal(payload, &message); err != nil {
+					t.Fatalf("decode ws payload: %v", err)
+				}
+				switch message["method"] {
+				case "initialize":
+					_ = conn.WriteJSON(map[string]any{"jsonrpc": "2.0", "id": message["id"], "result": map[string]any{"protocolVersion": 1}})
+				case "session/load":
+					_ = conn.WriteJSON(map[string]any{"jsonrpc": "2.0", "id": message["id"], "result": map[string]any{}})
+				case "session/prompt":
+					promptPayload = message
+					_ = conn.WriteJSON(map[string]any{
+						"jsonrpc": "2.0",
+						"method":  "session/update",
+						"params": map[string]any{
+							"update": map[string]any{
+								"sessionUpdate": "agent_message_chunk",
+								"content": []map[string]any{{
+									"type": "text",
+									"text": "Hello from concierge",
+								}},
+							},
+						},
+					})
+					_ = conn.WriteJSON(map[string]any{"jsonrpc": "2.0", "id": message["id"], "result": map[string]any{}})
+					return
+				default:
+					t.Fatalf("unexpected ACP method %#v", message["method"])
+				}
+			}
+		default:
+			t.Fatalf("unexpected spritz path %s", r.URL.Path)
+		}
+	}))
+	defer spritz.Close()
+
+	gateway := newSlackGateway(config{
+		BackendFastAPIBaseURL: backend.URL,
+		BackendBaseURL:        backend.URL,
+		BackendInternalToken:  "backend-internal-token",
+		SlackAPIBaseURL:       slackAPI.URL,
+		SpritzBaseURL:         spritz.URL,
+		SpritzServiceToken:    "spritz-service-token",
+		PrincipalID:           "shared-slack-gateway",
+		HTTPTimeout:           5 * time.Second,
+		DedupeTTL:             time.Minute,
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	form := url.Values{}
+	form.Set("teamId", "T_workspace_1")
+	form.Set("channelId", "C_workspace_1")
+	form.Set("prompt", "synthetic smoke")
+	form.Set("mode", "dry-run")
+	req := httptest.NewRequest(http.MethodPost, "/slack/workspaces/test", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("X-Spritz-User-Id", "user-1")
+	rec := httptest.NewRecorder()
+	gateway.routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if slackPostHits != 0 {
+		t.Fatalf("expected no slack posts during dry-run, got %d", slackPostHits)
+	}
+	if !strings.Contains(rec.Body.String(), "Outcome: dry_run") {
+		t.Fatalf("expected dry_run outcome, got %q", rec.Body.String())
+	}
+	params, ok := promptPayload["params"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected prompt params, got %#v", promptPayload)
+	}
+	chunks, ok := params["prompt"].([]any)
+	if !ok || len(chunks) != 1 {
+		t.Fatalf("expected one prompt chunk, got %#v", params["prompt"])
+	}
+	chunk, ok := chunks[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected prompt chunk object, got %#v", chunks[0])
+	}
+	promptText := fmt.Sprint(chunk["text"])
+	if !strings.Contains(promptText, `"synthetic":true`) {
+		t.Fatalf("expected synthetic marker in prompt context, got %q", promptText)
+	}
+}
+
+func TestWorkspaceTestSubmitRealModePostsSlackReply(t *testing.T) {
+	var slackPayload map[string]any
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/internal/v2/spritz/channel-installations/list":
+			writeJSON(w, http.StatusOK, map[string]any{
+				"status": "resolved",
+				"installations": []map[string]any{
+					{
+						"route": map[string]any{
+							"principalId":       "shared-slack-gateway",
+							"provider":          "slack",
+							"externalScopeType": "workspace",
+							"externalTenantId":  "T_workspace_1",
+						},
+						"state": "ready",
+						"currentTarget": map[string]any{
+							"id": "ag_workspace",
+							"profile": map[string]any{
+								"name": "Workspace Helper",
+							},
+						},
+						"allowedActions": []string{"changeTarget", "disconnect"},
+					},
+				},
+			})
+		case "/internal/v1/spritz/channel-sessions/exchange":
+			writeJSON(w, http.StatusOK, map[string]any{
+				"status": "resolved",
+				"session": map[string]any{
+					"accessToken": "owner-token",
+					"ownerAuthId": "owner-123",
+					"namespace":   "spritz-staging",
+					"instanceId":  "zeno-acme",
+					"providerAuth": map[string]any{
+						"teamId":         "T_workspace_1",
+						"botUserId":      "U_bot",
+						"botAccessToken": "xoxb-installed",
+					},
+				},
+			})
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer backend.Close()
+
+	slackAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat.postMessage" {
+			t.Fatalf("unexpected slack path %s", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&slackPayload); err != nil {
+			t.Fatalf("decode slack post payload: %v", err)
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true, "ts": "1711387376.000100"})
+	}))
+	defer slackAPI.Close()
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	spritz := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/channel-conversations/upsert":
+			writeJSON(w, http.StatusCreated, map[string]any{
+				"status": "success",
+				"data": map[string]any{
+					"conversation": map[string]any{
+						"metadata": map[string]any{"name": "conv-1"},
+					},
+				},
+			})
+		case "/api/acp/conversations/conv-1/bootstrap":
+			writeJSON(w, http.StatusOK, map[string]any{
+				"status": "success",
+				"data": map[string]any{
+					"effectiveSessionId": "session-1",
+					"effectiveCwd":       "/home/dev",
+				},
+			})
+		case "/api/acp/conversations/conv-1/connect":
+			conn, err := upgrader.Upgrade(w, r, nil)
+			if err != nil {
+				t.Fatalf("upgrade failed: %v", err)
+			}
+			defer conn.Close()
+			for {
+				_, payload, err := conn.ReadMessage()
+				if err != nil {
+					return
+				}
+				var message map[string]any
+				if err := json.Unmarshal(payload, &message); err != nil {
+					t.Fatalf("decode ws payload: %v", err)
+				}
+				switch message["method"] {
+				case "initialize":
+					_ = conn.WriteJSON(map[string]any{"jsonrpc": "2.0", "id": message["id"], "result": map[string]any{"protocolVersion": 1}})
+				case "session/load":
+					_ = conn.WriteJSON(map[string]any{"jsonrpc": "2.0", "id": message["id"], "result": map[string]any{}})
+				case "session/prompt":
+					_ = conn.WriteJSON(map[string]any{
+						"jsonrpc": "2.0",
+						"method":  "session/update",
+						"params": map[string]any{
+							"update": map[string]any{
+								"sessionUpdate": "agent_message_chunk",
+								"content": []map[string]any{{
+									"type": "text",
+									"text": "Hello from concierge",
+								}},
+							},
+						},
+					})
+					_ = conn.WriteJSON(map[string]any{"jsonrpc": "2.0", "id": message["id"], "result": map[string]any{}})
+					return
+				default:
+					t.Fatalf("unexpected ACP method %#v", message["method"])
+				}
+			}
+		default:
+			t.Fatalf("unexpected spritz path %s", r.URL.Path)
+		}
+	}))
+	defer spritz.Close()
+
+	gateway := newSlackGateway(config{
+		BackendFastAPIBaseURL: backend.URL,
+		BackendBaseURL:        backend.URL,
+		BackendInternalToken:  "backend-internal-token",
+		SlackAPIBaseURL:       slackAPI.URL,
+		SpritzBaseURL:         spritz.URL,
+		SpritzServiceToken:    "spritz-service-token",
+		PrincipalID:           "shared-slack-gateway",
+		HTTPTimeout:           5 * time.Second,
+		DedupeTTL:             time.Minute,
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	form := url.Values{}
+	form.Set("teamId", "T_workspace_1")
+	form.Set("channelId", "C_workspace_1")
+	form.Set("prompt", "synthetic smoke")
+	form.Set("mode", "real")
+	req := httptest.NewRequest(http.MethodPost, "/slack/workspaces/test", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("X-Spritz-User-Id", "user-1")
+	rec := httptest.NewRecorder()
+	gateway.routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if slackPayload["channel"] != "C_workspace_1" {
+		t.Fatalf("expected slack post to target the requested channel, got %#v", slackPayload["channel"])
+	}
+	if !strings.Contains(fmt.Sprint(slackPayload["text"]), "Hello from concierge") {
+		t.Fatalf("expected concierge reply to be posted, got %#v", slackPayload["text"])
+	}
+	if !strings.Contains(rec.Body.String(), "Outcome: delivered") {
+		t.Fatalf("expected delivered outcome, got %q", rec.Body.String())
 	}
 }
 

--- a/integrations/slack-gateway/slack_events.go
+++ b/integrations/slack-gateway/slack_events.go
@@ -45,6 +45,27 @@ type slackEventInner struct {
 	ThreadTS    string `json:"thread_ts,omitempty"`
 }
 
+type messageEventProcessOptions struct {
+	Synthetic bool
+	DryRun    bool
+}
+
+type messageEventProcessResult struct {
+	ConversationID  string
+	Outcome         string
+	Reply           string
+	PromptSent      bool
+	PostedMessageTS string
+}
+
+const (
+	messageEventOutcomeIgnored                = "ignored"
+	messageEventOutcomeDelivered              = "delivered"
+	messageEventOutcomeNoReply                = "no_reply"
+	messageEventOutcomeDryRun                 = "dry_run"
+	messageEventOutcomeTerminalFailureReplied = "terminal_failure_replied"
+)
+
 type channelSessionRecoveryState struct {
 	mu              sync.Mutex
 	startedAt       time.Time
@@ -526,6 +547,21 @@ func (g *slackGateway) processMessageEventWithDelivery(
 	envelope slackEnvelope,
 	delivery *slackMessageDelivery,
 ) error {
+	_, err := g.processMessageEventWithDeliveryOptions(
+		ctx,
+		envelope,
+		delivery,
+		messageEventProcessOptions{},
+	)
+	return err
+}
+
+func (g *slackGateway) processMessageEventWithDeliveryOptions(
+	ctx context.Context,
+	envelope slackEnvelope,
+	delivery *slackMessageDelivery,
+	options messageEventProcessOptions,
+) (messageEventProcessResult, error) {
 	success := false
 	defer func() {
 		delivery.finish(success)
@@ -534,7 +570,7 @@ func (g *slackGateway) processMessageEventWithDelivery(
 	event := envelope.Event
 	if normalizeSlackPromptText(event.Type, event.Text, "") == "" {
 		success = true
-		return nil
+		return messageEventProcessResult{Outcome: messageEventOutcomeIgnored}, nil
 	}
 
 	recoveryState := newChannelSessionRecoveryState()
@@ -546,24 +582,27 @@ func (g *slackGateway) processMessageEventWithDelivery(
 		false,
 	)
 	if err != nil {
-		return err
+		return messageEventProcessResult{}, err
 	}
 	if terminalHandled {
 		success = true
-		return nil
+		return messageEventProcessResult{
+			Outcome: messageEventOutcomeTerminalFailureReplied,
+		}, nil
 	}
 	if session.ProviderAuth.APIAppID != "" && strings.TrimSpace(envelope.APIAppID) != "" && session.ProviderAuth.APIAppID != strings.TrimSpace(envelope.APIAppID) {
-		return fmt.Errorf("slack api_app_id mismatch for team %s", envelope.TeamID)
+		return messageEventProcessResult{}, fmt.Errorf("slack api_app_id mismatch for team %s", envelope.TeamID)
 	}
 
-	promptText := buildSlackPromptText(
+	promptText := buildSlackPromptTextWithSynthetic(
 		envelope.TeamID,
 		event,
 		session.ProviderAuth.BotUserID,
+		options.Synthetic,
 	)
 	if promptText == "" {
 		success = true
-		return nil
+		return messageEventProcessResult{Outcome: messageEventOutcomeIgnored}, nil
 	}
 
 	result, err := g.executeConversationPrompt(ctx, envelope, event, session, promptText)
@@ -599,13 +638,17 @@ func (g *slackGateway) processMessageEventWithDelivery(
 						"channel_id", strings.TrimSpace(event.Channel),
 						"message_ts", strings.TrimSpace(event.TS),
 					)
-					return postErr
+					return messageEventProcessResult{}, postErr
 				}
 				if terminalHandled {
 					success = true
-					return nil
+					return messageEventProcessResult{
+						ConversationID: result.conversationID,
+						PromptSent:     result.promptSent,
+						Outcome:        messageEventOutcomeTerminalFailureReplied,
+					}, nil
 				}
-				return sleepErr
+				return messageEventProcessResult{}, sleepErr
 			}
 		} else {
 			recoveryState.resetPromptRetry()
@@ -617,24 +660,34 @@ func (g *slackGateway) processMessageEventWithDelivery(
 				true,
 			)
 			if recoveryErr != nil {
-				return recoveryErr
+				return messageEventProcessResult{}, recoveryErr
 			}
 			if recoveredTerminalHandled {
 				success = true
-				return nil
+				return messageEventProcessResult{
+					ConversationID: result.conversationID,
+					PromptSent:     result.promptSent,
+					Outcome:        messageEventOutcomeTerminalFailureReplied,
+				}, nil
 			}
 			session = recoveredSession
-			promptText = buildSlackPromptText(
+			promptText = buildSlackPromptTextWithSynthetic(
 				envelope.TeamID,
 				event,
 				session.ProviderAuth.BotUserID,
+				options.Synthetic,
 			)
 			if promptText == "" {
 				success = true
-				return nil
+				return messageEventProcessResult{Outcome: messageEventOutcomeIgnored}, nil
 			}
 		}
 		result, err = g.executeConversationPrompt(ctx, envelope, event, session, promptText)
+	}
+	processResult := messageEventProcessResult{
+		ConversationID: result.conversationID,
+		Reply:          result.reply,
+		PromptSent:     result.promptSent,
 	}
 	if err != nil {
 		if !result.promptSent {
@@ -648,16 +701,18 @@ func (g *slackGateway) processMessageEventWithDelivery(
 						"channel_id", strings.TrimSpace(event.Channel),
 						"message_ts", strings.TrimSpace(event.TS),
 					)
-					return postErr
+					return messageEventProcessResult{}, postErr
 				}
 				if terminalHandled {
 					success = true
-					return nil
+					processResult.Outcome = messageEventOutcomeTerminalFailureReplied
+					return processResult, nil
 				}
 			}
-			return err
+			return messageEventProcessResult{}, err
 		}
 		result.reply = "I hit an internal error while processing that request."
+		processResult.Reply = result.reply
 		g.logger.Error("acp prompt failed", "error", err, "conversation_id", result.conversationID)
 	}
 	if result.deliveryType == promptDeliveryNoReply {
@@ -669,20 +724,28 @@ func (g *slackGateway) processMessageEventWithDelivery(
 			"message_ts", strings.TrimSpace(event.TS),
 		)
 		success = true
-		return nil
+		processResult.Outcome = messageEventOutcomeNoReply
+		return processResult, nil
+	}
+	if options.DryRun {
+		success = true
+		processResult.Outcome = messageEventOutcomeDryRun
+		return processResult, nil
 	}
 	replyThreadTS := slackReplyThreadTS(event)
 	replyCtx, cancelReply := context.WithTimeout(context.WithoutCancel(ctx), g.cfg.HTTPTimeout)
 	defer cancelReply()
-	_, err = g.postSlackMessage(replyCtx, session.ProviderAuth.BotAccessToken, event.Channel, result.reply, replyThreadTS)
+	postedMessageTS, err := g.postSlackMessage(replyCtx, session.ProviderAuth.BotAccessToken, event.Channel, result.reply, replyThreadTS)
 	if err != nil {
 		// Once the ACP prompt has already been delivered, suppress duplicate
 		// Slack retries from re-running the same agent side effects.
 		success = result.promptSent
-		return err
+		return messageEventProcessResult{}, err
 	}
 	success = true
-	return nil
+	processResult.Outcome = messageEventOutcomeDelivered
+	processResult.PostedMessageTS = postedMessageTS
+	return processResult, nil
 }
 
 type conversationPromptResult struct {
@@ -908,9 +971,14 @@ type slackPromptContext struct {
 	ThreadTS       string `json:"thread_ts,omitempty"`
 	ConversationID string `json:"conversation_id"`
 	DirectMessage  bool   `json:"direct_message"`
+	Synthetic      bool   `json:"synthetic,omitempty"`
 }
 
 func buildSlackPromptText(teamID string, event slackEventInner, botUserID string) string {
+	return buildSlackPromptTextWithSynthetic(teamID, event, botUserID, false)
+}
+
+func buildSlackPromptTextWithSynthetic(teamID string, event slackEventInner, botUserID string, synthetic bool) string {
 	normalized := normalizeSlackPromptText(event.Type, event.Text, botUserID)
 	if normalized == "" {
 		return ""
@@ -928,6 +996,7 @@ func buildSlackPromptText(teamID string, event slackEventInner, botUserID string
 			ThreadTS:       strings.TrimSpace(event.ThreadTS),
 			ConversationID: slackExternalConversationID(event),
 			DirectMessage:  isSlackDirectMessageEvent(event),
+			Synthetic:      synthetic,
 		},
 	)
 	if err != nil {

--- a/integrations/slack-gateway/workspace_management.go
+++ b/integrations/slack-gateway/workspace_management.go
@@ -19,9 +19,11 @@ type workspaceManagementRow struct {
 	CurrentTargetOwner string
 	TargetStatus       string
 	ChangeTargetHref   string
+	TestHref           string
 	ReconnectHref      string
 	ShowReconnect      bool
 	ShowDisconnect     bool
+	ShowTest           bool
 }
 
 type workspaceManagementPageData struct {
@@ -163,6 +165,9 @@ var workspaceManagementTemplate = template.Must(template.New("workspace-manageme
         </div>
         <div class="actions">
           <a class="primary" href="{{ .ChangeTargetHref }}">Change target</a>
+          {{ if .ShowTest }}
+          <a class="secondary" href="{{ .TestHref }}">Send test</a>
+          {{ end }}
           {{ if .ShowReconnect }}
           <a class="secondary" href="{{ .ReconnectHref }}">Reconnect</a>
           {{ end }}
@@ -194,6 +199,14 @@ func (g *slackGateway) workspaceTargetPath() string {
 
 func (g *slackGateway) workspaceDisconnectPath() string {
 	return g.publicPathPrefix() + "/slack/workspaces/disconnect"
+}
+
+func (g *slackGateway) buildWorkspaceTestHref(teamID string) string {
+	target := url.URL{Path: g.workspaceTestPath()}
+	query := target.Query()
+	query.Set("teamId", strings.TrimSpace(teamID))
+	target.RawQuery = query.Encode()
+	return target.String()
 }
 
 func workspaceNoticeFromRequest(r *http.Request) *workspaceManagementNotice {
@@ -281,9 +294,11 @@ func (g *slackGateway) renderWorkspaceManagementPage(w http.ResponseWriter, r *h
 			CurrentTargetOwner: currentTargetOwner,
 			TargetStatus:       workspaceTargetStatus(installation),
 			ChangeTargetHref:   g.buildWorkspaceTargetHref(installation.Route.ExternalTenantID),
+			TestHref:           g.buildWorkspaceTestHref(installation.Route.ExternalTenantID),
 			ReconnectHref:      g.installRedirectPath(),
 			ShowReconnect:      hasAllowedAction(installation, "reconnect"),
 			ShowDisconnect:     hasAllowedAction(installation, "disconnect"),
+			ShowTest:           !strings.EqualFold(strings.TrimSpace(installation.State), "disconnected"),
 		})
 	}
 

--- a/integrations/slack-gateway/workspace_test_messages.go
+++ b/integrations/slack-gateway/workspace_test_messages.go
@@ -1,0 +1,413 @@
+package main
+
+import (
+	"fmt"
+	"html/template"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const syntheticSlackActorUserID = "U_SYNTHETIC"
+
+type workspaceTestPageData struct {
+	TeamID          string
+	ChannelID       string
+	ThreadTS        string
+	Prompt          string
+	Mode            string
+	CurrentTarget   string
+	Outcome         string
+	Reply           string
+	ConversationID  string
+	PostedMessageTS string
+	ErrorMessage    string
+}
+
+var workspaceTestTemplate = template.Must(template.New("workspace-test").Parse(`<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Slack workspace test</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f4f1ea;
+        --surface: #fffdf9;
+        --border: #ddd5c8;
+        --text: #1f1b16;
+        --muted: #675d50;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: linear-gradient(180deg, var(--bg), #ebe4d7);
+        color: var(--text);
+        padding: 24px;
+      }
+      main {
+        width: min(920px, 100%);
+        margin: 0 auto;
+        display: grid;
+        gap: 16px;
+      }
+      .hero, .card, .notice {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 24px;
+        box-shadow: 0 24px 80px rgba(31, 27, 22, 0.08);
+      }
+      .hero, .card, .notice {
+        padding: 24px;
+      }
+      .hero h1, .notice h2 {
+        margin: 0 0 10px;
+        font-size: 30px;
+        line-height: 1.1;
+      }
+      p, label, .meta {
+        line-height: 1.6;
+      }
+      .meta {
+        color: var(--muted);
+        margin: 0;
+      }
+      form {
+        display: grid;
+        gap: 14px;
+      }
+      label {
+        display: grid;
+        gap: 6px;
+        font-weight: 600;
+      }
+      input, textarea, select, button {
+        font: inherit;
+      }
+      input, textarea, select {
+        width: 100%;
+        border: 1px solid var(--border);
+        border-radius: 14px;
+        padding: 10px 12px;
+        background: #fff;
+        color: var(--text);
+      }
+      textarea {
+        min-height: 120px;
+        resize: vertical;
+      }
+      .inline {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+      .inline label {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        font-weight: 500;
+      }
+      .actions {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+      .actions a, .actions button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 999px;
+        padding: 10px 14px;
+        border: 0;
+        text-decoration: none;
+        cursor: pointer;
+        font-weight: 600;
+      }
+      .primary {
+        background: var(--text);
+        color: #fff;
+      }
+      .secondary {
+        background: #ede6da;
+        color: var(--text);
+      }
+      .value {
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <section class="hero">
+        <h1>Send a synthetic Slack test message</h1>
+        <p class="meta">Workspace {{ .TeamID }}{{ if .CurrentTarget }} · target {{ .CurrentTarget }}{{ end }}</p>
+      </section>
+
+      {{ if .Outcome }}
+      <section class="notice">
+        <h2>Test completed</h2>
+        <p class="meta">Outcome: {{ .Outcome }}</p>
+        {{ if .ConversationID }}<p class="meta">Conversation: <span class="value">{{ .ConversationID }}</span></p>{{ end }}
+        {{ if .PostedMessageTS }}<p class="meta">Posted Slack TS: <span class="value">{{ .PostedMessageTS }}</span></p>{{ end }}
+        {{ if .Reply }}<p class="meta">Reply:</p><p class="value">{{ .Reply }}</p>{{ end }}
+      </section>
+      {{ end }}
+
+      {{ if .ErrorMessage }}
+      <section class="notice">
+        <h2>Test failed</h2>
+        <p>{{ .ErrorMessage }}</p>
+      </section>
+      {{ end }}
+
+      <section class="card">
+        <form method="post" action="">
+          <input type="hidden" name="teamId" value="{{ .TeamID }}">
+          <label>
+            Channel ID
+            <input type="text" name="channelId" value="{{ .ChannelID }}" placeholder="C12345678" required>
+          </label>
+          <label>
+            Thread TS
+            <input type="text" name="threadTs" value="{{ .ThreadTS }}" placeholder="Optional existing thread timestamp">
+          </label>
+          <label>
+            Prompt
+            <textarea name="prompt" required>{{ .Prompt }}</textarea>
+          </label>
+          <div class="inline">
+            <label><input type="radio" name="mode" value="real" {{ if ne .Mode "dry-run" }}checked{{ end }}> Real reply</label>
+            <label><input type="radio" name="mode" value="dry-run" {{ if eq .Mode "dry-run" }}checked{{ end }}> Dry run</label>
+          </div>
+          <div class="actions">
+            <button class="primary" type="submit">Run test</button>
+            <a class="secondary" href="{{ .BackHref }}">Back to workspaces</a>
+          </div>
+        </form>
+      </section>
+    </main>
+  </body>
+</html>`))
+
+type workspaceSyntheticTestPageData struct {
+	workspaceTestPageData
+	BackHref string
+}
+
+func (g *slackGateway) workspaceTestPath() string {
+	return g.publicPathPrefix() + "/slack/workspaces/test"
+}
+
+func defaultWorkspaceTestPrompt() string {
+	return fmt.Sprintf("spritz-slack-smoke-%d", time.Now().UTC().Unix())
+}
+
+func inferSyntheticSlackEvent(channelID, text, threadTS string) (slackEnvelope, error) {
+	normalizedChannelID := strings.TrimSpace(channelID)
+	if normalizedChannelID == "" {
+		return slackEnvelope{}, fmt.Errorf("channel id is required")
+	}
+	normalizedText := strings.TrimSpace(text)
+	if normalizedText == "" {
+		return slackEnvelope{}, fmt.Errorf("prompt is required")
+	}
+	eventType := "app_mention"
+	channelType := "channel"
+	if strings.HasPrefix(normalizedChannelID, "D") {
+		eventType = "message"
+		channelType = "im"
+	} else if strings.HasPrefix(normalizedChannelID, "G") {
+		eventType = "message"
+		channelType = "mpim"
+	}
+	now := time.Now().UTC()
+	messageTS := fmt.Sprintf("%d.%06d", now.Unix(), now.Nanosecond()/1000)
+	return slackEnvelope{
+		Type:    "event_callback",
+		EventID: "synthetic-" + strings.ReplaceAll(messageTS, ".", ""),
+		Event: slackEventInner{
+			Type:        eventType,
+			User:        syntheticSlackActorUserID,
+			Text:        normalizedText,
+			Channel:     normalizedChannelID,
+			ChannelType: channelType,
+			TS:          messageTS,
+			ThreadTS:    strings.TrimSpace(threadTS),
+		},
+	}, nil
+}
+
+func (g *slackGateway) lookupManagedWorkspace(
+	r *http.Request,
+	callerAuthID string,
+	teamID string,
+) (*backendManagedInstallation, error) {
+	installations, err := g.listManagedInstallations(r.Context(), callerAuthID)
+	if err != nil {
+		return nil, err
+	}
+	normalizedTeamID := strings.TrimSpace(teamID)
+	for _, installation := range installations {
+		if strings.TrimSpace(installation.Route.ExternalTenantID) != normalizedTeamID {
+			continue
+		}
+		installationCopy := installation
+		return &installationCopy, nil
+	}
+	return nil, nil
+}
+
+func (g *slackGateway) renderWorkspaceTestPage(
+	w http.ResponseWriter,
+	data workspaceTestPageData,
+) {
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_ = workspaceTestTemplate.Execute(w, workspaceSyntheticTestPageData{
+		workspaceTestPageData: data,
+		BackHref:              g.workspacesPath(),
+	})
+}
+
+func (g *slackGateway) handleWorkspaceTest(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		g.handleWorkspaceTestForm(w, r)
+	case http.MethodPost:
+		g.handleWorkspaceTestSubmit(w, r)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (g *slackGateway) handleWorkspaceTestForm(w http.ResponseWriter, r *http.Request) {
+	principal, ok := requireBrowserPrincipal(g.cfg, w, r)
+	if !ok {
+		return
+	}
+	teamID := strings.TrimSpace(r.URL.Query().Get("teamId"))
+	if teamID == "" {
+		http.Error(w, "teamId is required", http.StatusBadRequest)
+		return
+	}
+	installation, err := g.lookupManagedWorkspace(r, principal.ID, teamID)
+	if err != nil {
+		g.logger.ErrorContext(
+			r.Context(),
+			"workspace test lookup failed",
+			"err", err,
+			"caller_auth_id", principal.ID,
+			"team_id", teamID,
+		)
+		http.Error(w, "workspace lookup unavailable", http.StatusBadGateway)
+		return
+	}
+	if installation == nil {
+		http.Error(w, "workspace not manageable", http.StatusForbidden)
+		return
+	}
+	currentTarget := ""
+	if installation.CurrentTarget != nil {
+		currentTarget = strings.TrimSpace(installation.CurrentTarget.Profile.Name)
+	}
+	g.renderWorkspaceTestPage(w, workspaceTestPageData{
+		TeamID:        teamID,
+		Prompt:        defaultWorkspaceTestPrompt(),
+		Mode:          "real",
+		CurrentTarget: currentTarget,
+	})
+}
+
+func (g *slackGateway) handleWorkspaceTestSubmit(w http.ResponseWriter, r *http.Request) {
+	principal, ok := requireBrowserPrincipal(g.cfg, w, r)
+	if !ok {
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "invalid form payload", http.StatusBadRequest)
+		return
+	}
+	teamID := strings.TrimSpace(r.FormValue("teamId"))
+	if teamID == "" {
+		http.Error(w, "teamId is required", http.StatusBadRequest)
+		return
+	}
+	installation, err := g.lookupManagedWorkspace(r, principal.ID, teamID)
+	if err != nil {
+		g.logger.ErrorContext(
+			r.Context(),
+			"workspace test lookup failed",
+			"err", err,
+			"caller_auth_id", principal.ID,
+			"team_id", teamID,
+		)
+		http.Error(w, "workspace lookup unavailable", http.StatusBadGateway)
+		return
+	}
+	if installation == nil {
+		http.Error(w, "workspace not manageable", http.StatusForbidden)
+		return
+	}
+	channelID := strings.TrimSpace(r.FormValue("channelId"))
+	threadTS := strings.TrimSpace(r.FormValue("threadTs"))
+	prompt := strings.TrimSpace(r.FormValue("prompt"))
+	mode := strings.TrimSpace(r.FormValue("mode"))
+	if mode == "" {
+		mode = "real"
+	}
+	pageData := workspaceTestPageData{
+		TeamID:        teamID,
+		ChannelID:     channelID,
+		ThreadTS:      threadTS,
+		Prompt:        prompt,
+		Mode:          mode,
+		CurrentTarget: "",
+	}
+	if installation.CurrentTarget != nil {
+		pageData.CurrentTarget = strings.TrimSpace(installation.CurrentTarget.Profile.Name)
+	}
+	envelope, err := inferSyntheticSlackEvent(channelID, prompt, threadTS)
+	if err != nil {
+		pageData.ErrorMessage = err.Error()
+		g.renderWorkspaceTestPage(w, pageData)
+		return
+	}
+	envelope.TeamID = teamID
+
+	delivery, process, err := g.beginMessageEventDelivery(envelope)
+	if err != nil {
+		pageData.ErrorMessage = err.Error()
+		g.renderWorkspaceTestPage(w, pageData)
+		return
+	}
+	if !process {
+		pageData.Outcome = messageEventOutcomeIgnored
+		g.renderWorkspaceTestPage(w, pageData)
+		return
+	}
+	result, err := g.processMessageEventWithDeliveryOptions(
+		r.Context(),
+		envelope,
+		delivery,
+		messageEventProcessOptions{
+			Synthetic: true,
+			DryRun:    mode == "dry-run",
+		},
+	)
+	if err != nil {
+		pageData.ErrorMessage = err.Error()
+		g.renderWorkspaceTestPage(w, pageData)
+		return
+	}
+	pageData.Outcome = result.Outcome
+	pageData.Reply = result.Reply
+	pageData.ConversationID = result.ConversationID
+	pageData.PostedMessageTS = result.PostedMessageTS
+	g.renderWorkspaceTestPage(w, pageData)
+}


### PR DESCRIPTION
## Summary
- add a browser-authenticated workspace test flow in the Slack gateway
- run synthetic Slack events through the existing routing/runtime pipeline with dry-run or real-reply modes
- mark synthetic prompts in the channel context and cover the new path with gateway tests

## Testing
- go test ./... (in integrations/slack-gateway)