### PR TITLE
feat: support Slack channel mention policies

### DIFF
--- a/api/channel_installation_config.go
+++ b/api/channel_installation_config.go
@@ -30,18 +30,20 @@ func applyChannelInstallationConfigProjection(spec *spritzv1.SpritzSpec, attribu
 		return nil
 	}
 	trimmed := bytes.TrimSpace(raw)
-	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+	if len(trimmed) == 0 {
 		return nil
 	}
 	var payload channelInstallationConfigPayload
-	decoder := json.NewDecoder(bytes.NewReader(trimmed))
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&payload); err != nil {
-		return errors.New("installationConfig is invalid")
-	}
-	var trailing any
-	if err := decoder.Decode(&trailing); err != io.EOF {
-		return errors.New("installationConfig is invalid")
+	if !bytes.Equal(trimmed, []byte("null")) {
+		decoder := json.NewDecoder(bytes.NewReader(trimmed))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&payload); err != nil {
+			return errors.New("installationConfig is invalid")
+		}
+		var trailing any
+		if err := decoder.Decode(&trailing); err != io.EOF {
+			return errors.New("installationConfig is invalid")
+		}
 	}
 
 	provider := strings.TrimSpace(attributes["provider"])
@@ -61,15 +63,14 @@ func applyChannelInstallationConfigProjection(spec *spritzv1.SpritzSpec, attribu
 	}
 	providers := ensureObjectField(config, "providers")
 	providerConfig := ensureObjectField(providers, provider)
-	scopeConfig := ensureObjectField(providerConfig, openClawScopeConfigKey(externalScopeType))
-	tenantConfig := ensureObjectField(scopeConfig, externalTenantID)
 	channels := map[string]any{}
 	for _, policy := range channelPolicies {
 		channels[policy.ExternalChannelID] = map[string]any{
+			"allow":          true,
 			"requireMention": *policy.RequireMention,
 		}
 	}
-	tenantConfig["channels"] = channels
+	providerConfig["channels"] = channels
 
 	encoded, err := json.Marshal(config)
 	if err != nil {
@@ -99,15 +100,6 @@ func normalizeChannelInstallationPolicies(policies []channelInstallationChannelP
 		normalized = append(normalized, policy)
 	}
 	return normalized, nil
-}
-
-func openClawScopeConfigKey(externalScopeType string) string {
-	switch strings.TrimSpace(externalScopeType) {
-	case "workspace":
-		return "workspaces"
-	default:
-		return "tenants"
-	}
 }
 
 func readOpenClawConfigEnv(env []corev1.EnvVar) (map[string]any, error) {

--- a/api/channel_installation_config.go
+++ b/api/channel_installation_config.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+
+	spritzv1 "spritz.sh/operator/api/v1"
+)
+
+const openclawConfigEnvName = "OPENCLAW_CONFIG_JSON"
+
+type channelInstallationConfigPayload struct {
+	ChannelPolicies []channelInstallationChannelPolicy `json:"channelPolicies,omitempty"`
+}
+
+type channelInstallationChannelPolicy struct {
+	ExternalChannelID   string `json:"externalChannelId"`
+	ExternalChannelType string `json:"externalChannelType,omitempty"`
+	RequireMention      *bool  `json:"requireMention"`
+}
+
+func applyChannelInstallationConfigProjection(spec *spritzv1.SpritzSpec, attributes map[string]string, raw json.RawMessage) error {
+	if spec == nil {
+		return nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil
+	}
+	var payload channelInstallationConfigPayload
+	decoder := json.NewDecoder(bytes.NewReader(trimmed))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&payload); err != nil {
+		return errors.New("installationConfig is invalid")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return errors.New("installationConfig is invalid")
+	}
+
+	provider := strings.TrimSpace(attributes["provider"])
+	externalScopeType := strings.TrimSpace(attributes["externalScopeType"])
+	externalTenantID := strings.TrimSpace(attributes["externalTenantId"])
+	if provider == "" || externalScopeType == "" || externalTenantID == "" {
+		return errors.New("installationConfig requires provider route attributes")
+	}
+	channelPolicies, err := normalizeChannelInstallationPolicies(payload.ChannelPolicies)
+	if err != nil {
+		return err
+	}
+
+	config, err := readOpenClawConfigEnv(spec.Env)
+	if err != nil {
+		return err
+	}
+	providers := ensureObjectField(config, "providers")
+	providerConfig := ensureObjectField(providers, provider)
+	scopeConfig := ensureObjectField(providerConfig, openClawScopeConfigKey(externalScopeType))
+	tenantConfig := ensureObjectField(scopeConfig, externalTenantID)
+	channels := map[string]any{}
+	for _, policy := range channelPolicies {
+		channels[policy.ExternalChannelID] = map[string]any{
+			"requireMention": *policy.RequireMention,
+		}
+	}
+	tenantConfig["channels"] = channels
+
+	encoded, err := json.Marshal(config)
+	if err != nil {
+		return errors.New("OPENCLAW_CONFIG_JSON is invalid")
+	}
+	setOpenClawConfigEnv(&spec.Env, string(encoded))
+	return nil
+}
+
+func normalizeChannelInstallationPolicies(policies []channelInstallationChannelPolicy) ([]channelInstallationChannelPolicy, error) {
+	seen := map[string]struct{}{}
+	normalized := make([]channelInstallationChannelPolicy, 0, len(policies))
+	for index, policy := range policies {
+		channelID := strings.TrimSpace(policy.ExternalChannelID)
+		if channelID == "" {
+			return nil, fmt.Errorf("installationConfig.channelPolicies.%d.externalChannelId is required", index)
+		}
+		if _, exists := seen[channelID]; exists {
+			return nil, fmt.Errorf("installationConfig.channelPolicies.%d.externalChannelId is duplicate", index)
+		}
+		seen[channelID] = struct{}{}
+		if policy.RequireMention == nil {
+			return nil, fmt.Errorf("installationConfig.channelPolicies.%d.requireMention is required", index)
+		}
+		policy.ExternalChannelID = channelID
+		policy.ExternalChannelType = strings.TrimSpace(policy.ExternalChannelType)
+		normalized = append(normalized, policy)
+	}
+	return normalized, nil
+}
+
+func openClawScopeConfigKey(externalScopeType string) string {
+	switch strings.TrimSpace(externalScopeType) {
+	case "workspace":
+		return "workspaces"
+	default:
+		return "tenants"
+	}
+}
+
+func readOpenClawConfigEnv(env []corev1.EnvVar) (map[string]any, error) {
+	for _, item := range env {
+		if item.Name != openclawConfigEnvName {
+			continue
+		}
+		if item.ValueFrom != nil {
+			return nil, errors.New("OPENCLAW_CONFIG_JSON cannot use valueFrom with installationConfig")
+		}
+		return parseOpenClawConfigJSON(item.Value)
+	}
+	return map[string]any{}, nil
+}
+
+func parseOpenClawConfigJSON(value string) (map[string]any, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return map[string]any{}, nil
+	}
+	var payload map[string]any
+	decoder := json.NewDecoder(strings.NewReader(trimmed))
+	decoder.UseNumber()
+	if err := decoder.Decode(&payload); err != nil {
+		return nil, errors.New("OPENCLAW_CONFIG_JSON is invalid")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return nil, errors.New("OPENCLAW_CONFIG_JSON is invalid")
+	}
+	if payload == nil {
+		payload = map[string]any{}
+	}
+	return payload, nil
+}
+
+func ensureObjectField(parent map[string]any, key string) map[string]any {
+	if existing, ok := parent[key].(map[string]any); ok {
+		return existing
+	}
+	child := map[string]any{}
+	parent[key] = child
+	return child
+}
+
+func setOpenClawConfigEnv(env *[]corev1.EnvVar, value string) {
+	for index := range *env {
+		if (*env)[index].Name == openclawConfigEnvName {
+			(*env)[index].Value = value
+			(*env)[index].ValueFrom = nil
+			return
+		}
+	}
+	*env = append(*env, corev1.EnvVar{Name: openclawConfigEnvName, Value: value})
+}

--- a/api/internal_bindings.go
+++ b/api/internal_bindings.go
@@ -20,13 +20,14 @@ import (
 )
 
 type internalBindingRequest struct {
-	DesiredRevision string                      `json:"desiredRevision,omitempty"`
-	Disconnected    bool                        `json:"disconnected,omitempty"`
-	Attributes      map[string]string           `json:"attributes,omitempty"`
-	Principal       internalCreatePrincipal     `json:"principal"`
-	Request         json.RawMessage             `json:"request"`
-	AdoptActive     *internalBindingInstanceRef `json:"adoptActive,omitempty"`
-	AdoptedRevision string                      `json:"adoptedRevision,omitempty"`
+	DesiredRevision    string                      `json:"desiredRevision,omitempty"`
+	Disconnected       bool                        `json:"disconnected,omitempty"`
+	Attributes         map[string]string           `json:"attributes,omitempty"`
+	InstallationConfig json.RawMessage             `json:"installationConfig,omitempty"`
+	Principal          internalCreatePrincipal     `json:"principal"`
+	Request            json.RawMessage             `json:"request"`
+	AdoptActive        *internalBindingInstanceRef `json:"adoptActive,omitempty"`
+	AdoptedRevision    string                      `json:"adoptedRevision,omitempty"`
 }
 
 type internalBindingInstanceRef struct {
@@ -173,6 +174,9 @@ func (s *server) upsertInternalBinding(c echo.Context) error {
 		return writeError(c, http.StatusInternalServerError, err.Error())
 	}
 	if err := resolveCreateLifetimes(&requestBody.Spec, s.provisioners, true); err != nil {
+		return writeError(c, http.StatusBadRequest, err.Error())
+	}
+	if err := applyChannelInstallationConfigProjection(&requestBody.Spec, body.Attributes, body.InstallationConfig); err != nil {
 		return writeError(c, http.StatusBadRequest, err.Error())
 	}
 

--- a/api/internal_bindings_test.go
+++ b/api/internal_bindings_test.go
@@ -189,7 +189,10 @@ func TestInternalUpsertBindingPreservesNormalizedCreateAnnotations(t *testing.T)
 
 func TestInternalUpsertBindingProjectsInstallationConfigIntoOpenClawEnv(t *testing.T) {
 	s := newInternalSpritzesTestServer(t)
-	s.presets.byID[0].Env = []corev1.EnvVar{{Name: "OPENCLAW_CONFIG_JSON", Value: "{}"}}
+	s.presets.byID[0].Env = []corev1.EnvVar{{
+		Name:  "OPENCLAW_CONFIG_JSON",
+		Value: `{"providers":{"slack":{"channels":{"C_OLD":{"allow":true,"requireMention":false}}}}}`,
+	}}
 	e := echo.New()
 	s.registerRoutes(e)
 
@@ -243,8 +246,58 @@ func TestInternalUpsertBindingProjectsInstallationConfigIntoOpenClawEnv(t *testi
 			openClawConfig = item.Value
 		}
 	}
-	if !strings.Contains(openClawConfig, `"C0ANJGDB4Q5":{"requireMention":false}`) {
+	var projected map[string]any
+	if err := json.Unmarshal([]byte(openClawConfig), &projected); err != nil {
+		t.Fatalf("expected valid OpenClaw config JSON, got %s: %v", openClawConfig, err)
+	}
+	providers, _ := projected["providers"].(map[string]any)
+	slackConfig, _ := providers["slack"].(map[string]any)
+	channels, _ := slackConfig["channels"].(map[string]any)
+	channelConfig, _ := channels["C0ANJGDB4Q5"].(map[string]any)
+	if channelConfig["allow"] != true || channelConfig["requireMention"] != false {
 		t.Fatalf("expected OpenClaw channel policy in env, got %s", openClawConfig)
+	}
+	if _, exists := channels["C_OLD"]; exists {
+		t.Fatalf("expected stale OpenClaw channel policy to be removed, got %s", openClawConfig)
+	}
+}
+
+func TestInternalUpsertBindingProjectsNullInstallationConfigAsEmptyPolicy(t *testing.T) {
+	spec := spritzv1.SpritzSpec{
+		Env: []corev1.EnvVar{{
+			Name:  "OPENCLAW_CONFIG_JSON",
+			Value: `{"providers":{"slack":{"channels":{"C_OLD":{"allow":true,"requireMention":false}}}}}`,
+		}},
+	}
+
+	err := applyChannelInstallationConfigProjection(
+		&spec,
+		map[string]string{
+			"provider":          "slack",
+			"externalScopeType": "workspace",
+			"externalTenantId":  "T021GRS5F4P",
+		},
+		json.RawMessage(`null`),
+	)
+	if err != nil {
+		t.Fatalf("expected null installationConfig to clear policy projection, got %v", err)
+	}
+
+	var openClawConfig string
+	for _, item := range spec.Env {
+		if item.Name == "OPENCLAW_CONFIG_JSON" {
+			openClawConfig = item.Value
+		}
+	}
+	var projected map[string]any
+	if err := json.Unmarshal([]byte(openClawConfig), &projected); err != nil {
+		t.Fatalf("expected valid OpenClaw config JSON, got %s: %v", openClawConfig, err)
+	}
+	providers, _ := projected["providers"].(map[string]any)
+	slackConfig, _ := providers["slack"].(map[string]any)
+	channels, _ := slackConfig["channels"].(map[string]any)
+	if len(channels) != 0 {
+		t.Fatalf("expected null installationConfig to remove stale channels, got %s", openClawConfig)
 	}
 }
 

--- a/api/internal_bindings_test.go
+++ b/api/internal_bindings_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -183,6 +184,67 @@ func TestInternalUpsertBindingPreservesNormalizedCreateAnnotations(t *testing.T)
 			instanceClassVersionAnnotationKey,
 			stored.Spec.Template.Annotations,
 		)
+	}
+}
+
+func TestInternalUpsertBindingProjectsInstallationConfigIntoOpenClawEnv(t *testing.T) {
+	s := newInternalSpritzesTestServer(t)
+	s.presets.byID[0].Env = []corev1.EnvVar{{Name: "OPENCLAW_CONFIG_JSON", Value: "{}"}}
+	e := echo.New()
+	s.registerRoutes(e)
+
+	body := `{
+		"desiredRevision": "sha256:rev-1",
+		"attributes": {
+			"provider": "slack",
+			"externalScopeType": "workspace",
+			"externalTenantId": "T021GRS5F4P"
+		},
+		"installationConfig": {
+			"channelPolicies": [
+				{"externalChannelId": "C0ANJGDB4Q5", "requireMention": false}
+			]
+		},
+		"principal": {"id": "channel-gateway"},
+		"request": {
+			"presetId": "zeno",
+			"ownerId": "user-123",
+			"requestId": "binding-upsert-config",
+			"source": "channel-gateway",
+			"spec": {}
+		}
+	}`
+	req := httptest.NewRequest(http.MethodPut, "/api/internal/v1/bindings/channel-installation-binding-config", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer spritz-internal-token")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var stored spritzv1.SpritzBinding
+	if err := s.client.Get(
+		context.Background(),
+		client.ObjectKey{
+			Namespace: "default",
+			Name:      bindingResourceNameForKey("channel-installation-binding-config"),
+		},
+		&stored,
+	); err != nil {
+		t.Fatalf("failed to load stored binding: %v", err)
+	}
+
+	var openClawConfig string
+	for _, item := range stored.Spec.Template.Spec.Env {
+		if item.Name == "OPENCLAW_CONFIG_JSON" {
+			openClawConfig = item.Value
+		}
+	}
+	if !strings.Contains(openClawConfig, `"C0ANJGDB4Q5":{"requireMention":false}`) {
+		t.Fatalf("expected OpenClaw channel policy in env, got %s", openClawConfig)
 	}
 }
 

--- a/docs/2026-04-24-channel-install-message-policy-config.md
+++ b/docs/2026-04-24-channel-install-message-policy-config.md
@@ -1,0 +1,351 @@
+---
+date: 2026-04-24
+author: Onur Solmaz <onur@textcortex.com>
+title: Channel Install Message Policy Config
+tags: [spritz, channel-gateway, slack, install, config, openclaw, architecture]
+---
+
+## Overview
+
+This document defines how a workspace-level channel installation can allow
+selected channels to relay normal messages without requiring a bot mention.
+
+The immediate use case is Slack:
+
+- the Slack app remains installed at workspace scope
+- one or more Slack channels are configured with `requireMention: false`
+- messages in those channels are relayed without tagging the bot account
+- other workspace channels continue to require a mention
+
+The design keeps Spritz generic. The setting is modeled as installation config,
+not as deployment-specific target selection and not as TextCortex-specific
+state.
+
+Related docs:
+
+- [Channel Install Target Selection Architecture](2026-04-17-channel-install-target-selection-architecture.md)
+- [Channel Install Ownership and Management Architecture](2026-04-17-channel-install-ownership-and-management-architecture.md)
+- [Slack Channel Gateway Implementation Plan](2026-03-24-slack-channel-gateway-implementation-plan.md)
+- [Shared Channel Concierge Lifecycle Architecture](2026-03-31-shared-channel-concierge-lifecycle-architecture.md)
+
+## Problem
+
+Workspace installs are useful because one provider installation can route
+messages for a whole external tenant, such as one Slack workspace.
+
+However, message delivery policy is not always workspace-wide. A deployment may
+want only specific channels to behave as always-on relay channels, while all
+other channels still require an explicit bot mention.
+
+If this setting is encoded in install target selection, the model becomes
+incorrect:
+
+- the selected target did not change
+- the Slack workspace install did not change
+- only provider message policy for selected channels changed
+
+Spritz therefore needs a separate installation-config surface.
+
+## Core Decision
+
+Store channel mention policy as mutable installation config on the durable
+channel installation record.
+
+The route identity remains unchanged:
+
+- `principalId`
+- `provider`
+- `externalScopeType`
+- `externalTenantId`
+
+For Slack workspace installs, `externalTenantId` is the Slack team or workspace
+ID. The installation can then carry message policy for channels inside that
+workspace.
+
+## Config Shape
+
+The generic installation config should use provider-owned external IDs, not
+deployment-owned concepts.
+
+Recommended v1 shape:
+
+```json
+{
+  "channelPolicies": [
+    {
+      "externalChannelId": "C1234567890",
+      "requireMention": false
+    }
+  ]
+}
+```
+
+Field meanings:
+
+- `channelPolicies`: message handling rules for external provider channels.
+- `externalChannelId`: the provider's stable channel ID.
+- `requireMention`: whether normal channel messages must mention the bot before
+  Spritz relays them.
+
+Default behavior:
+
+- if no matching channel policy exists, `requireMention` is `true`
+- explicit app mentions continue to work
+- direct messages keep their existing behavior
+
+The config can be extended later without changing the route identity:
+
+```json
+{
+  "channelPolicies": [
+    {
+      "externalChannelId": "C1234567890",
+      "externalChannelType": "channel",
+      "requireMention": false
+    }
+  ]
+}
+```
+
+## What This Is Not
+
+This setting must not be stored in `presetInputs`.
+
+`presetInputs` selects the deployment-owned target that backs the installation.
+Installation config controls mutable provider behavior for that installation.
+
+Pinned split:
+
+- route identity determines the shared app and external tenant
+- `presetInputs` determines the target behind that installation
+- installation config determines provider message behavior
+
+This keeps the design TextCortex-agnostic. Spritz only stores provider IDs and
+generic message policy. The deployment remains free to decide what the selected
+target means.
+
+## Storage Ownership
+
+The deployment that owns channel installations should persist the config on the
+same durable installation object that already stores route identity,
+ownership, provider auth, and `presetInputs`.
+
+Spritz defines the API contract and semantics. The deployment stores the data.
+
+That means:
+
+- Spritz owns the install-management UX and generic API shape
+- the deployment owns the database table and authorization checks
+- Spritz and the channel gateway consume the effective config
+- OpenClaw receives a projected runtime config during concierge boot
+
+Existing installs should default to empty config, which preserves current
+mention-required behavior.
+
+## API Contract
+
+Add a generic install-management operation for config updates.
+
+Recommended operation:
+
+- `channel.installation.config.update`
+
+Recommended request shape:
+
+```json
+{
+  "installationId": "inst_123",
+  "installationConfig": {
+    "channelPolicies": [
+      {
+        "externalChannelId": "C1234567890",
+        "requireMention": false
+      }
+    ]
+  }
+}
+```
+
+Recommended response shape:
+
+```json
+{
+  "installation": {
+    "id": "inst_123",
+    "provider": "slack",
+    "externalScopeType": "workspace",
+    "externalTenantId": "T1234567890",
+    "installationConfig": {
+      "channelPolicies": [
+        {
+          "externalChannelId": "C1234567890",
+          "requireMention": false
+        }
+      ]
+    }
+  }
+}
+```
+
+Management list responses should also include `installationConfig` so Spritz can
+render current channel policy.
+
+Validation rules:
+
+- the caller must be allowed to manage the installation
+- `externalChannelId` must be non-empty
+- `requireMention` must be boolean
+- duplicate channel policies should be rejected or normalized
+- provider-specific ID validation may be applied by the deployment
+- deployments may cap the number of channel policies per installation
+
+Reinstall should preserve existing installation config unless the reinstall
+request explicitly changes it through a config-management operation.
+
+## Session Exchange
+
+The channel gateway needs access to effective install config before deciding
+whether a normal channel message can be relayed without a mention.
+
+Recommended v1 behavior:
+
+- session exchange returns the workspace installation config
+- the gateway caches it by provider tenant ID for a short TTL
+- each event checks the current channel against `channelPolicies`
+
+For Slack this means the gateway can receive normal `message` events for a
+workspace install, then decide locally:
+
+```text
+if event is app_mention:
+  relay
+
+if event is normal message and channel policy says requireMention=false:
+  relay
+
+if event is normal message and channel policy is missing:
+  require bot mention
+```
+
+The gateway must keep existing safety checks:
+
+- ignore bot messages
+- ignore unsupported Slack message subtypes
+- ignore empty prompts after mention stripping
+- dedupe by Slack team, channel, and timestamp
+
+The dedupe rule is important because Slack can surface both a normal message
+event and an app mention event for the same user message.
+
+## OpenClaw Projection
+
+The stored installation config is the source of truth. OpenClaw config is a
+runtime projection of that source of truth.
+
+When concierge is created, recovered, or reconciled, Spritz should project the
+same channel policies into the OpenClaw config passed to the runtime.
+
+Example projection:
+
+```json
+{
+  "providers": {
+    "slack": {
+      "workspaces": {
+        "T1234567890": {
+          "channels": {
+            "C1234567890": {
+              "requireMention": false
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+The exact OpenClaw JSON should match OpenClaw's config schema. Spritz should
+perform that mapping at the runtime adapter or preset boundary, not in the
+generic installation-management API.
+
+## Reconciliation
+
+Config changes must affect the desired concierge state.
+
+If `installationConfig` changes, the binding or rollout desired state must
+change too. Otherwise the database can be updated while the running concierge
+keeps old OpenClaw config.
+
+Recommended implementation:
+
+- store deterministic JSON for installation config
+- compute a config hash or revision
+- include that hash in the desired binding or rollout input
+- reconcile the concierge when the hash changes
+
+This makes config changes behave like other desired runtime changes.
+
+## Failure Behavior
+
+The default must fail closed.
+
+Rules:
+
+- missing config means mentions are required
+- invalid config should be rejected before save
+- if config cannot be loaded during message handling, require a mention
+- if OpenClaw projection fails, concierge rollout should fail rather than start
+  with broader message access than intended
+
+## Implementation Notes
+
+Recommended platform changes:
+
+- add an `installation_config` JSON/Text field to the durable channel
+  installation model
+- add config serialization to installation list and detail responses
+- add the config update operation
+- pass installation config into binding creation or reconciliation
+- include config revision in desired state
+
+Recommended Slack gateway changes:
+
+- include installation config in session exchange response or add a lightweight
+  config lookup
+- cache config by Slack team ID with a short TTL
+- allow unmentioned normal channel messages only when the matching channel
+  policy has `requireMention: false`
+- keep mention-required behavior as the default
+
+Recommended Spritz runtime changes:
+
+- accept installation config separately from `presetInputs`
+- project relevant channel policies into OpenClaw config during concierge boot
+- reconcile runtime config when installation config changes
+
+## Test Plan
+
+Backend tests:
+
+- saves and returns installation config
+- rejects invalid channel policies
+- preserves config across reinstall
+- keeps config separate from `presetInputs`
+- changes desired binding state when config changes
+
+Slack gateway tests:
+
+- relays unmentioned message in configured channel
+- ignores unmentioned message in unconfigured channel
+- still relays explicit app mention
+- dedupes duplicate `message` and `app_mention` delivery for the same Slack
+  timestamp
+- ignores bot messages in configured channels
+
+Runtime tests:
+
+- concierge boot includes configured `requireMention: false` channels in
+  OpenClaw config
+- config changes trigger reconcile or rollout
+- missing config preserves mention-required behavior

--- a/docs/2026-04-24-channel-install-message-policy-config.md
+++ b/docs/2026-04-24-channel-install-message-policy-config.md
@@ -18,7 +18,7 @@ The immediate use case is Slack:
 - other workspace channels continue to require a mention
 
 The design keeps Spritz generic. The setting is modeled as installation config,
-not as deployment-specific target selection and not as TextCortex-specific
+not as deployment-specific target selection and not as organization-specific
 state.
 
 Related docs:
@@ -120,9 +120,9 @@ Pinned split:
 - `presetInputs` determines the target behind that installation
 - installation config determines provider message behavior
 
-This keeps the design TextCortex-agnostic. Spritz only stores provider IDs and
-generic message policy. The deployment remains free to decide what the selected
-target means.
+This keeps the design organization-agnostic. Spritz only stores provider IDs
+and generic message policy. The deployment remains free to decide what the
+selected target means.
 
 ## Storage Ownership
 
@@ -251,13 +251,10 @@ Example projection:
 {
   "providers": {
     "slack": {
-      "workspaces": {
-        "T1234567890": {
-          "channels": {
-            "C1234567890": {
-              "requireMention": false
-            }
-          }
+      "channels": {
+        "C1234567890": {
+          "allow": true,
+          "requireMention": false
         }
       }
     }

--- a/docs/2026-04-24-slack-install-modes.md
+++ b/docs/2026-04-24-slack-install-modes.md
@@ -1,0 +1,187 @@
+---
+date: 2026-04-24
+author: Onur Solmaz <onur@textcortex.com>
+title: Slack Install Modes
+tags: [slack, oauth, install, channels, workspace, enterprise]
+---
+
+## Overview
+
+Slack apps are normally installed into a workspace or an Enterprise Grid
+organization.
+
+People sometimes say "channel install" when they mean one of two different
+things:
+
+- the OAuth flow included an incoming webhook channel picker
+- the app is already installed in the workspace and is then added to, invited
+  into, or configured for a specific channel
+
+Those are different from a normal workspace app install.
+
+Slack's core install model is OAuth-based. The install grants tokens and scopes
+to the app for a workspace or organization. Channel behavior is usually a later
+authorization, membership, routing, or configuration layer.
+
+Sources:
+
+- [Installing with OAuth](https://docs.slack.dev/authentication/installing-with-oauth)
+- [Developing apps for Enterprise orgs](https://docs.slack.dev/enterprise/developing-for-enterprise-orgs)
+- [Incoming webhook scope](https://docs.slack.dev/reference/scopes/incoming-webhook)
+- [Sending messages using incoming webhooks](https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks)
+- [conversations.join](https://docs.slack.dev/reference/methods/conversations.join/)
+
+## Short Version
+
+Use "workspace install" for the normal Slack app OAuth install.
+
+Use "org-wide install" for Enterprise Grid installs.
+
+Use "incoming webhook channel selection" when OAuth asks the user to choose one
+channel and returns a webhook URL for that channel.
+
+Use "channel membership" or "channel configuration" when an already-installed
+app is enabled for a channel.
+
+Avoid using "channel install" by itself unless the product defines exactly what
+it means.
+
+## Modes
+
+| Mode | What Slack Creates | Main Scope | Use It For | Important Detail |
+| --- | --- | --- | --- | --- |
+| Workspace OAuth install | Bot token, app installation, optional user token | One workspace | Most Slack apps and bots | The app is installed in the workspace, not automatically in every channel. |
+| Enterprise org-wide install | Org-level installation and enterprise identity | Enterprise Grid org, then selected workspaces | Enterprise-wide apps and admin-managed deployments | The OAuth result can be `is_enterprise_install=true`; apps still need to reason about workspace grants. |
+| Incoming webhook channel selection | Incoming webhook URL tied to one selected channel | One destination channel for webhook posting | Simple notification-style posting | This is the closest Slack-native thing to a channel install, but it is only for the webhook destination. |
+| Channel membership | App/bot joins or is invited to a channel | One Slack conversation at a time | Reading, replying, or participating in a channel | This happens after workspace install. It is not a separate OAuth install. |
+| User authorization | User token under `authed_user` | One installing or authorizing user | Acting on behalf of a user or reading user-accessible data | User scopes are separate from bot scopes. Sign in with Slack scopes must use a separate OAuth flow. |
+| Single-workspace app install | App installed only into its development workspace | One fixed workspace | Internal tools and development | This is a distribution choice, not a different runtime model. |
+| Distributed app install | OAuth install into many customer workspaces | Many workspace installs, one per customer workspace | Marketplace or customer-installed apps | Store each installation separately by workspace or enterprise identity. |
+
+## Workspace OAuth Install
+
+This is the standard Slack app install.
+
+The user approves an OAuth URL. Slack redirects back to the app. The app
+exchanges the OAuth code and receives an access response with workspace
+identity, bot token details, scopes, and optionally user token details.
+
+The workspace identity is normally the Slack `team.id`.
+
+Use this when the app needs to:
+
+- receive workspace events
+- post as the app's bot user
+- respond to mentions or messages
+- expose slash commands or app home
+- serve many workspaces through the same distributed app
+
+A workspace install does not mean the bot can act in every channel. Private
+channels still require invitation. Public channel access depends on scopes,
+membership, and Slack API behavior.
+
+## Enterprise Org-Wide Install
+
+Enterprise Grid supports org-ready apps and organization-level installation.
+
+This is different from installing the app into one workspace inside an
+Enterprise Grid organization.
+
+In an org-wide install, the app receives enterprise identity, and Slack's OAuth
+install data can indicate that this is an enterprise install. The app should
+store and fetch this installation by enterprise identity when appropriate.
+
+An org-wide install may still require the admin to add or grant the app to
+specific workspaces in the organization.
+
+Use this when the app is intended to operate across an Enterprise Grid
+organization or use Enterprise-level capabilities.
+
+## Incoming Webhook Channel Selection
+
+If an app requests the `incoming-webhook` scope, Slack shows a channel picker
+during OAuth.
+
+The OAuth access response includes an `incoming_webhook` object with:
+
+- `channel`
+- `channel_id`
+- `configuration_url`
+- `url`
+
+That webhook URL posts to the selected channel.
+
+This is channel-specific, but it is not a general channel-scoped app install.
+It only grants an incoming webhook destination.
+
+Use this for notification-style apps that only need to post to one selected
+channel.
+
+## Channel Membership Or Channel Configuration
+
+Many products say "install to a channel" when the real behavior is:
+
+1. the app is installed into the workspace
+2. the bot is invited to a channel or joins a public channel
+3. the product stores a channel preference, route, allowlist, or subscription
+
+This is not a separate Slack OAuth install.
+
+It is a product-level configuration on top of a workspace install.
+
+Use this when the app needs to operate only in selected channels.
+
+Good names for this are:
+
+- channel configuration
+- channel binding
+- channel allowlist
+- add app to channel
+- enable app in channel
+
+## User Authorization
+
+Slack OAuth can return user-level authorization under `authed_user` when the app
+requests `user_scope`.
+
+This is not the same thing as installing the app into a channel.
+
+Use user authorization when the app must act on behalf of a specific user or
+read data according to that user's access.
+
+Slack treats Sign in with Slack scopes separately from normal Slack app scopes.
+Do not mix those scopes into the same OAuth flow.
+
+## Recommended Vocabulary
+
+Use Slack-native words when talking about Slack behavior:
+
+- workspace install
+- org-wide install
+- incoming webhook channel selection
+- channel membership
+- channel configuration
+- user authorization
+
+Use product-specific words only after defining them.
+
+For example:
+
+- "Workspace mode" can mean one app install per Slack workspace.
+- "Channel mode" can mean one workspace install plus a selected channel route.
+
+But Slack itself does not treat those as symmetric install modes.
+
+## Spritz Mapping
+
+For Spritz shared Slack apps, the Slack side is a workspace OAuth install.
+
+Spritz then maps the Slack workspace identity to a deployment-owned target and a
+live concierge runtime.
+
+That means Spritz's shared-channel install flow is built on top of Slack
+workspace install, not instead of it.
+
+If Spritz later adds channel-specific settings, those should be modeled as
+installation configuration or channel routing rules, not as a second Slack app
+install.

--- a/integrations/slack-gateway/backend_client.go
+++ b/integrations/slack-gateway/backend_client.go
@@ -153,6 +153,7 @@ type channelSession struct {
 type channelSessionUnavailableError struct {
 	providerAuth       slackInstallation
 	installationConfig installationConfig
+	hasPolicySnapshot  bool
 	cause              *httpStatusError
 }
 
@@ -187,6 +188,9 @@ func channelSessionUnavailableProviderAuth(err error) (slackInstallation, bool) 
 func channelSessionUnavailablePolicySnapshot(err error) (installationPolicySnapshot, bool) {
 	var unavailableErr *channelSessionUnavailableError
 	if !errors.As(err, &unavailableErr) {
+		return installationPolicySnapshot{}, false
+	}
+	if !unavailableErr.hasPolicySnapshot {
 		return installationPolicySnapshot{}, false
 	}
 	return installationPolicySnapshot{
@@ -236,6 +240,7 @@ func (g *slackGateway) exchangeChannelSession(ctx context.Context, teamID string
 				return channelSession{}, &channelSessionUnavailableError{
 					providerAuth:       unavailablePayload.ProviderAuth,
 					installationConfig: unavailablePayload.InstallationConfig,
+					hasPolicySnapshot:  true,
 					cause:              statusErr,
 				}
 			}

--- a/integrations/slack-gateway/backend_client.go
+++ b/integrations/slack-gateway/backend_client.go
@@ -33,18 +33,20 @@ func (err *httpStatusError) Error() string {
 type backendChannelSessionResponse struct {
 	Status  string `json:"status"`
 	Session struct {
-		AccessToken  string            `json:"accessToken"`
-		ExpiresAt    string            `json:"expiresAt"`
-		OwnerAuthID  string            `json:"ownerAuthId"`
-		Namespace    string            `json:"namespace"`
-		InstanceID   string            `json:"instanceId"`
-		ProviderAuth slackInstallation `json:"providerAuth"`
+		AccessToken        string             `json:"accessToken"`
+		ExpiresAt          string             `json:"expiresAt"`
+		OwnerAuthID        string             `json:"ownerAuthId"`
+		Namespace          string             `json:"namespace"`
+		InstanceID         string             `json:"instanceId"`
+		ProviderAuth       slackInstallation  `json:"providerAuth"`
+		InstallationConfig installationConfig `json:"installationConfig"`
 	} `json:"session"`
 }
 
 type backendChannelSessionUnavailableResponse struct {
-	Status       string            `json:"status"`
-	ProviderAuth slackInstallation `json:"providerAuth"`
+	Status             string             `json:"status"`
+	ProviderAuth       slackInstallation  `json:"providerAuth"`
+	InstallationConfig installationConfig `json:"installationConfig"`
 }
 
 type backendInstallationUpsertResponse struct {
@@ -85,12 +87,13 @@ type backendManagedInstallationRoute struct {
 }
 
 type backendManagedInstallation struct {
-	Route          backendManagedInstallationRoute   `json:"route"`
-	State          string                            `json:"state"`
-	CurrentTarget  *backendInstallationTargetSummary `json:"currentTarget,omitempty"`
-	AllowedActions []string                          `json:"allowedActions"`
-	ProblemCode    string                            `json:"problemCode,omitempty"`
-	DisconnectedAt string                            `json:"disconnectedAt,omitempty"`
+	Route              backendManagedInstallationRoute   `json:"route"`
+	State              string                            `json:"state"`
+	CurrentTarget      *backendInstallationTargetSummary `json:"currentTarget,omitempty"`
+	InstallationConfig installationConfig                `json:"installationConfig"`
+	AllowedActions     []string                          `json:"allowedActions"`
+	ProblemCode        string                            `json:"problemCode,omitempty"`
+	DisconnectedAt     string                            `json:"disconnectedAt,omitempty"`
 }
 
 type backendManagedInstallationListResponse struct {
@@ -139,16 +142,18 @@ type spritzBootstrapResponse struct {
 }
 
 type channelSession struct {
-	AccessToken  string
-	OwnerAuthID  string
-	Namespace    string
-	InstanceID   string
-	ProviderAuth slackInstallation
+	AccessToken        string
+	OwnerAuthID        string
+	Namespace          string
+	InstanceID         string
+	ProviderAuth       slackInstallation
+	InstallationConfig installationConfig
 }
 
 type channelSessionUnavailableError struct {
-	providerAuth slackInstallation
-	cause        *httpStatusError
+	providerAuth       slackInstallation
+	installationConfig installationConfig
+	cause              *httpStatusError
 }
 
 func (err *channelSessionUnavailableError) Error() string {
@@ -177,6 +182,17 @@ func channelSessionUnavailableProviderAuth(err error) (slackInstallation, bool) 
 		return slackInstallation{}, false
 	}
 	return unavailableErr.providerAuth, true
+}
+
+func channelSessionUnavailablePolicySnapshot(err error) (installationPolicySnapshot, bool) {
+	var unavailableErr *channelSessionUnavailableError
+	if !errors.As(err, &unavailableErr) {
+		return installationPolicySnapshot{}, false
+	}
+	return installationPolicySnapshot{
+		config:    unavailableErr.installationConfig,
+		botUserID: strings.TrimSpace(unavailableErr.providerAuth.BotUserID),
+	}, true
 }
 
 func isSpritzRuntimeMissingError(err error) bool {
@@ -218,8 +234,9 @@ func (g *slackGateway) exchangeChannelSession(ctx context.Context, teamID string
 			var unavailablePayload backendChannelSessionUnavailableResponse
 			if json.Unmarshal([]byte(statusErr.body), &unavailablePayload) == nil && strings.TrimSpace(unavailablePayload.Status) == "unavailable" {
 				return channelSession{}, &channelSessionUnavailableError{
-					providerAuth: unavailablePayload.ProviderAuth,
-					cause:        statusErr,
+					providerAuth:       unavailablePayload.ProviderAuth,
+					installationConfig: unavailablePayload.InstallationConfig,
+					cause:              statusErr,
 				}
 			}
 			return channelSession{}, &channelSessionUnavailableError{cause: statusErr}
@@ -230,11 +247,12 @@ func (g *slackGateway) exchangeChannelSession(ctx context.Context, teamID string
 		return channelSession{}, fmt.Errorf("channel session was not resolved")
 	}
 	return channelSession{
-		AccessToken:  payload.Session.AccessToken,
-		OwnerAuthID:  payload.Session.OwnerAuthID,
-		Namespace:    payload.Session.Namespace,
-		InstanceID:   payload.Session.InstanceID,
-		ProviderAuth: payload.Session.ProviderAuth,
+		AccessToken:        payload.Session.AccessToken,
+		OwnerAuthID:        payload.Session.OwnerAuthID,
+		Namespace:          payload.Session.Namespace,
+		InstanceID:         payload.Session.InstanceID,
+		ProviderAuth:       payload.Session.ProviderAuth,
+		InstallationConfig: payload.Session.InstallationConfig,
 	}, nil
 }
 
@@ -315,6 +333,26 @@ func (g *slackGateway) updateManagedInstallationTarget(ctx context.Context, call
 	}
 	if payload.Status != "resolved" {
 		return fmt.Errorf("channel installation target was not updated")
+	}
+	return nil
+}
+
+func (g *slackGateway) updateManagedInstallationConfig(ctx context.Context, callerAuthID, teamID, requestID string, installationConfig installationConfig) error {
+	body := map[string]any{
+		"callerAuthId":       strings.TrimSpace(callerAuthID),
+		"principalId":        g.cfg.PrincipalID,
+		"provider":           slackProvider,
+		"externalScopeType":  slackWorkspaceScope,
+		"externalTenantId":   strings.TrimSpace(teamID),
+		"installationConfig": installationConfig,
+		"requestId":          strings.TrimSpace(requestID),
+	}
+	var payload backendManagedInstallationUpdateResponse
+	if err := g.postBackendFastAPIJSON(ctx, "/internal/v2/spritz/channel-installations/config/update", body, &payload); err != nil {
+		return err
+	}
+	if payload.Status != "resolved" {
+		return fmt.Errorf("channel installation config was not updated")
 	}
 	return nil
 }

--- a/integrations/slack-gateway/backend_client_test.go
+++ b/integrations/slack-gateway/backend_client_test.go
@@ -222,6 +222,37 @@ func TestUpdateManagedInstallationConfigPostsExpectedPayload(t *testing.T) {
 	}
 }
 
+func TestChannelSessionUnavailablePolicySnapshotRequiresStructuredPayload(t *testing.T) {
+	snapshot, ok := channelSessionUnavailablePolicySnapshot(&channelSessionUnavailableError{
+		cause: &httpStatusError{
+			method:     http.MethodPost,
+			endpoint:   "/internal/v1/spritz/channel-sessions/exchange",
+			statusCode: http.StatusServiceUnavailable,
+			body:       "temporarily unavailable",
+		},
+	})
+	if ok {
+		t.Fatalf("expected unstructured 503 to have no policy snapshot, got %#v", snapshot)
+	}
+
+	requireMention := false
+	snapshot, ok = channelSessionUnavailablePolicySnapshot(&channelSessionUnavailableError{
+		providerAuth: slackInstallation{BotUserID: "U_bot"},
+		installationConfig: installationConfig{
+			ChannelPolicies: []installationChannelPolicy{
+				{ExternalChannelID: "C_channel_1", RequireMention: &requireMention},
+			},
+		},
+		hasPolicySnapshot: true,
+	})
+	if !ok {
+		t.Fatalf("expected structured unavailable response to have a policy snapshot")
+	}
+	if snapshot.botUserID != "U_bot" || len(snapshot.config.ChannelPolicies) != 1 {
+		t.Fatalf("unexpected policy snapshot: %#v", snapshot)
+	}
+}
+
 func TestDisconnectManagedInstallationPostsExpectedPayload(t *testing.T) {
 	var disconnectPayload map[string]any
 	fastapi := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/integrations/slack-gateway/backend_client_test.go
+++ b/integrations/slack-gateway/backend_client_test.go
@@ -165,6 +165,63 @@ func TestUpdateManagedInstallationTargetPostsExpectedPayload(t *testing.T) {
 	}
 }
 
+func TestUpdateManagedInstallationConfigPostsExpectedPayload(t *testing.T) {
+	var updatePayload map[string]any
+	fastapi := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/internal/v2/spritz/channel-installations/config/update" {
+			t.Fatalf("unexpected fastapi path %s", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&updatePayload); err != nil {
+			t.Fatalf("decode update payload: %v", err)
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"status":            "resolved",
+			"needsProvisioning": true,
+		})
+	}))
+	defer fastapi.Close()
+
+	gateway := newSlackGateway(config{
+		BackendFastAPIBaseURL: fastapi.URL,
+		BackendInternalToken:  "backend-internal-token",
+		PrincipalID:           "shared-slack-gateway",
+		HTTPTimeout:           5 * time.Second,
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	requireMention := false
+	if err := gateway.updateManagedInstallationConfig(
+		context.Background(),
+		"user-1",
+		"T_workspace_1",
+		"req-manage-config-1",
+		installationConfig{
+			ChannelPolicies: []installationChannelPolicy{
+				{ExternalChannelID: "C_channel_1", RequireMention: &requireMention},
+			},
+		},
+	); err != nil {
+		t.Fatalf("update managed installation config: %v", err)
+	}
+	if updatePayload["callerAuthId"] != "user-1" {
+		t.Fatalf("expected caller auth id to be forwarded, got %#v", updatePayload["callerAuthId"])
+	}
+	if updatePayload["externalTenantId"] != "T_workspace_1" {
+		t.Fatalf("expected team id to be forwarded, got %#v", updatePayload["externalTenantId"])
+	}
+	configPayload, ok := updatePayload["installationConfig"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected installationConfig payload, got %#v", updatePayload["installationConfig"])
+	}
+	policies, ok := configPayload["channelPolicies"].([]any)
+	if !ok || len(policies) != 1 {
+		t.Fatalf("expected one channel policy, got %#v", configPayload["channelPolicies"])
+	}
+	policy, ok := policies[0].(map[string]any)
+	if !ok || policy["externalChannelId"] != "C_channel_1" || policy["requireMention"] != false {
+		t.Fatalf("unexpected channel policy: %#v", policies[0])
+	}
+}
+
 func TestDisconnectManagedInstallationPostsExpectedPayload(t *testing.T) {
 	var disconnectPayload map[string]any
 	fastapi := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/integrations/slack-gateway/config.go
+++ b/integrations/slack-gateway/config.go
@@ -9,62 +9,64 @@ import (
 )
 
 type config struct {
-	Addr                   string
-	PublicURL              string
-	BrowserAuthHeaderID    string
-	BrowserAuthHeaderEmail string
-	SlackClientID          string
-	SlackClientSecret      string
-	SlackSigningSecret     string
-	OAuthStateSecret       string
-	SlackAPIBaseURL        string
-	SlackBotScopes         []string
-	PresetID               string
-	BackendBaseURL         string
-	BackendFastAPIBaseURL  string
-	BackendInternalToken   string
-	SpritzBaseURL          string
-	SpritzServiceToken     string
-	PrincipalID            string
-	HTTPTimeout            time.Duration
-	DedupeTTL              time.Duration
-	ProcessingTimeout      time.Duration
-	SessionRetryInterval   time.Duration
-	StatusMessageDelay     time.Duration
-	RecoveryTimeout        time.Duration
-	PromptRetryInitial     time.Duration
-	PromptRetryMax         time.Duration
-	PromptRetryTimeout     time.Duration
+	Addr                       string
+	PublicURL                  string
+	BrowserAuthHeaderID        string
+	BrowserAuthHeaderEmail     string
+	SlackClientID              string
+	SlackClientSecret          string
+	SlackSigningSecret         string
+	OAuthStateSecret           string
+	SlackAPIBaseURL            string
+	SlackBotScopes             []string
+	PresetID                   string
+	BackendBaseURL             string
+	BackendFastAPIBaseURL      string
+	BackendInternalToken       string
+	SpritzBaseURL              string
+	SpritzServiceToken         string
+	PrincipalID                string
+	HTTPTimeout                time.Duration
+	DedupeTTL                  time.Duration
+	ProcessingTimeout          time.Duration
+	SessionRetryInterval       time.Duration
+	StatusMessageDelay         time.Duration
+	RecoveryTimeout            time.Duration
+	PromptRetryInitial         time.Duration
+	PromptRetryMax             time.Duration
+	PromptRetryTimeout         time.Duration
+	InstallationPolicyCacheTTL time.Duration
 }
 
 func loadConfig() (config, error) {
 	cfg := config{
-		Addr:                   envOrDefault("SPRITZ_SLACK_GATEWAY_ADDR", ":8080"),
-		PublicURL:              strings.TrimRight(strings.TrimSpace(os.Getenv("SPRITZ_SLACK_GATEWAY_PUBLIC_URL")), "/"),
-		BrowserAuthHeaderID:    envOrDefault("SPRITZ_AUTH_HEADER_ID", "X-Spritz-User-Id"),
-		BrowserAuthHeaderEmail: envOrDefault("SPRITZ_AUTH_HEADER_EMAIL", "X-Spritz-User-Email"),
-		SlackClientID:          strings.TrimSpace(os.Getenv("SPRITZ_SLACK_CLIENT_ID")),
-		SlackClientSecret:      strings.TrimSpace(os.Getenv("SPRITZ_SLACK_CLIENT_SECRET")),
-		SlackSigningSecret:     strings.TrimSpace(os.Getenv("SPRITZ_SLACK_SIGNING_SECRET")),
-		OAuthStateSecret:       strings.TrimSpace(os.Getenv("SPRITZ_SLACK_OAUTH_STATE_SECRET")),
-		SlackAPIBaseURL:        strings.TrimRight(envOrDefault("SPRITZ_SLACK_API_BASE_URL", "https://slack.com/api"), "/"),
-		SlackBotScopes:         splitCSV(envOrDefault("SPRITZ_SLACK_BOT_SCOPES", "app_mentions:read,channels:history,chat:write,im:history,mpim:history")),
-		PresetID:               strings.TrimSpace(envOrDefault("SPRITZ_SLACK_PRESET_ID", defaultSlackPresetID)),
-		BackendBaseURL:         strings.TrimRight(strings.TrimSpace(os.Getenv("SPRITZ_SLACK_BACKEND_BASE_URL")), "/"),
-		BackendFastAPIBaseURL:  strings.TrimRight(strings.TrimSpace(os.Getenv("SPRITZ_SLACK_BACKEND_FASTAPI_BASE_URL")), "/"),
-		BackendInternalToken:   strings.TrimSpace(os.Getenv("SPRITZ_SLACK_BACKEND_INTERNAL_TOKEN")),
-		SpritzBaseURL:          strings.TrimRight(strings.TrimSpace(os.Getenv("SPRITZ_SLACK_SPRITZ_BASE_URL")), "/"),
-		SpritzServiceToken:     strings.TrimSpace(os.Getenv("SPRITZ_SLACK_SPRITZ_SERVICE_TOKEN")),
-		PrincipalID:            strings.TrimSpace(os.Getenv("SPRITZ_SLACK_PRINCIPAL_ID")),
-		HTTPTimeout:            parseDurationEnv("SPRITZ_SLACK_HTTP_TIMEOUT", 15*time.Second),
-		DedupeTTL:              parseDurationEnv("SPRITZ_SLACK_DEDUPE_TTL", 10*time.Minute),
-		ProcessingTimeout:      parseDurationEnv("SPRITZ_SLACK_PROCESSING_TIMEOUT", 120*time.Second),
-		SessionRetryInterval:   parseDurationEnv("SPRITZ_SLACK_SESSION_RETRY_INTERVAL", time.Second),
-		StatusMessageDelay:     parseDurationEnv("SPRITZ_SLACK_STATUS_MESSAGE_DELAY", 5*time.Second),
-		RecoveryTimeout:        parseDurationEnv("SPRITZ_SLACK_RECOVERY_TIMEOUT", 120*time.Second),
-		PromptRetryInitial:     parseDurationEnv("SPRITZ_SLACK_PROMPT_RETRY_INITIAL", 250*time.Millisecond),
-		PromptRetryMax:         parseDurationEnv("SPRITZ_SLACK_PROMPT_RETRY_MAX", 2*time.Second),
-		PromptRetryTimeout:     parseDurationEnv("SPRITZ_SLACK_PROMPT_RETRY_TIMEOUT", 8*time.Second),
+		Addr:                       envOrDefault("SPRITZ_SLACK_GATEWAY_ADDR", ":8080"),
+		PublicURL:                  strings.TrimRight(strings.TrimSpace(os.Getenv("SPRITZ_SLACK_GATEWAY_PUBLIC_URL")), "/"),
+		BrowserAuthHeaderID:        envOrDefault("SPRITZ_AUTH_HEADER_ID", "X-Spritz-User-Id"),
+		BrowserAuthHeaderEmail:     envOrDefault("SPRITZ_AUTH_HEADER_EMAIL", "X-Spritz-User-Email"),
+		SlackClientID:              strings.TrimSpace(os.Getenv("SPRITZ_SLACK_CLIENT_ID")),
+		SlackClientSecret:          strings.TrimSpace(os.Getenv("SPRITZ_SLACK_CLIENT_SECRET")),
+		SlackSigningSecret:         strings.TrimSpace(os.Getenv("SPRITZ_SLACK_SIGNING_SECRET")),
+		OAuthStateSecret:           strings.TrimSpace(os.Getenv("SPRITZ_SLACK_OAUTH_STATE_SECRET")),
+		SlackAPIBaseURL:            strings.TrimRight(envOrDefault("SPRITZ_SLACK_API_BASE_URL", "https://slack.com/api"), "/"),
+		SlackBotScopes:             splitCSV(envOrDefault("SPRITZ_SLACK_BOT_SCOPES", "app_mentions:read,channels:history,chat:write,im:history,mpim:history")),
+		PresetID:                   strings.TrimSpace(envOrDefault("SPRITZ_SLACK_PRESET_ID", defaultSlackPresetID)),
+		BackendBaseURL:             strings.TrimRight(strings.TrimSpace(os.Getenv("SPRITZ_SLACK_BACKEND_BASE_URL")), "/"),
+		BackendFastAPIBaseURL:      strings.TrimRight(strings.TrimSpace(os.Getenv("SPRITZ_SLACK_BACKEND_FASTAPI_BASE_URL")), "/"),
+		BackendInternalToken:       strings.TrimSpace(os.Getenv("SPRITZ_SLACK_BACKEND_INTERNAL_TOKEN")),
+		SpritzBaseURL:              strings.TrimRight(strings.TrimSpace(os.Getenv("SPRITZ_SLACK_SPRITZ_BASE_URL")), "/"),
+		SpritzServiceToken:         strings.TrimSpace(os.Getenv("SPRITZ_SLACK_SPRITZ_SERVICE_TOKEN")),
+		PrincipalID:                strings.TrimSpace(os.Getenv("SPRITZ_SLACK_PRINCIPAL_ID")),
+		HTTPTimeout:                parseDurationEnv("SPRITZ_SLACK_HTTP_TIMEOUT", 15*time.Second),
+		DedupeTTL:                  parseDurationEnv("SPRITZ_SLACK_DEDUPE_TTL", 10*time.Minute),
+		ProcessingTimeout:          parseDurationEnv("SPRITZ_SLACK_PROCESSING_TIMEOUT", 120*time.Second),
+		SessionRetryInterval:       parseDurationEnv("SPRITZ_SLACK_SESSION_RETRY_INTERVAL", time.Second),
+		StatusMessageDelay:         parseDurationEnv("SPRITZ_SLACK_STATUS_MESSAGE_DELAY", 5*time.Second),
+		RecoveryTimeout:            parseDurationEnv("SPRITZ_SLACK_RECOVERY_TIMEOUT", 120*time.Second),
+		PromptRetryInitial:         parseDurationEnv("SPRITZ_SLACK_PROMPT_RETRY_INITIAL", 250*time.Millisecond),
+		PromptRetryMax:             parseDurationEnv("SPRITZ_SLACK_PROMPT_RETRY_MAX", 2*time.Second),
+		PromptRetryTimeout:         parseDurationEnv("SPRITZ_SLACK_PROMPT_RETRY_TIMEOUT", 8*time.Second),
+		InstallationPolicyCacheTTL: parseDurationEnv("SPRITZ_SLACK_INSTALLATION_POLICY_CACHE_TTL", 10*time.Second),
 	}
 
 	if cfg.PublicURL == "" {

--- a/integrations/slack-gateway/gateway.go
+++ b/integrations/slack-gateway/gateway.go
@@ -23,6 +23,7 @@ type slackGateway struct {
 	httpClient *http.Client
 	state      *oauthStateManager
 	dedupe     *dedupeStore
+	policies   *installationPolicyCache
 	logger     *slog.Logger
 	workers    sync.WaitGroup
 }
@@ -66,11 +67,15 @@ func newSlackGateway(cfg config, logger *slog.Logger) *slackGateway {
 	if cfg.PromptRetryTimeout <= 0 {
 		cfg.PromptRetryTimeout = 8 * time.Second
 	}
+	if cfg.InstallationPolicyCacheTTL <= 0 {
+		cfg.InstallationPolicyCacheTTL = 10 * time.Second
+	}
 	return &slackGateway{
 		cfg:        cfg,
 		httpClient: &http.Client{},
 		state:      newOAuthStateManager(cfg.OAuthStateSecret, 15*time.Minute),
 		dedupe:     newDedupeStore(cfg.DedupeTTL),
+		policies:   newInstallationPolicyCache(cfg.InstallationPolicyCacheTTL),
 		logger:     logger,
 	}
 }

--- a/integrations/slack-gateway/gateway_test.go
+++ b/integrations/slack-gateway/gateway_test.go
@@ -1632,7 +1632,22 @@ func TestSlackEventIgnoresTopLevelChannelMessagesWithoutMention(t *testing.T) {
 	var backendCalls int
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		backendCalls++
-		t.Fatalf("unexpected backend path %s", r.URL.Path)
+		if r.URL.Path != "/internal/v1/spritz/channel-sessions/exchange" {
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"status": "resolved",
+			"session": map[string]any{
+				"accessToken":  "owner-token",
+				"ownerAuthId":  "owner-123",
+				"namespace":    "spritz-staging",
+				"instanceId":   "zeno-acme",
+				"providerAuth": map[string]any{"botUserId": "U_bot"},
+				"installationConfig": map[string]any{
+					"channelPolicies": []map[string]any{},
+				},
+			},
+		})
 	}))
 	defer backend.Close()
 
@@ -1672,8 +1687,8 @@ func TestSlackEventIgnoresTopLevelChannelMessagesWithoutMention(t *testing.T) {
 	if err := gateway.waitForWorkers(drainCtx); err != nil {
 		t.Fatalf("worker drain failed: %v", err)
 	}
-	if backendCalls != 0 {
-		t.Fatalf("expected plain channel chatter to be ignored, got %d backend calls", backendCalls)
+	if backendCalls != 1 {
+		t.Fatalf("expected one backend policy lookup, got %d backend calls", backendCalls)
 	}
 }
 
@@ -2458,8 +2473,8 @@ func TestShouldIgnoreSlackMessageEventRejectsSystemSubtypes(t *testing.T) {
 	}
 }
 
-func TestShouldProcessSlackMessageEventRequiresMentionOutsideDMs(t *testing.T) {
-	if shouldProcessSlackMessageEvent(
+func TestShouldProcessSlackMessageEventQueuesChannelMessagesForPolicyCheck(t *testing.T) {
+	if !shouldProcessSlackMessageEvent(
 		slackEventInner{
 			Type:        "message",
 			Channel:     "C_1",
@@ -2467,7 +2482,7 @@ func TestShouldProcessSlackMessageEventRequiresMentionOutsideDMs(t *testing.T) {
 			TS:          "1711387375.000100",
 		},
 	) {
-		t.Fatalf("expected top-level channel messages to be ignored")
+		t.Fatalf("expected top-level channel messages to be queued for policy check")
 	}
 	if !shouldProcessSlackMessageEvent(
 		slackEventInner{
@@ -2479,7 +2494,7 @@ func TestShouldProcessSlackMessageEventRequiresMentionOutsideDMs(t *testing.T) {
 	) {
 		t.Fatalf("expected channel app_mention events to be processed")
 	}
-	if shouldProcessSlackMessageEvent(
+	if !shouldProcessSlackMessageEvent(
 		slackEventInner{
 			Type:        "message",
 			Channel:     "C_1",
@@ -2488,7 +2503,7 @@ func TestShouldProcessSlackMessageEventRequiresMentionOutsideDMs(t *testing.T) {
 			TS:          "1711387376.000100",
 		},
 	) {
-		t.Fatalf("expected unmentioned channel thread replies to be ignored")
+		t.Fatalf("expected channel thread replies to be queued for policy check")
 	}
 	if !shouldProcessSlackMessageEvent(
 		slackEventInner{
@@ -2499,6 +2514,37 @@ func TestShouldProcessSlackMessageEventRequiresMentionOutsideDMs(t *testing.T) {
 		},
 	) {
 		t.Fatalf("expected DM messages to be processed")
+	}
+}
+
+func TestShouldRelaySlackMessageEventUsesInstallationPolicy(t *testing.T) {
+	requireMention := true
+	withoutMention := false
+	config := installationConfig{
+		ChannelPolicies: []installationChannelPolicy{
+			{ExternalChannelID: "C_requires", RequireMention: &requireMention},
+			{ExternalChannelID: "C_open", RequireMention: &withoutMention},
+		},
+	}
+	snapshot := installationPolicySnapshot{config: config, botUserID: "U_bot"}
+
+	if shouldRelaySlackMessageEvent(
+		slackEventInner{Type: "message", Channel: "C_requires", Text: "hello"},
+		snapshot,
+	) {
+		t.Fatalf("expected configured requireMention channel to require the bot mention")
+	}
+	if !shouldRelaySlackMessageEvent(
+		slackEventInner{Type: "message", Channel: "C_open", Text: "hello"},
+		snapshot,
+	) {
+		t.Fatalf("expected requireMention=false channel to relay without mention")
+	}
+	if !shouldRelaySlackMessageEvent(
+		slackEventInner{Type: "message", Channel: "C_requires", Text: "<@U_bot> hello"},
+		snapshot,
+	) {
+		t.Fatalf("expected explicit bot mention to relay even when requireMention is true")
 	}
 }
 

--- a/integrations/slack-gateway/installation_policy.go
+++ b/integrations/slack-gateway/installation_policy.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"strings"
+	"sync"
+	"time"
+)
+
+type installationConfig struct {
+	ChannelPolicies []installationChannelPolicy `json:"channelPolicies,omitempty"`
+}
+
+type installationChannelPolicy struct {
+	ExternalChannelID   string `json:"externalChannelId"`
+	ExternalChannelType string `json:"externalChannelType,omitempty"`
+	RequireMention      *bool  `json:"requireMention"`
+}
+
+type installationPolicySnapshot struct {
+	config    installationConfig
+	botUserID string
+}
+
+type installationPolicyCacheEntry struct {
+	snapshot  installationPolicySnapshot
+	expiresAt time.Time
+}
+
+type installationPolicyCache struct {
+	mu      sync.Mutex
+	ttl     time.Duration
+	now     func() time.Time
+	entries map[string]installationPolicyCacheEntry
+}
+
+func newInstallationPolicyCache(ttl time.Duration) *installationPolicyCache {
+	if ttl <= 0 {
+		ttl = 10 * time.Second
+	}
+	return &installationPolicyCache{
+		ttl:     ttl,
+		now:     time.Now,
+		entries: map[string]installationPolicyCacheEntry{},
+	}
+}
+
+func (cache *installationPolicyCache) remember(teamID string, snapshot installationPolicySnapshot) {
+	if cache == nil {
+		return
+	}
+	teamID = strings.TrimSpace(teamID)
+	if teamID == "" {
+		return
+	}
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	cache.entries[teamID] = installationPolicyCacheEntry{
+		snapshot:  snapshot,
+		expiresAt: cache.now().Add(cache.ttl),
+	}
+}
+
+func (cache *installationPolicyCache) lookup(teamID string) (installationPolicySnapshot, bool) {
+	if cache == nil {
+		return installationPolicySnapshot{}, false
+	}
+	teamID = strings.TrimSpace(teamID)
+	if teamID == "" {
+		return installationPolicySnapshot{}, false
+	}
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	entry, ok := cache.entries[teamID]
+	if !ok {
+		return installationPolicySnapshot{}, false
+	}
+	if !entry.expiresAt.After(cache.now()) {
+		delete(cache.entries, teamID)
+		return installationPolicySnapshot{}, false
+	}
+	return entry.snapshot, true
+}
+
+func (session channelSession) policySnapshot() installationPolicySnapshot {
+	return installationPolicySnapshot{
+		config:    session.InstallationConfig,
+		botUserID: strings.TrimSpace(session.ProviderAuth.BotUserID),
+	}
+}
+
+func shouldRelaySlackMessageEvent(event slackEventInner, snapshot installationPolicySnapshot) bool {
+	eventType := strings.TrimSpace(event.Type)
+	if isSlackDirectMessageEvent(event) {
+		return eventType == "message"
+	}
+	if eventType == "app_mention" {
+		return true
+	}
+	if eventType != "message" {
+		return false
+	}
+	if slackTextMentionsBot(event.Text, snapshot.botUserID) {
+		return true
+	}
+	return installationConfigAllowsChannelWithoutMention(
+		snapshot.config,
+		strings.TrimSpace(event.Channel),
+	)
+}
+
+func slackTextMentionsBot(text, botUserID string) bool {
+	botUserID = strings.TrimSpace(botUserID)
+	if botUserID == "" {
+		return false
+	}
+	return strings.Contains(strings.TrimSpace(text), "<@"+botUserID+">")
+}
+
+func installationConfigAllowsChannelWithoutMention(config installationConfig, channelID string) bool {
+	channelID = strings.TrimSpace(channelID)
+	if channelID == "" {
+		return false
+	}
+	for _, policy := range config.ChannelPolicies {
+		if strings.TrimSpace(policy.ExternalChannelID) != channelID {
+			continue
+		}
+		return policy.RequireMention != nil && !*policy.RequireMention
+	}
+	return false
+}

--- a/integrations/slack-gateway/slack_events.go
+++ b/integrations/slack-gateway/slack_events.go
@@ -574,7 +574,11 @@ func (g *slackGateway) processMessageEventWithDeliveryOptions(
 	}
 
 	recoveryState := newChannelSessionRecoveryState()
-	session, terminalHandled, err := g.awaitChannelSession(
+	if snapshot, ok := g.policies.lookup(envelope.TeamID); ok && !shouldRelaySlackMessageEvent(event, snapshot) {
+		success = true
+		return messageEventProcessResult{Outcome: messageEventOutcomeIgnored}, nil
+	}
+	session, ignoredByPolicy, terminalHandled, err := g.awaitChannelSession(
 		ctx,
 		envelope,
 		event,
@@ -583,6 +587,10 @@ func (g *slackGateway) processMessageEventWithDeliveryOptions(
 	)
 	if err != nil {
 		return messageEventProcessResult{}, err
+	}
+	if ignoredByPolicy {
+		success = true
+		return messageEventProcessResult{Outcome: messageEventOutcomeIgnored}, nil
 	}
 	if terminalHandled {
 		success = true
@@ -652,7 +660,7 @@ func (g *slackGateway) processMessageEventWithDeliveryOptions(
 			}
 		} else {
 			recoveryState.resetPromptRetry()
-			recoveredSession, recoveredTerminalHandled, recoveryErr := g.awaitChannelSession(
+			recoveredSession, recoveredIgnoredByPolicy, recoveredTerminalHandled, recoveryErr := g.awaitChannelSession(
 				ctx,
 				envelope,
 				event,
@@ -661,6 +669,10 @@ func (g *slackGateway) processMessageEventWithDeliveryOptions(
 			)
 			if recoveryErr != nil {
 				return messageEventProcessResult{}, recoveryErr
+			}
+			if recoveredIgnoredByPolicy {
+				success = true
+				return messageEventProcessResult{Outcome: messageEventOutcomeIgnored}, nil
 			}
 			if recoveredTerminalHandled {
 				success = true
@@ -807,7 +819,7 @@ func (g *slackGateway) awaitChannelSession(
 	event slackEventInner,
 	recoveryState *channelSessionRecoveryState,
 	forceRefresh bool,
-) (channelSession, bool, error) {
+) (channelSession, bool, bool, error) {
 	if recoveryState == nil {
 		recoveryState = newChannelSessionRecoveryState()
 	}
@@ -831,11 +843,11 @@ func (g *slackGateway) awaitChannelSession(
 					"channel_id", strings.TrimSpace(event.Channel),
 					"message_ts", strings.TrimSpace(event.TS),
 				)
-				return channelSession{}, false, postErr
+				return channelSession{}, false, false, postErr
 			} else if terminalHandled {
-				return channelSession{}, true, nil
+				return channelSession{}, false, true, nil
 			}
-			return channelSession{}, false, context.DeadlineExceeded
+			return channelSession{}, false, false, context.DeadlineExceeded
 		}
 
 		exchangeCtx := ctx
@@ -852,7 +864,17 @@ func (g *slackGateway) awaitChannelSession(
 		cancelExchange()
 		if err == nil {
 			recoveryState.rememberProviderAuth(session.ProviderAuth)
-			return session, false, nil
+			g.policies.remember(envelope.TeamID, session.policySnapshot())
+			if !shouldRelaySlackMessageEvent(event, session.policySnapshot()) {
+				return channelSession{}, true, false, nil
+			}
+			return session, false, false, nil
+		}
+		if snapshot, ok := channelSessionUnavailablePolicySnapshot(err); ok {
+			g.policies.remember(envelope.TeamID, snapshot)
+			if !shouldRelaySlackMessageEvent(event, snapshot) {
+				return channelSession{}, true, false, nil
+			}
 		}
 
 		providerAuth, recoverable := channelSessionUnavailableProviderAuth(err)
@@ -874,11 +896,11 @@ func (g *slackGateway) awaitChannelSession(
 						"channel_id", strings.TrimSpace(event.Channel),
 						"message_ts", strings.TrimSpace(event.TS),
 					)
-					return channelSession{}, false, postErr
+					return channelSession{}, false, false, postErr
 				} else if terminalHandled {
-					return channelSession{}, true, nil
+					return channelSession{}, false, true, nil
 				}
-				return channelSession{}, false, err
+				return channelSession{}, false, false, err
 			}
 		} else {
 			recoveryState.rememberProviderAuth(providerAuth)
@@ -912,11 +934,11 @@ func (g *slackGateway) awaitChannelSession(
 					"channel_id", strings.TrimSpace(event.Channel),
 					"message_ts", strings.TrimSpace(event.TS),
 				)
-				return channelSession{}, false, postErr
+				return channelSession{}, false, false, postErr
 			} else if terminalHandled {
-				return channelSession{}, true, nil
+				return channelSession{}, false, true, nil
 			}
-			return channelSession{}, false, err
+			return channelSession{}, false, false, err
 		}
 	}
 }
@@ -931,7 +953,7 @@ func shouldProcessSlackMessageEvent(event slackEventInner) bool {
 	if isSlackDirectMessageEvent(event) {
 		return eventType == "message"
 	}
-	return eventType == "app_mention"
+	return eventType == "app_mention" || eventType == "message"
 }
 
 func isSlackDirectMessageEvent(event slackEventInner) bool {
@@ -944,18 +966,16 @@ func isSlackDirectMessageEvent(event slackEventInner) bool {
 
 func normalizeSlackPromptText(eventType, text, botUserID string) string {
 	normalized := strings.TrimSpace(text)
-	if strings.TrimSpace(eventType) == "app_mention" {
-		botUserID = strings.TrimSpace(botUserID)
-		if botUserID != "" {
-			mentionToken := "<@" + botUserID + ">"
-			if index := strings.Index(normalized, mentionToken); index >= 0 {
-				normalized = strings.TrimSpace(
-					normalized[:index] + normalized[index+len(mentionToken):],
-				)
-			}
-		} else {
-			normalized = slackMentionTokenPattern.ReplaceAllString(normalized, " ")
+	botUserID = strings.TrimSpace(botUserID)
+	if botUserID != "" {
+		mentionToken := "<@" + botUserID + ">"
+		if index := strings.Index(normalized, mentionToken); index >= 0 {
+			normalized = strings.TrimSpace(
+				normalized[:index] + normalized[index+len(mentionToken):],
+			)
 		}
+	} else if strings.TrimSpace(eventType) == "app_mention" {
+		normalized = slackMentionTokenPattern.ReplaceAllString(normalized, " ")
 	}
 	return strings.TrimSpace(normalized)
 }


### PR DESCRIPTION
## Summary

Workspace-installed Slack apps still needed a bot mention in every channel message.
This change lets selected channels opt out with `requireMention:false`, while every other channel keeps the normal mention-required behavior.
It stores the setting in platform, passes it into Spritz bindings and Slack sessions, and teaches the Slack gateway to relay untagged messages only for configured channels.

## What Changed

The channel policy now lives as provider-agnostic installation config.
Spritz projects that config into OpenClaw at binding boot time, and the Slack gateway uses the same config when deciding whether to process a message event.

- Added `installationConfig.channelPolicies[]` support to internal binding requests.
- Projected channel policies into `OPENCLAW_CONFIG_JSON` under provider, scope, tenant, and channel.
- Added Slack gateway policy parsing, short-lived policy caching, and message-event routing for configured channels.
- Added a typed gateway client helper for the platform config-update endpoint.
- Kept DM and `app_mention` behavior unchanged.

## Testing

I tested the Spritz API projection path and the Slack gateway event policy path locally.
Staging Slack verification still needs the platform PR deployed with the DB column before the live channel can be configured.

- `go test ./...` from `api` passed.
- `go test ./...` from `integrations/slack-gateway` passed.

## Risks

The default remains conservative.
Messages without a mention are ignored unless the backend session config explicitly allows that channel.

- A stale gateway policy cache can delay config changes by up to `SPRITZ_SLACK_INSTALLATION_POLICY_CACHE_TTL`, default 10 seconds.
- Invalid installation config is rejected before it reaches runtime projection.