### PR TITLE
docs: add channel installation data model

### DIFF
--- a/api/channel_installation_config.go
+++ b/api/channel_installation_config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,7 +14,11 @@ import (
 	spritzv1 "spritz.sh/operator/api/v1"
 )
 
-const openclawConfigEnvName = "OPENCLAW_CONFIG_JSON"
+const (
+	openclawConfigEnvName     = "OPENCLAW_CONFIG_JSON"
+	openclawConfigB64EnvName  = "OPENCLAW_CONFIG_B64"
+	openclawConfigFileEnvName = "OPENCLAW_CONFIG_FILE"
+)
 
 type channelInstallationConfigPayload struct {
 	ChannelPolicies []channelInstallationChannelPolicy `json:"channelPolicies,omitempty"`
@@ -103,19 +108,50 @@ func normalizeChannelInstallationPolicies(policies []channelInstallationChannelP
 }
 
 func readOpenClawConfigEnv(env []corev1.EnvVar) (map[string]any, error) {
+	var b64Env *corev1.EnvVar
+	var fileEnv *corev1.EnvVar
 	for _, item := range env {
-		if item.Name != openclawConfigEnvName {
-			continue
+		switch item.Name {
+		case openclawConfigEnvName:
+			if item.ValueFrom != nil {
+				return nil, errors.New("OPENCLAW_CONFIG_JSON cannot use valueFrom with installationConfig")
+			}
+			return parseOpenClawConfigJSON(item.Value, openclawConfigEnvName)
+		case openclawConfigB64EnvName:
+			copied := item
+			b64Env = &copied
+		case openclawConfigFileEnvName:
+			copied := item
+			fileEnv = &copied
 		}
-		if item.ValueFrom != nil {
-			return nil, errors.New("OPENCLAW_CONFIG_JSON cannot use valueFrom with installationConfig")
-		}
-		return parseOpenClawConfigJSON(item.Value)
 	}
-	return map[string]any{}, nil
+	if b64Env != nil {
+		if b64Env.ValueFrom != nil {
+			return nil, errors.New("OPENCLAW_CONFIG_B64 cannot use valueFrom with installationConfig")
+		}
+		decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(b64Env.Value))
+		if err != nil {
+			return nil, errors.New("OPENCLAW_CONFIG_B64 is invalid")
+		}
+		return parseOpenClawConfigJSON(string(decoded), openclawConfigB64EnvName)
+	}
+	if fileEnv != nil {
+		return nil, errors.New("OPENCLAW_CONFIG_FILE cannot be merged with installationConfig")
+	}
+	return defaultOpenClawConfig(), nil
 }
 
-func parseOpenClawConfigJSON(value string) (map[string]any, error) {
+func defaultOpenClawConfig() map[string]any {
+	return map[string]any{
+		"browser": map[string]any{
+			"enabled":        true,
+			"headless":       true,
+			"executablePath": "/usr/bin/chromium",
+		},
+	}
+}
+
+func parseOpenClawConfigJSON(value string, source string) (map[string]any, error) {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {
 		return map[string]any{}, nil
@@ -124,11 +160,11 @@ func parseOpenClawConfigJSON(value string) (map[string]any, error) {
 	decoder := json.NewDecoder(strings.NewReader(trimmed))
 	decoder.UseNumber()
 	if err := decoder.Decode(&payload); err != nil {
-		return nil, errors.New("OPENCLAW_CONFIG_JSON is invalid")
+		return nil, fmt.Errorf("%s is invalid", source)
 	}
 	var trailing any
 	if err := decoder.Decode(&trailing); err != io.EOF {
-		return nil, errors.New("OPENCLAW_CONFIG_JSON is invalid")
+		return nil, fmt.Errorf("%s is invalid", source)
 	}
 	if payload == nil {
 		payload = map[string]any{}
@@ -146,12 +182,23 @@ func ensureObjectField(parent map[string]any, key string) map[string]any {
 }
 
 func setOpenClawConfigEnv(env *[]corev1.EnvVar, value string) {
+	filtered := (*env)[:0]
+	jsonIndex := -1
 	for index := range *env {
-		if (*env)[index].Name == openclawConfigEnvName {
+		switch (*env)[index].Name {
+		case openclawConfigEnvName:
 			(*env)[index].Value = value
 			(*env)[index].ValueFrom = nil
-			return
+			jsonIndex = len(filtered)
+			filtered = append(filtered, (*env)[index])
+		case openclawConfigB64EnvName, openclawConfigFileEnvName:
+			continue
+		default:
+			filtered = append(filtered, (*env)[index])
 		}
 	}
-	*env = append(*env, corev1.EnvVar{Name: openclawConfigEnvName, Value: value})
+	if jsonIndex < 0 {
+		filtered = append(filtered, corev1.EnvVar{Name: openclawConfigEnvName, Value: value})
+	}
+	*env = filtered
 }

--- a/api/channel_installation_config.go
+++ b/api/channel_installation_config.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+
+	spritzv1 "spritz.sh/operator/api/v1"
+)
+
+const openclawConfigEnvName = "OPENCLAW_CONFIG_JSON"
+
+type channelInstallationConfigPayload struct {
+	ChannelPolicies []channelInstallationChannelPolicy `json:"channelPolicies,omitempty"`
+}
+
+type channelInstallationChannelPolicy struct {
+	ExternalChannelID   string `json:"externalChannelId"`
+	ExternalChannelType string `json:"externalChannelType,omitempty"`
+	RequireMention      *bool  `json:"requireMention"`
+}
+
+func applyChannelInstallationConfigProjection(spec *spritzv1.SpritzSpec, attributes map[string]string, raw json.RawMessage) error {
+	if spec == nil {
+		return nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil
+	}
+	var payload channelInstallationConfigPayload
+	if !bytes.Equal(trimmed, []byte("null")) {
+		decoder := json.NewDecoder(bytes.NewReader(trimmed))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&payload); err != nil {
+			return errors.New("installationConfig is invalid")
+		}
+		var trailing any
+		if err := decoder.Decode(&trailing); err != io.EOF {
+			return errors.New("installationConfig is invalid")
+		}
+	}
+
+	provider := strings.TrimSpace(attributes["provider"])
+	externalScopeType := strings.TrimSpace(attributes["externalScopeType"])
+	externalTenantID := strings.TrimSpace(attributes["externalTenantId"])
+	if provider == "" || externalScopeType == "" || externalTenantID == "" {
+		return errors.New("installationConfig requires provider route attributes")
+	}
+	channelPolicies, err := normalizeChannelInstallationPolicies(payload.ChannelPolicies)
+	if err != nil {
+		return err
+	}
+
+	config, err := readOpenClawConfigEnv(spec.Env)
+	if err != nil {
+		return err
+	}
+	providers := ensureObjectField(config, "providers")
+	providerConfig := ensureObjectField(providers, provider)
+	channels := map[string]any{}
+	for _, policy := range channelPolicies {
+		channels[policy.ExternalChannelID] = map[string]any{
+			"allow":          true,
+			"requireMention": *policy.RequireMention,
+		}
+	}
+	providerConfig["channels"] = channels
+
+	encoded, err := json.Marshal(config)
+	if err != nil {
+		return errors.New("OPENCLAW_CONFIG_JSON is invalid")
+	}
+	setOpenClawConfigEnv(&spec.Env, string(encoded))
+	return nil
+}
+
+func normalizeChannelInstallationPolicies(policies []channelInstallationChannelPolicy) ([]channelInstallationChannelPolicy, error) {
+	seen := map[string]struct{}{}
+	normalized := make([]channelInstallationChannelPolicy, 0, len(policies))
+	for index, policy := range policies {
+		channelID := strings.TrimSpace(policy.ExternalChannelID)
+		if channelID == "" {
+			return nil, fmt.Errorf("installationConfig.channelPolicies.%d.externalChannelId is required", index)
+		}
+		if _, exists := seen[channelID]; exists {
+			return nil, fmt.Errorf("installationConfig.channelPolicies.%d.externalChannelId is duplicate", index)
+		}
+		seen[channelID] = struct{}{}
+		if policy.RequireMention == nil {
+			return nil, fmt.Errorf("installationConfig.channelPolicies.%d.requireMention is required", index)
+		}
+		policy.ExternalChannelID = channelID
+		policy.ExternalChannelType = strings.TrimSpace(policy.ExternalChannelType)
+		normalized = append(normalized, policy)
+	}
+	return normalized, nil
+}
+
+func readOpenClawConfigEnv(env []corev1.EnvVar) (map[string]any, error) {
+	for _, item := range env {
+		if item.Name != openclawConfigEnvName {
+			continue
+		}
+		if item.ValueFrom != nil {
+			return nil, errors.New("OPENCLAW_CONFIG_JSON cannot use valueFrom with installationConfig")
+		}
+		return parseOpenClawConfigJSON(item.Value)
+	}
+	return map[string]any{}, nil
+}
+
+func parseOpenClawConfigJSON(value string) (map[string]any, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return map[string]any{}, nil
+	}
+	var payload map[string]any
+	decoder := json.NewDecoder(strings.NewReader(trimmed))
+	decoder.UseNumber()
+	if err := decoder.Decode(&payload); err != nil {
+		return nil, errors.New("OPENCLAW_CONFIG_JSON is invalid")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return nil, errors.New("OPENCLAW_CONFIG_JSON is invalid")
+	}
+	if payload == nil {
+		payload = map[string]any{}
+	}
+	return payload, nil
+}
+
+func ensureObjectField(parent map[string]any, key string) map[string]any {
+	if existing, ok := parent[key].(map[string]any); ok {
+		return existing
+	}
+	child := map[string]any{}
+	parent[key] = child
+	return child
+}
+
+func setOpenClawConfigEnv(env *[]corev1.EnvVar, value string) {
+	for index := range *env {
+		if (*env)[index].Name == openclawConfigEnvName {
+			(*env)[index].Value = value
+			(*env)[index].ValueFrom = nil
+			return
+		}
+	}
+	*env = append(*env, corev1.EnvVar{Name: openclawConfigEnvName, Value: value})
+}

--- a/api/internal_bindings.go
+++ b/api/internal_bindings.go
@@ -20,13 +20,14 @@ import (
 )
 
 type internalBindingRequest struct {
-	DesiredRevision string                      `json:"desiredRevision,omitempty"`
-	Disconnected    bool                        `json:"disconnected,omitempty"`
-	Attributes      map[string]string           `json:"attributes,omitempty"`
-	Principal       internalCreatePrincipal     `json:"principal"`
-	Request         json.RawMessage             `json:"request"`
-	AdoptActive     *internalBindingInstanceRef `json:"adoptActive,omitempty"`
-	AdoptedRevision string                      `json:"adoptedRevision,omitempty"`
+	DesiredRevision    string                      `json:"desiredRevision,omitempty"`
+	Disconnected       bool                        `json:"disconnected,omitempty"`
+	Attributes         map[string]string           `json:"attributes,omitempty"`
+	InstallationConfig json.RawMessage             `json:"installationConfig,omitempty"`
+	Principal          internalCreatePrincipal     `json:"principal"`
+	Request            json.RawMessage             `json:"request"`
+	AdoptActive        *internalBindingInstanceRef `json:"adoptActive,omitempty"`
+	AdoptedRevision    string                      `json:"adoptedRevision,omitempty"`
 }
 
 type internalBindingInstanceRef struct {
@@ -173,6 +174,9 @@ func (s *server) upsertInternalBinding(c echo.Context) error {
 		return writeError(c, http.StatusInternalServerError, err.Error())
 	}
 	if err := resolveCreateLifetimes(&requestBody.Spec, s.provisioners, true); err != nil {
+		return writeError(c, http.StatusBadRequest, err.Error())
+	}
+	if err := applyChannelInstallationConfigProjection(&requestBody.Spec, body.Attributes, body.InstallationConfig); err != nil {
 		return writeError(c, http.StatusBadRequest, err.Error())
 	}
 

--- a/api/internal_bindings_test.go
+++ b/api/internal_bindings_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -183,6 +184,120 @@ func TestInternalUpsertBindingPreservesNormalizedCreateAnnotations(t *testing.T)
 			instanceClassVersionAnnotationKey,
 			stored.Spec.Template.Annotations,
 		)
+	}
+}
+
+func TestInternalUpsertBindingProjectsInstallationConfigIntoOpenClawEnv(t *testing.T) {
+	s := newInternalSpritzesTestServer(t)
+	s.presets.byID[0].Env = []corev1.EnvVar{{
+		Name:  "OPENCLAW_CONFIG_JSON",
+		Value: `{"providers":{"slack":{"channels":{"C_OLD":{"allow":true,"requireMention":false}}}}}`,
+	}}
+	e := echo.New()
+	s.registerRoutes(e)
+
+	body := `{
+		"desiredRevision": "sha256:rev-1",
+		"attributes": {
+			"provider": "slack",
+			"externalScopeType": "workspace",
+			"externalTenantId": "T021GRS5F4P"
+		},
+		"installationConfig": {
+			"channelPolicies": [
+				{"externalChannelId": "C0ANJGDB4Q5", "requireMention": false}
+			]
+		},
+		"principal": {"id": "channel-gateway"},
+		"request": {
+			"presetId": "zeno",
+			"ownerId": "user-123",
+			"requestId": "binding-upsert-config",
+			"source": "channel-gateway",
+			"spec": {}
+		}
+	}`
+	req := httptest.NewRequest(http.MethodPut, "/api/internal/v1/bindings/channel-installation-binding-config", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer spritz-internal-token")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var stored spritzv1.SpritzBinding
+	if err := s.client.Get(
+		context.Background(),
+		client.ObjectKey{
+			Namespace: "default",
+			Name:      bindingResourceNameForKey("channel-installation-binding-config"),
+		},
+		&stored,
+	); err != nil {
+		t.Fatalf("failed to load stored binding: %v", err)
+	}
+
+	var openClawConfig string
+	for _, item := range stored.Spec.Template.Spec.Env {
+		if item.Name == "OPENCLAW_CONFIG_JSON" {
+			openClawConfig = item.Value
+		}
+	}
+	var projected map[string]any
+	if err := json.Unmarshal([]byte(openClawConfig), &projected); err != nil {
+		t.Fatalf("expected valid OpenClaw config JSON, got %s: %v", openClawConfig, err)
+	}
+	providers, _ := projected["providers"].(map[string]any)
+	slackConfig, _ := providers["slack"].(map[string]any)
+	channels, _ := slackConfig["channels"].(map[string]any)
+	channelConfig, _ := channels["C0ANJGDB4Q5"].(map[string]any)
+	if channelConfig["allow"] != true || channelConfig["requireMention"] != false {
+		t.Fatalf("expected OpenClaw channel policy in env, got %s", openClawConfig)
+	}
+	if _, exists := channels["C_OLD"]; exists {
+		t.Fatalf("expected stale OpenClaw channel policy to be removed, got %s", openClawConfig)
+	}
+}
+
+func TestInternalUpsertBindingProjectsNullInstallationConfigAsEmptyPolicy(t *testing.T) {
+	spec := spritzv1.SpritzSpec{
+		Env: []corev1.EnvVar{{
+			Name:  "OPENCLAW_CONFIG_JSON",
+			Value: `{"providers":{"slack":{"channels":{"C_OLD":{"allow":true,"requireMention":false}}}}}`,
+		}},
+	}
+
+	err := applyChannelInstallationConfigProjection(
+		&spec,
+		map[string]string{
+			"provider":          "slack",
+			"externalScopeType": "workspace",
+			"externalTenantId":  "T021GRS5F4P",
+		},
+		json.RawMessage(`null`),
+	)
+	if err != nil {
+		t.Fatalf("expected null installationConfig to clear policy projection, got %v", err)
+	}
+
+	var openClawConfig string
+	for _, item := range spec.Env {
+		if item.Name == "OPENCLAW_CONFIG_JSON" {
+			openClawConfig = item.Value
+		}
+	}
+	var projected map[string]any
+	if err := json.Unmarshal([]byte(openClawConfig), &projected); err != nil {
+		t.Fatalf("expected valid OpenClaw config JSON, got %s: %v", openClawConfig, err)
+	}
+	providers, _ := projected["providers"].(map[string]any)
+	slackConfig, _ := providers["slack"].(map[string]any)
+	channels, _ := slackConfig["channels"].(map[string]any)
+	if len(channels) != 0 {
+		t.Fatalf("expected null installationConfig to remove stale channels, got %s", openClawConfig)
 	}
 }
 

--- a/api/internal_bindings_test.go
+++ b/api/internal_bindings_test.go
@@ -301,6 +301,45 @@ func TestInternalUpsertBindingProjectsNullInstallationConfigAsEmptyPolicy(t *tes
 	}
 }
 
+func TestInternalUpsertBindingProjectsInstallationConfigWithoutDroppingOpenClawDefaults(t *testing.T) {
+	spec := spritzv1.SpritzSpec{}
+
+	err := applyChannelInstallationConfigProjection(
+		&spec,
+		map[string]string{
+			"provider":          "slack",
+			"externalScopeType": "workspace",
+			"externalTenantId":  "T021GRS5F4P",
+		},
+		json.RawMessage(`{"channelPolicies":[{"externalChannelId":"C0ANJGDB4Q5","requireMention":false}]}`),
+	)
+	if err != nil {
+		t.Fatalf("expected installationConfig projection to succeed, got %v", err)
+	}
+
+	var openClawConfig string
+	for _, item := range spec.Env {
+		if item.Name == "OPENCLAW_CONFIG_JSON" {
+			openClawConfig = item.Value
+		}
+	}
+	var projected map[string]any
+	if err := json.Unmarshal([]byte(openClawConfig), &projected); err != nil {
+		t.Fatalf("expected valid OpenClaw config JSON, got %s: %v", openClawConfig, err)
+	}
+	browser, _ := projected["browser"].(map[string]any)
+	if browser["enabled"] != true || browser["executablePath"] != "/usr/bin/chromium" {
+		t.Fatalf("expected OpenClaw browser defaults to be preserved, got %s", openClawConfig)
+	}
+	providers, _ := projected["providers"].(map[string]any)
+	slackConfig, _ := providers["slack"].(map[string]any)
+	channels, _ := slackConfig["channels"].(map[string]any)
+	channelConfig, _ := channels["C0ANJGDB4Q5"].(map[string]any)
+	if channelConfig["allow"] != true || channelConfig["requireMention"] != false {
+		t.Fatalf("expected OpenClaw channel policy in env, got %s", openClawConfig)
+	}
+}
+
 func TestInternalDeleteBindingRemovesStoredBinding(t *testing.T) {
 	s := newInternalSpritzesTestServer(t)
 	e := echo.New()

--- a/docs/2026-04-24-channel-install-message-policy-config.md
+++ b/docs/2026-04-24-channel-install-message-policy-config.md
@@ -1,0 +1,348 @@
+---
+date: 2026-04-24
+author: Onur Solmaz <onur@textcortex.com>
+title: Channel Install Message Policy Config
+tags: [spritz, channel-gateway, slack, install, config, openclaw, architecture]
+---
+
+## Overview
+
+This document defines how a workspace-level channel installation can allow
+selected channels to relay normal messages without requiring a bot mention.
+
+The immediate use case is Slack:
+
+- the Slack app remains installed at workspace scope
+- one or more Slack channels are configured with `requireMention: false`
+- messages in those channels are relayed without tagging the bot account
+- other workspace channels continue to require a mention
+
+The design keeps Spritz generic. The setting is modeled as installation config,
+not as deployment-specific target selection and not as organization-specific
+state.
+
+Related docs:
+
+- [Channel Install Target Selection Architecture](2026-04-17-channel-install-target-selection-architecture.md)
+- [Channel Install Ownership and Management Architecture](2026-04-17-channel-install-ownership-and-management-architecture.md)
+- [Slack Channel Gateway Implementation Plan](2026-03-24-slack-channel-gateway-implementation-plan.md)
+- [Shared Channel Concierge Lifecycle Architecture](2026-03-31-shared-channel-concierge-lifecycle-architecture.md)
+
+## Problem
+
+Workspace installs are useful because one provider installation can route
+messages for a whole external tenant, such as one Slack workspace.
+
+However, message delivery policy is not always workspace-wide. A deployment may
+want only specific channels to behave as always-on relay channels, while all
+other channels still require an explicit bot mention.
+
+If this setting is encoded in install target selection, the model becomes
+incorrect:
+
+- the selected target did not change
+- the Slack workspace install did not change
+- only provider message policy for selected channels changed
+
+Spritz therefore needs a separate installation-config surface.
+
+## Core Decision
+
+Store channel mention policy as mutable installation config on the durable
+channel installation record.
+
+The route identity remains unchanged:
+
+- `principalId`
+- `provider`
+- `externalScopeType`
+- `externalTenantId`
+
+For Slack workspace installs, `externalTenantId` is the Slack team or workspace
+ID. The installation can then carry message policy for channels inside that
+workspace.
+
+## Config Shape
+
+The generic installation config should use provider-owned external IDs, not
+deployment-owned concepts.
+
+Recommended v1 shape:
+
+```json
+{
+  "channelPolicies": [
+    {
+      "externalChannelId": "C1234567890",
+      "requireMention": false
+    }
+  ]
+}
+```
+
+Field meanings:
+
+- `channelPolicies`: message handling rules for external provider channels.
+- `externalChannelId`: the provider's stable channel ID.
+- `requireMention`: whether normal channel messages must mention the bot before
+  Spritz relays them.
+
+Default behavior:
+
+- if no matching channel policy exists, `requireMention` is `true`
+- explicit app mentions continue to work
+- direct messages keep their existing behavior
+
+The config can be extended later without changing the route identity:
+
+```json
+{
+  "channelPolicies": [
+    {
+      "externalChannelId": "C1234567890",
+      "externalChannelType": "channel",
+      "requireMention": false
+    }
+  ]
+}
+```
+
+## What This Is Not
+
+This setting must not be stored in `presetInputs`.
+
+`presetInputs` selects the deployment-owned target that backs the installation.
+Installation config controls mutable provider behavior for that installation.
+
+Pinned split:
+
+- route identity determines the shared app and external tenant
+- `presetInputs` determines the target behind that installation
+- installation config determines provider message behavior
+
+This keeps the design organization-agnostic. Spritz only stores provider IDs
+and generic message policy. The deployment remains free to decide what the
+selected target means.
+
+## Storage Ownership
+
+The deployment that owns channel installations should persist the config on the
+same durable installation object that already stores route identity,
+ownership, provider auth, and `presetInputs`.
+
+Spritz defines the API contract and semantics. The deployment stores the data.
+
+That means:
+
+- Spritz owns the install-management UX and generic API shape
+- the deployment owns the database table and authorization checks
+- Spritz and the channel gateway consume the effective config
+- OpenClaw receives a projected runtime config during concierge boot
+
+Existing installs should default to empty config, which preserves current
+mention-required behavior.
+
+## API Contract
+
+Add a generic install-management operation for config updates.
+
+Recommended operation:
+
+- `channel.installation.config.update`
+
+Recommended request shape:
+
+```json
+{
+  "installationId": "inst_123",
+  "installationConfig": {
+    "channelPolicies": [
+      {
+        "externalChannelId": "C1234567890",
+        "requireMention": false
+      }
+    ]
+  }
+}
+```
+
+Recommended response shape:
+
+```json
+{
+  "installation": {
+    "id": "inst_123",
+    "provider": "slack",
+    "externalScopeType": "workspace",
+    "externalTenantId": "T1234567890",
+    "installationConfig": {
+      "channelPolicies": [
+        {
+          "externalChannelId": "C1234567890",
+          "requireMention": false
+        }
+      ]
+    }
+  }
+}
+```
+
+Management list responses should also include `installationConfig` so Spritz can
+render current channel policy.
+
+Validation rules:
+
+- the caller must be allowed to manage the installation
+- `externalChannelId` must be non-empty
+- `requireMention` must be boolean
+- duplicate channel policies should be rejected or normalized
+- provider-specific ID validation may be applied by the deployment
+- deployments may cap the number of channel policies per installation
+
+Reinstall should preserve existing installation config unless the reinstall
+request explicitly changes it through a config-management operation.
+
+## Session Exchange
+
+The channel gateway needs access to effective install config before deciding
+whether a normal channel message can be relayed without a mention.
+
+Recommended v1 behavior:
+
+- session exchange returns the workspace installation config
+- the gateway caches it by provider tenant ID for a short TTL
+- each event checks the current channel against `channelPolicies`
+
+For Slack this means the gateway can receive normal `message` events for a
+workspace install, then decide locally:
+
+```text
+if event is app_mention:
+  relay
+
+if event is normal message and channel policy says requireMention=false:
+  relay
+
+if event is normal message and channel policy is missing:
+  require bot mention
+```
+
+The gateway must keep existing safety checks:
+
+- ignore bot messages
+- ignore unsupported Slack message subtypes
+- ignore empty prompts after mention stripping
+- dedupe by Slack team, channel, and timestamp
+
+The dedupe rule is important because Slack can surface both a normal message
+event and an app mention event for the same user message.
+
+## OpenClaw Projection
+
+The stored installation config is the source of truth. OpenClaw config is a
+runtime projection of that source of truth.
+
+When concierge is created, recovered, or reconciled, Spritz should project the
+same channel policies into the OpenClaw config passed to the runtime.
+
+Example projection:
+
+```json
+{
+  "providers": {
+    "slack": {
+      "channels": {
+        "C1234567890": {
+          "allow": true,
+          "requireMention": false
+        }
+      }
+    }
+  }
+}
+```
+
+The exact OpenClaw JSON should match OpenClaw's config schema. Spritz should
+perform that mapping at the runtime adapter or preset boundary, not in the
+generic installation-management API.
+
+## Reconciliation
+
+Config changes must affect the desired concierge state.
+
+If `installationConfig` changes, the binding or rollout desired state must
+change too. Otherwise the database can be updated while the running concierge
+keeps old OpenClaw config.
+
+Recommended implementation:
+
+- store deterministic JSON for installation config
+- compute a config hash or revision
+- include that hash in the desired binding or rollout input
+- reconcile the concierge when the hash changes
+
+This makes config changes behave like other desired runtime changes.
+
+## Failure Behavior
+
+The default must fail closed.
+
+Rules:
+
+- missing config means mentions are required
+- invalid config should be rejected before save
+- if config cannot be loaded during message handling, require a mention
+- if OpenClaw projection fails, concierge rollout should fail rather than start
+  with broader message access than intended
+
+## Implementation Notes
+
+Recommended platform changes:
+
+- add an `installation_config` JSON/Text field to the durable channel
+  installation model
+- add config serialization to installation list and detail responses
+- add the config update operation
+- pass installation config into binding creation or reconciliation
+- include config revision in desired state
+
+Recommended Slack gateway changes:
+
+- include installation config in session exchange response or add a lightweight
+  config lookup
+- cache config by Slack team ID with a short TTL
+- allow unmentioned normal channel messages only when the matching channel
+  policy has `requireMention: false`
+- keep mention-required behavior as the default
+
+Recommended Spritz runtime changes:
+
+- accept installation config separately from `presetInputs`
+- project relevant channel policies into OpenClaw config during concierge boot
+- reconcile runtime config when installation config changes
+
+## Test Plan
+
+Backend tests:
+
+- saves and returns installation config
+- rejects invalid channel policies
+- preserves config across reinstall
+- keeps config separate from `presetInputs`
+- changes desired binding state when config changes
+
+Slack gateway tests:
+
+- relays unmentioned message in configured channel
+- ignores unmentioned message in unconfigured channel
+- still relays explicit app mention
+- dedupes duplicate `message` and `app_mention` delivery for the same Slack
+  timestamp
+- ignores bot messages in configured channels
+
+Runtime tests:
+
+- concierge boot includes configured `requireMention: false` channels in
+  OpenClaw config
+- config changes trigger reconcile or rollout
+- missing config preserves mention-required behavior

--- a/docs/2026-04-24-channel-installation-data-model.md
+++ b/docs/2026-04-24-channel-installation-data-model.md
@@ -90,6 +90,9 @@ contract do not keep growing one-off fields.
 - Moving all deployment-owned authorization into Spritz.
 - Making Spritz understand deployment-specific target types such as agents,
   teams, organizations, or accounts.
+- Making Spritz understand whether the installation is owned by an individual
+  user, an organization, a workspace, or any other deployment-specific owner
+  type.
 - Supporting multiple active connections for the same external channel in v1.
 - Having Spritz core own the physical database schema or storage migrations
   for deployment-owned installation state.
@@ -231,8 +234,9 @@ Field meanings:
 
 - `id` is the stable product/API ID, for example `ci_...`.
 - `provider` is the messaging provider, for example `slack`.
-- `principal_id` identifies which shared app or gateway principal owns this
-  install route.
+- `principal_id` identifies which shared app or gateway principal receives
+  events for this install route. It is not the product owner of the
+  installation.
 - `external_installation_key` is a deterministic provider-adapter key for the
   external install surface.
 - `external_tenant_id` is a searchable/displayable provider tenant ID when
@@ -463,6 +467,22 @@ backend service, not to a generic UI component.
 
 The channel schema should not encode a product-specific ownership taxonomy.
 
+Spritz should not know whether a channel installation is owned by an individual
+user, an organization, a team, an account, or another deployment-specific
+owner type.
+
+Do not add these fields to the Spritz-facing generic contract:
+
+- `ownerType`
+- `userId`
+- `orgId`
+- `tenantId`
+- `accountId`
+
+The deployment backend may store those fields, or any equivalent ownership
+reference, in its own persistence layer. Those values should stay opaque to
+Spritz.
+
 Each deployment still needs to answer:
 
 - who may see an installation
@@ -472,6 +492,10 @@ Each deployment still needs to answer:
 
 Those checks should be enforced by the deployment's normal authorization
 system and surfaced to Spritz as server-driven action availability.
+
+For UI purposes, the deployment may return display-only ownership fields such
+as `ownerLabel`. Spritz may render that label, but it must not infer
+authorization or routing behavior from it.
 
 The generic channel model only needs stable IDs and enough route state to
 resolve provider events.
@@ -521,6 +545,7 @@ Minimum validation for this model:
 - Model provider installation, internal connection, Spritz runtime backing,
   and channel routes as separate concepts.
 - Do not add core `targetType`, `preset`, or `runtime` fields.
+- Do not add core user-vs-organization ownership fields.
 - Do not require `scopeType` in the core uniqueness key.
 - Keep Spritz storage-agnostic; deployment backends create and own the
   physical storage.

--- a/docs/2026-04-24-channel-installation-data-model.md
+++ b/docs/2026-04-24-channel-installation-data-model.md
@@ -108,11 +108,11 @@ That includes:
 
 Spritz should not require one specific storage implementation.
 
-The deployment-owned backend should define and create the physical storage.
-In the current production deployment, that means Platform creates the database
-tables through its normal backend migration system. Another deployment could
-store the same logical entities in a different database or service as long as
-it satisfies the same Spritz-facing contract.
+The deployment-owned backend should define and create the physical storage
+through its normal migration or provisioning system. One deployment may create
+relational database tables. Another deployment could store the same logical
+entities in a different database or service as long as it satisfies the same
+Spritz-facing contract.
 
 The entity names in this document are canonical logical names. The SQL below
 is an illustrative relational implementation shape, not a requirement that
@@ -251,7 +251,7 @@ Example Slack row:
 {
   "id": "ci_01k...",
   "provider": "slack",
-  "principalId": "slack-gateway-staging",
+  "principalId": "shared-slack-gateway",
   "externalInstallationKey": "workspace:T021GRS5F4P",
   "externalTenantId": "T021GRS5F4P",
   "externalDisplayName": "Example Workspace",
@@ -449,7 +449,7 @@ The route upsert body can stay generic:
 ```json
 {
   "externalChannelId": "C0ANJGDB4Q5",
-  "externalChannelName": "zeno-staging",
+  "externalChannelName": "support-triage",
   "requireMention": false,
   "enabled": true
 }

--- a/docs/2026-04-24-channel-installation-data-model.md
+++ b/docs/2026-04-24-channel-installation-data-model.md
@@ -733,6 +733,34 @@ During the migration window, the deployment backend can keep serving the old
 session exchange response shape by reading from the new storage and projecting
 the legacy response.
 
+## Implementation Plan
+
+This design is ready to implement as a v1.
+
+The build should happen in this order:
+
+1. Add deployment-backend storage and migrations for the logical entities.
+   Spritz core should not create these tables.
+2. Add deployment-backend management APIs for installations, connections,
+   routes, and provider channel lookup.
+3. Add a compatibility projection for the current channel session exchange so
+   existing gateways can keep working during migration.
+4. Update provider gateways and runtime config generation to read channel
+   route policy from the new API shape.
+5. Add Spritz settings pages over the generic management APIs.
+6. Migrate existing `installation_config.channelPolicies[]` data into
+   `channel_route` records.
+
+The remaining choices are implementation details, not design blockers:
+
+- exact endpoint or resolver names for the management APIs
+- whether existing rows migrate in place or through a compatibility projection
+- the database-specific mechanism for enforcing one active default connection
+  per installation
+- whether `namespace` remains necessary once runtime references are resolved
+  consistently
+- the exact provider-channel-list pagination and search behavior
+
 ## Validation
 
 Minimum validation for this model:

--- a/docs/2026-04-24-channel-installation-data-model.md
+++ b/docs/2026-04-24-channel-installation-data-model.md
@@ -495,22 +495,65 @@ That keeps channel-level behavior separate from Slack installation mode.
 
 ## UI Model
 
+The settings UI should be a Spritz-owned generic management surface over
+deployment-owned channel-installation APIs.
+
+Spritz owns:
+
+- routes and page structure
+- generic list/detail forms
+- provider-aware labels and pickers
+- rendering server-provided action availability
+
+The deployment backend owns:
+
+- storage
+- authorization
+- provider credential use
+- provider channel lookup
+- mutations to installations, connections, and routes
+
+Spritz should never infer ownership or permissions locally.
+
 The UI should be installation-scoped first, then connection-scoped.
 
 Recommended routes:
 
 ```text
+/settings/channels
 /settings/channels/installations/:installationId
 /settings/channels/installations/:installationId/connections/:connectionId
 ```
+
+### `/settings/channels`
+
+This page lists channel installations the current viewer may manage.
+
+It should render only rows returned by the deployment backend. If an
+installation is not returned, Spritz should treat it as not manageable by the
+viewer.
+
+The page should show:
+
+- provider
+- external workspace, guild, team, or tenant display name
+- install status
+- display-only owner label when the deployment returns one
+- available actions from `allowedActions`
+
+### `/settings/channels/installations/:installationId`
 
 The installation page should show:
 
 - provider
 - external workspace, guild, team, or tenant name
 - install status
+- display-only owner label when available
 - reconnect or disconnect actions
 - all connections under the installation
+- which connection is the default
+
+### `/settings/channels/installations/:installationId/connections/:connectionId`
 
 The connection page should show:
 
@@ -523,6 +566,45 @@ The connection page should show:
 Slack-specific labels are fine in the UI when the provider is Slack. The route
 shape should still use stable internal IDs instead of Slack team IDs or agent
 IDs.
+
+### Channel Picker
+
+Provider channel lookup should be a backend operation, not a Spritz storage
+query.
+
+For Slack, the backend can use the saved credential reference and Slack adapter
+to list channels. Spritz should only render returned options.
+
+Example operation:
+
+```text
+channel.provider.channels.list
+```
+
+Example request:
+
+```json
+{
+  "installationId": "ci_123",
+  "query": "support"
+}
+```
+
+Example response:
+
+```json
+{
+  "channels": [
+    {
+      "externalChannelId": "C0ANJGDB4Q5",
+      "displayName": "support-triage"
+    }
+  ]
+}
+```
+
+The display name is allowed in the picker response because it is UI data. It
+should not become core route storage.
 
 ## API Shape
 
@@ -541,6 +623,26 @@ PUT /channel/connections/cc_456/routes/C0ANJGDB4Q5
 DELETE /channel/routes/cr_789
 ```
 
+The list and detail responses should be server-driven. Spritz should use
+`allowedActions` to decide which buttons and form controls are enabled.
+
+Example installation list response:
+
+```json
+{
+  "installations": [
+    {
+      "id": "ci_123",
+      "provider": "slack",
+      "displayName": "Example Workspace",
+      "status": "active",
+      "ownerLabel": "Example Team",
+      "allowedActions": ["view", "reconnect", "disconnect"]
+    }
+  ]
+}
+```
+
 The route upsert body can stay generic:
 
 ```json
@@ -554,6 +656,24 @@ The route upsert body can stay generic:
 Provider-specific validation should happen server-side. For example, Slack
 channel ID validation belongs to the Slack provider adapter or deployment
 backend service, not to a generic UI component.
+
+The generic settings UI should not know:
+
+- user-vs-organization ownership
+- provider token storage
+- database tables
+- deployment-specific target IDs
+- whether the backing thing is an agent, workflow, or another product concept
+
+The generic settings UI may know:
+
+- `installationId`
+- `connectionId`
+- `routeId`
+- `provider`
+- display labels
+- `allowedActions`
+- route config such as `requireMention`
 
 ## Ownership And Authorization
 

--- a/docs/2026-04-24-channel-installation-data-model.md
+++ b/docs/2026-04-24-channel-installation-data-model.md
@@ -148,6 +148,17 @@ Expected values:
 - `discord`
 - `msteams`
 
+### `app_principal_id`
+
+Use `app_principal_id`, not plain `principal_id`.
+
+This field identifies the shared app or gateway identity that receives events
+for the installation route. It does not identify the user, organization,
+account, team, agent, or workspace that owns the installation.
+
+The longer name is intentional because `principal` alone is overloaded in auth
+systems. In this model, the field is only part of provider event routing.
+
 ### No core `targetType`
 
 Do not add `targetType` to the core channel schema.
@@ -187,8 +198,9 @@ produce one stable `externalInstallationKey` for routing. For Slack workspace
 installs, that key can be derived from the Slack team ID. A future Teams
 adapter can derive a different key without changing the core schema.
 
-The provider-specific facts can still be stored as metadata for display,
-debugging, and migration.
+Provider-specific facts that are not part of routing should stay outside the
+core logical model. A deployment may store them in provider-specific storage,
+audit events, or adapter-owned caches.
 
 ## Logical Data Model
 
@@ -210,44 +222,45 @@ A relational implementation might use this shape:
 CREATE TABLE channel_installation (
     id                         VARCHAR(32) PRIMARY KEY,
     provider                   VARCHAR(32) NOT NULL,
-    principal_id               VARCHAR(128) NOT NULL,
+    app_principal_id           VARCHAR(128) NOT NULL,
     external_installation_key  VARCHAR(256) NOT NULL,
     external_tenant_id         VARCHAR(256) NULL,
     external_display_name      VARCHAR(512) NULL,
-    provider_auth_ref          VARCHAR(512) NULL,
+    credential_ref             VARCHAR(512) NULL,
     status                     VARCHAR(32) NOT NULL,
-    provider_metadata          JSON NULL,
-    installed_by_external_id   VARCHAR(256) NULL,
     created_at                 DATETIME NOT NULL,
     updated_at                 DATETIME NOT NULL,
     deleted_at                 DATETIME NULL,
 
     UNIQUE KEY uq_channel_installation_route (
         provider,
-        principal_id,
+        app_principal_id,
         external_installation_key
     )
 );
 ```
 
-Field meanings:
+Entity justification:
 
-- `id` is the stable product/API ID, for example `ci_...`.
-- `provider` is the messaging provider, for example `slack`.
-- `principal_id` identifies which shared app or gateway principal receives
-  events for this install route. It is not the product owner of the
-  installation.
-- `external_installation_key` is a deterministic provider-adapter key for the
-  external install surface.
-- `external_tenant_id` is a searchable/displayable provider tenant ID when
-  one exists, such as a Slack team ID.
-- `external_display_name` caches the workspace, guild, team, or tenant name.
-- `provider_auth_ref` points to provider OAuth credentials or another durable
-  auth reference.
-- `provider_metadata` stores provider-specific facts that should not become
-  core columns.
-- `installed_by_external_id` stores the provider user ID that performed the
-  latest install or reconnect when available.
+This entity separates the external provider install from any internal
+assistant or runtime. Without it, reconnects, disconnects, provider auth
+updates, and workspace-level settings get mixed into assistant/runtime state.
+
+Column justifications:
+
+| Column | Decision | Justification |
+|---|---|---|
+| `id` | keep | Stable internal ID for APIs and UI. External provider IDs should not be the primary product URL. |
+| `provider` | keep | Identifies the messaging provider, such as `slack`, `discord`, or `msteams`. Routing and provider adapters need this. |
+| `app_principal_id` | keep | Identifies which shared app or gateway identity receives events for this route. This is not the product owner. The old `principal_id` name is too vague. |
+| `external_installation_key` | keep | Provider-adapter-generated stable key for the external install surface. This avoids a core `scopeType` enum while still giving routing a deterministic key. |
+| `external_tenant_id` | optional | Useful for search, debugging, and display when the provider has a tenant/workspace ID. It should not replace `external_installation_key`. |
+| `external_display_name` | optional | Cached UI label for the workspace, guild, team, or tenant. It is non-authoritative and may lag provider state. |
+| `credential_ref` | optional | Pointer to OAuth or credential storage. Token material should not live on the installation entity. |
+| `status` | keep | Needed to fail routing closed for disconnected, broken, or reconnect-required installs. |
+| `created_at` | keep | Standard audit and lifecycle field. |
+| `updated_at` | keep | Standard lifecycle field for management and debugging. |
+| `deleted_at` | keep | Supports soft release and audit history without keeping the active route claim alive. |
 
 Example Slack row:
 
@@ -255,13 +268,23 @@ Example Slack row:
 {
   "id": "ci_01k...",
   "provider": "slack",
-  "principalId": "shared-slack-gateway",
+  "appPrincipalId": "shared-slack-gateway",
   "externalInstallationKey": "workspace:T021GRS5F4P",
   "externalTenantId": "T021GRS5F4P",
   "externalDisplayName": "Example Workspace",
   "status": "active"
 }
 ```
+
+Deliberately excluded:
+
+- `provider_metadata`: too easy to become a dumping ground. Provider-specific
+  facts should live in provider-specific storage or adapter caches.
+- `installed_by_external_id`: audit data, not installation identity. Store it
+  in installation events instead.
+- owner fields such as `ownerType`, `userId`, `orgId`, `tenantId`, and
+  `accountId`: deployment-owned authorization details, not Spritz-facing
+  routing state.
 
 ### `channel_connection`
 
@@ -288,6 +311,26 @@ CREATE TABLE channel_connection (
 );
 ```
 
+Entity justification:
+
+This entity separates "the provider app is installed" from "this install has
+an internal destination." A single workspace install can therefore host
+multiple internal connections, while reconnecting or disconnecting the provider
+install remains independent.
+
+Column justifications:
+
+| Column | Decision | Justification |
+|---|---|---|
+| `id` | keep | Stable internal connection ID for APIs and UI. |
+| `installation_id` | keep | Parent external installation. A connection cannot exist without an installed provider app. |
+| `display_name` | keep | Human-facing label in settings. The UI should not need Spritz runtime details to list connections. |
+| `is_default` | keep | Defines fallback routing when a channel has no explicit route. Without this, workspace-mode behavior is ambiguous. |
+| `status` | keep | Allows a connection to be disabled or broken without disconnecting the whole provider install. |
+| `created_at` | keep | Standard audit and lifecycle field. |
+| `updated_at` | keep | Standard lifecycle field for management and debugging. |
+| `deleted_at` | keep | Supports soft deletion and route repair without losing history. |
+
 Recommended constraints:
 
 - one active default connection per installation
@@ -312,7 +355,6 @@ CREATE TABLE spritz_channel_connection (
     connection_id              VARCHAR(32) PRIMARY KEY,
     preset_id                  VARCHAR(128) NOT NULL,
     preset_inputs              JSON NULL,
-    preset_inputs_hash         VARCHAR(128) NULL,
     spritz_binding_key         VARCHAR(256) NULL,
     spritz_instance_id         VARCHAR(256) NULL,
     namespace                  VARCHAR(256) NULL,
@@ -329,6 +371,32 @@ This is the right logical home for the fields that currently describe Spritz
 provisioning and runtime binding. A deployment can store those fields in a
 separate table, a nested document, or another equivalent persistence shape.
 
+Entity justification:
+
+This entity keeps Spritz-specific runtime concerns out of the provider-agnostic
+connection model. The generic connection can exist even if another deployment
+backs it with something other than Spritz.
+
+Column justifications:
+
+| Column | Decision | Justification |
+|---|---|---|
+| `connection_id` | keep | One-to-one link to the generic connection. |
+| `preset_id` | keep | Identifies the Spritz preset or class used to create or resolve the backing runtime. |
+| `preset_inputs` | keep | Opaque deployment-selected target inputs. Spritz should use or round-trip them without interpreting ownership. |
+| `spritz_binding_key` | keep | Stable logical binding separate from the current live runtime. Useful when runtimes are replaced. |
+| `spritz_instance_id` | keep | Current live runtime reference. It is only a cached binding and must be validated before routing. |
+| `namespace` | optional | Keep only when runtime lookup is namespace-scoped. If runtime references become globally unique, this can go away. |
+| `applied_revision` | keep | Lets controllers know whether runtime config has caught up with saved connection/route changes. |
+| `runtime_binding_assigned_at` | keep | Helps debug stale runtime bindings and recovery behavior. |
+| `created_at` | keep | Standard audit and lifecycle field. |
+| `updated_at` | keep | Standard lifecycle field for management and debugging. |
+
+Deliberately excluded:
+
+- `preset_inputs_hash`: do not add in v1 unless there is a real uniqueness or
+  idempotency query that needs it.
+
 ### `channel_route`
 
 One logical record means one external channel has explicit routing behavior.
@@ -344,7 +412,6 @@ CREATE TABLE channel_route (
     installation_id      VARCHAR(32) NOT NULL,
     connection_id        VARCHAR(32) NOT NULL,
     external_channel_id  VARCHAR(256) NOT NULL,
-    external_channel_name VARCHAR(512) NULL,
     require_mention      BOOLEAN NOT NULL DEFAULT TRUE,
     enabled              BOOLEAN NOT NULL DEFAULT TRUE,
     created_at           DATETIME NOT NULL,
@@ -360,6 +427,32 @@ CREATE TABLE channel_route (
     )
 );
 ```
+
+Entity justification:
+
+This entity is the rule for a specific external channel. It chooses the
+destination connection and stores the mention policy for that channel. This is
+where `require_mention = false` is saved.
+
+Column justifications:
+
+| Column | Decision | Justification |
+|---|---|---|
+| `id` | keep | Stable internal route ID for update, delete, and audit. |
+| `installation_id` | keep | Scopes the route to one external app installation. Provider channel IDs are not globally unique across installs. |
+| `connection_id` | keep | Destination for messages from this external channel. |
+| `external_channel_id` | keep | Provider channel ID from incoming events. This is the actual routing selector. |
+| `require_mention` | keep | Saves the required setting. `false` means messages in this channel can relay without tagging the bot. |
+| `enabled` | keep | Lets users disable a route without deleting the saved configuration. |
+| `created_at` | keep | Standard audit and lifecycle field. |
+| `updated_at` | keep | Standard lifecycle field for management and debugging. |
+| `deleted_at` | keep | Supports soft deletion and route history. |
+
+Deliberately excluded:
+
+- `external_channel_name`: channel names are mutable display cache. Routing
+  should use `external_channel_id`; names can come from provider lookup or UI
+  cache.
 
 The unique route constraint is intentional. In v1, one external channel should
 route to one active connection for a given provider installation. That avoids
@@ -379,7 +472,7 @@ Incoming provider events should resolve in this order:
 
 1. The provider gateway computes the provider route:
    - `provider`
-   - `principal_id`
+   - `app_principal_id`
    - `external_installation_key`
 2. The backend resolves the matching `channel_installation`.
 3. If the event has an external channel ID, the backend looks for an enabled
@@ -453,7 +546,6 @@ The route upsert body can stay generic:
 ```json
 {
   "externalChannelId": "C0ANJGDB4Q5",
-  "externalChannelName": "support-triage",
   "requireMention": false,
   "enabled": true
 }
@@ -506,8 +598,8 @@ The existing combined installation row can migrate into the split logical model
 in four steps.
 
 1. Create one `channel_installation` row for each existing external route.
-   The current provider route fields map into `provider`, `principal_id`, and
-   `external_installation_key`.
+   The current provider route fields map into `provider`,
+   `app_principal_id`, and `external_installation_key`.
 2. Create one `channel_connection` row for each existing backing concierge.
    Existing single-connection installs should mark that row as default.
 3. Move Spritz-specific fields into `spritz_channel_connection`.
@@ -532,7 +624,7 @@ Minimum validation for this model:
 - a channel route with `require_mention = false` relays unmentioned messages
   for that channel
 - channels without an explicit route keep requiring a bot mention
-- reconnect updates provider auth without rewriting Spritz runtime state
+- reconnect updates credentials without rewriting Spritz runtime state
 - runtime replacement updates `spritz_channel_connection` without rewriting
   provider installation identity
 - Discord or Teams can add provider adapters without changing the core logical

--- a/docs/2026-04-24-channel-installation-data-model.md
+++ b/docs/2026-04-24-channel-installation-data-model.md
@@ -10,6 +10,12 @@ tags: [spritz, channel-gateway, install, data-model, slack, discord, teams, arch
 This document defines the long-term data model for shared channel
 installations.
 
+This is a logical model and API contract, not a Spritz-owned database
+migration plan. Spritz should stay storage-agnostic. The deployment-owned
+backend that persists installation state is responsible for creating physical
+tables, documents, or any other storage shape through its own migration
+system.
+
 The immediate use case is Slack workspace installs where one workspace can
 have one or more Spritz-backed connections, and selected channels can be
 configured with `requireMention: false`.
@@ -17,7 +23,7 @@ configured with `requireMention: false`.
 The model is intentionally not Slack-specific or deployment-specific. Slack is
 the first provider. Discord, Microsoft Teams, and other channel
 providers should fit the same shape without adding provider-specific core
-tables.
+entities.
 
 Related docs:
 
@@ -71,8 +77,8 @@ contract do not keep growing one-off fields.
   connections.
 - Support one or more connections under one external workspace install.
 - Support per-channel routing and mention policy.
-- Keep the core tables provider-agnostic.
-- Keep Spritz runtime fields out of the generic channel-installation table.
+- Keep the core logical model provider-agnostic.
+- Keep Spritz runtime fields out of the generic channel-installation entity.
 - Keep the URL and API model stable by using internal installation and
   connection IDs.
 - Avoid deployment-specific names in the core channel schema.
@@ -85,6 +91,32 @@ contract do not keep growing one-off fields.
 - Making Spritz understand deployment-specific target types such as agents,
   teams, organizations, or accounts.
 - Supporting multiple active connections for the same external channel in v1.
+- Having Spritz core own the physical database schema or storage migrations
+  for deployment-owned installation state.
+
+## API And Storage Boundary
+
+Spritz should define the generic channel-installation contract.
+
+That includes:
+
+- provider route identity fields
+- stable installation, connection, and route IDs
+- management API shapes
+- UI routing and rendering expectations
+- gateway behavior for routing and mention policy
+
+Spritz should not require one specific storage implementation.
+
+The deployment-owned backend should define and create the physical storage.
+In the current production deployment, that means Platform creates the database
+tables through its normal backend migration system. Another deployment could
+store the same logical entities in a different database or service as long as
+it satisfies the same Spritz-facing contract.
+
+The entity names in this document are canonical logical names. The SQL below
+is an illustrative relational implementation shape, not a requirement that
+Spritz core ships or runs these migrations.
 
 ## Naming Decisions
 
@@ -124,7 +156,7 @@ the deployment or to a product-specific extension table.
 ### No core `preset` or `runtime`
 
 Do not put Spritz `preset` or `runtime` fields on the generic installation
-table.
+entity.
 
 Those are Spritz implementation details:
 
@@ -155,16 +187,21 @@ adapter can derive a different key without changing the core schema.
 The provider-specific facts can still be stored as metadata for display,
 debugging, and migration.
 
-## Core Data Model
+## Logical Data Model
+
+The sections below describe logical entities that a deployment must be able to
+read and write. A relational deployment can map them to tables with similar
+names. A non-relational deployment can use another storage layout as long as
+the behavior and uniqueness rules are preserved.
 
 ### `channel_installation`
 
-One row means one external messaging app installation.
+One logical record means one external messaging app installation.
 
 For Slack workspace mode, this is the workspace-level Slack app installation.
 It is not an agent and it is not a Spritz runtime.
 
-Recommended columns:
+A relational implementation might use this shape:
 
 ```sql
 CREATE TABLE channel_installation (
@@ -224,12 +261,13 @@ Example Slack row:
 
 ### `channel_connection`
 
-One row means one internal connection under an external installation.
+One logical record means one internal connection under an external
+installation.
 
 This is where "the Slack workspace is connected to this assistant" should
 start. A workspace can have more than one connection.
 
-Recommended columns:
+A relational implementation might use this shape:
 
 ```sql
 CREATE TABLE channel_connection (
@@ -257,12 +295,13 @@ channel route exists.
 
 ### `spritz_channel_connection`
 
-One row stores Spritz-specific backing data for a generic channel connection.
+One logical record stores Spritz-specific backing data for a generic channel
+connection.
 
-This table is allowed to contain Spritz words because it is no longer part of
-the provider-agnostic core.
+This entity is allowed to contain Spritz words because it is no longer part of
+the provider-agnostic core model.
 
-Recommended columns:
+A relational implementation might use this shape:
 
 ```sql
 CREATE TABLE spritz_channel_connection (
@@ -282,17 +321,18 @@ CREATE TABLE spritz_channel_connection (
 );
 ```
 
-This is the right home for the fields that currently describe Spritz
-provisioning and runtime binding.
+This is the right logical home for the fields that currently describe Spritz
+provisioning and runtime binding. A deployment can store those fields in a
+separate table, a nested document, or another equivalent persistence shape.
 
 ### `channel_route`
 
-One row means one external channel has explicit routing behavior.
+One logical record means one external channel has explicit routing behavior.
 
 For Slack, this maps a Slack channel ID to one connection and one mention
 policy.
 
-Recommended columns:
+A relational implementation might use this shape:
 
 ```sql
 CREATE TABLE channel_route (
@@ -416,8 +456,8 @@ The route upsert body can stay generic:
 ```
 
 Provider-specific validation should happen server-side. For example, Slack
-channel ID validation belongs to the Slack provider adapter or backend service,
-not to a generic UI component.
+channel ID validation belongs to the Slack provider adapter or deployment
+backend service, not to a generic UI component.
 
 ## Ownership And Authorization
 
@@ -433,13 +473,13 @@ Each deployment still needs to answer:
 Those checks should be enforced by the deployment's normal authorization
 system and surfaced to Spritz as server-driven action availability.
 
-The generic channel tables only need stable IDs and enough route state to
+The generic channel model only needs stable IDs and enough route state to
 resolve provider events.
 
 ## Migration From The Current Shape
 
-The existing combined installation row can migrate into the split model in
-four steps.
+The existing combined installation row can migrate into the split logical model
+in four steps.
 
 1. Create one `channel_installation` row for each existing external route.
    The current provider route fields map into `provider`, `principal_id`, and
@@ -453,9 +493,9 @@ four steps.
    Each current `channelPolicies[]` entry becomes a route row with
    `require_mention`.
 
-During the migration window, the backend can keep serving the old session
-exchange response shape by reading from the new tables and projecting the
-legacy response.
+During the migration window, the deployment backend can keep serving the old
+session exchange response shape by reading from the new storage and projecting
+the legacy response.
 
 ## Validation
 
@@ -471,8 +511,8 @@ Minimum validation for this model:
 - reconnect updates provider auth without rewriting Spritz runtime state
 - runtime replacement updates `spritz_channel_connection` without rewriting
   provider installation identity
-- Discord or Teams can add provider adapters without changing the core table
-  names
+- Discord or Teams can add provider adapters without changing the core logical
+  model
 
 ## Pinned Decisions
 
@@ -482,6 +522,8 @@ Minimum validation for this model:
   and channel routes as separate concepts.
 - Do not add core `targetType`, `preset`, or `runtime` fields.
 - Do not require `scopeType` in the core uniqueness key.
+- Keep Spritz storage-agnostic; deployment backends create and own the
+  physical storage.
 - Use one explicit channel route per external channel in v1.
 - Treat no-mention behavior as channel route policy, not as Slack install
   mode.

--- a/docs/2026-04-24-channel-installation-data-model.md
+++ b/docs/2026-04-24-channel-installation-data-model.md
@@ -1,0 +1,487 @@
+---
+date: 2026-04-24
+author: Onur Solmaz <onur@textcortex.com>
+title: Channel Installation Data Model
+tags: [spritz, channel-gateway, install, data-model, slack, discord, teams, architecture]
+---
+
+## Overview
+
+This document defines the long-term data model for shared channel
+installations.
+
+The immediate use case is Slack workspace installs where one workspace can
+have one or more Spritz-backed connections, and selected channels can be
+configured with `requireMention: false`.
+
+The model is intentionally not Slack-specific or deployment-specific. Slack is
+the first provider. Discord, Microsoft Teams, and other channel
+providers should fit the same shape without adding provider-specific core
+tables.
+
+Related docs:
+
+- [Channel Install Target Selection Architecture](2026-04-17-channel-install-target-selection-architecture.md)
+- [Channel Install Ownership and Management Architecture](2026-04-17-channel-install-ownership-and-management-architecture.md)
+- [Shared Channel Concierge Lifecycle Architecture](2026-03-31-shared-channel-concierge-lifecycle-architecture.md)
+- [Shared App Tenant Routing Architecture](2026-03-23-shared-app-tenant-routing-architecture.md)
+
+## Plain Language
+
+A Slack workspace install is not the same thing as a Spritz agent.
+
+The workspace install says, "this Slack workspace has installed this shared
+app." A connection under that install says, "messages for this workspace can go
+to this internal assistant." A channel route says, "this Slack channel should
+use this connection, with this mention policy."
+
+That split lets one Slack workspace have multiple internal connections without
+duplicating the provider install or mixing Slack OAuth data with Spritz runtime
+state.
+
+## Problem
+
+The current shape treats a provider installation, an internal target, runtime
+binding state, and mutable channel policy as one record.
+
+That works for the first narrow case:
+
+- one shared Slack app
+- one Slack workspace
+- one backing concierge
+- one workspace-level mention behavior
+
+It becomes awkward as soon as any of these change:
+
+- one Slack workspace has more than one backing assistant
+- a channel should route without requiring a bot mention
+- a channel should route to a different assistant from the workspace default
+- the same provider install needs to reconnect without changing its internal
+  target
+- Spritz-specific runtime state needs to change without changing provider
+  install identity
+- a future provider such as Discord or Teams needs the same installation model
+
+The data model needs to separate those concepts now so the UI and routing
+contract do not keep growing one-off fields.
+
+## Goals
+
+- Model provider installations independently from internal assistant
+  connections.
+- Support one or more connections under one external workspace install.
+- Support per-channel routing and mention policy.
+- Keep the core tables provider-agnostic.
+- Keep Spritz runtime fields out of the generic channel-installation table.
+- Keep the URL and API model stable by using internal installation and
+  connection IDs.
+- Avoid deployment-specific names in the core channel schema.
+
+## Non-Goals
+
+- Redesigning provider OAuth.
+- Defining provider-specific UI copy.
+- Moving all deployment-owned authorization into Spritz.
+- Making Spritz understand deployment-specific target types such as agents,
+  teams, organizations, or accounts.
+- Supporting multiple active connections for the same external channel in v1.
+
+## Naming Decisions
+
+### `provider`
+
+Use `provider` inside the channel-installation domain.
+
+For Slack, the value is:
+
+```text
+slack
+```
+
+This is already how the gateway and backend contracts identify Slack. In this
+domain, `provider` means the external messaging provider, not an LLM provider
+or an auth provider.
+
+If an API surface needs extra clarity, it may describe the field as
+"messaging provider" or "channel provider" in documentation. The database
+column can still be `provider` because the table name gives the field enough
+context.
+
+Expected values:
+
+- `slack`
+- `discord`
+- `msteams`
+
+### No core `targetType`
+
+Do not add `targetType` to the core channel schema.
+
+The core channel system does not need to know whether the internal target is
+an agent, workflow, team assistant, or future product concept. That belongs to
+the deployment or to a product-specific extension table.
+
+### No core `preset` or `runtime`
+
+Do not put Spritz `preset` or `runtime` fields on the generic installation
+table.
+
+Those are Spritz implementation details:
+
+- `preset` describes how Spritz creates or resolves the backing instance
+- `runtime` describes the current live Spritz instance
+
+They should live in a Spritz-specific extension table attached to a generic
+channel connection.
+
+### Avoid `scopeType` in the core key
+
+The core model should not require a separate `scopeType` column as part of
+the installation identity.
+
+Different providers expose different install surfaces:
+
+- Slack workspace
+- Slack enterprise grid
+- Discord guild
+- Teams tenant
+- Teams team
+
+Instead of forcing those into a shared enum, each provider adapter should
+produce one stable `externalInstallationKey` for routing. For Slack workspace
+installs, that key can be derived from the Slack team ID. A future Teams
+adapter can derive a different key without changing the core schema.
+
+The provider-specific facts can still be stored as metadata for display,
+debugging, and migration.
+
+## Core Data Model
+
+### `channel_installation`
+
+One row means one external messaging app installation.
+
+For Slack workspace mode, this is the workspace-level Slack app installation.
+It is not an agent and it is not a Spritz runtime.
+
+Recommended columns:
+
+```sql
+CREATE TABLE channel_installation (
+    id                         VARCHAR(32) PRIMARY KEY,
+    provider                   VARCHAR(32) NOT NULL,
+    principal_id               VARCHAR(128) NOT NULL,
+    external_installation_key  VARCHAR(256) NOT NULL,
+    external_tenant_id         VARCHAR(256) NULL,
+    external_display_name      VARCHAR(512) NULL,
+    provider_auth_ref          VARCHAR(512) NULL,
+    status                     VARCHAR(32) NOT NULL,
+    provider_metadata          JSON NULL,
+    installed_by_external_id   VARCHAR(256) NULL,
+    created_at                 DATETIME NOT NULL,
+    updated_at                 DATETIME NOT NULL,
+    deleted_at                 DATETIME NULL,
+
+    UNIQUE KEY uq_channel_installation_route (
+        provider,
+        principal_id,
+        external_installation_key
+    )
+);
+```
+
+Field meanings:
+
+- `id` is the stable product/API ID, for example `ci_...`.
+- `provider` is the messaging provider, for example `slack`.
+- `principal_id` identifies which shared app or gateway principal owns this
+  install route.
+- `external_installation_key` is a deterministic provider-adapter key for the
+  external install surface.
+- `external_tenant_id` is a searchable/displayable provider tenant ID when
+  one exists, such as a Slack team ID.
+- `external_display_name` caches the workspace, guild, team, or tenant name.
+- `provider_auth_ref` points to provider OAuth credentials or another durable
+  auth reference.
+- `provider_metadata` stores provider-specific facts that should not become
+  core columns.
+- `installed_by_external_id` stores the provider user ID that performed the
+  latest install or reconnect when available.
+
+Example Slack row:
+
+```json
+{
+  "id": "ci_01k...",
+  "provider": "slack",
+  "principalId": "slack-gateway-staging",
+  "externalInstallationKey": "workspace:T021GRS5F4P",
+  "externalTenantId": "T021GRS5F4P",
+  "externalDisplayName": "Example Workspace",
+  "status": "active"
+}
+```
+
+### `channel_connection`
+
+One row means one internal connection under an external installation.
+
+This is where "the Slack workspace is connected to this assistant" should
+start. A workspace can have more than one connection.
+
+Recommended columns:
+
+```sql
+CREATE TABLE channel_connection (
+    id                  VARCHAR(32) PRIMARY KEY,
+    installation_id     VARCHAR(32) NOT NULL,
+    display_name        VARCHAR(512) NULL,
+    is_default          BOOLEAN NOT NULL DEFAULT FALSE,
+    status              VARCHAR(32) NOT NULL,
+    created_at          DATETIME NOT NULL,
+    updated_at          DATETIME NOT NULL,
+    deleted_at          DATETIME NULL,
+
+    FOREIGN KEY (installation_id) REFERENCES channel_installation(id)
+);
+```
+
+Recommended constraints:
+
+- one active default connection per installation
+- soft-deleted connections do not count against the active default constraint
+- each connection belongs to exactly one installation
+
+The default connection is used for workspace-level behavior when no explicit
+channel route exists.
+
+### `spritz_channel_connection`
+
+One row stores Spritz-specific backing data for a generic channel connection.
+
+This table is allowed to contain Spritz words because it is no longer part of
+the provider-agnostic core.
+
+Recommended columns:
+
+```sql
+CREATE TABLE spritz_channel_connection (
+    connection_id              VARCHAR(32) PRIMARY KEY,
+    preset_id                  VARCHAR(128) NOT NULL,
+    preset_inputs              JSON NULL,
+    preset_inputs_hash         VARCHAR(128) NULL,
+    spritz_binding_key         VARCHAR(256) NULL,
+    spritz_instance_id         VARCHAR(256) NULL,
+    namespace                  VARCHAR(256) NULL,
+    applied_revision           BIGINT NOT NULL DEFAULT 0,
+    runtime_binding_assigned_at DATETIME NULL,
+    created_at                 DATETIME NOT NULL,
+    updated_at                 DATETIME NOT NULL,
+
+    FOREIGN KEY (connection_id) REFERENCES channel_connection(id)
+);
+```
+
+This is the right home for the fields that currently describe Spritz
+provisioning and runtime binding.
+
+### `channel_route`
+
+One row means one external channel has explicit routing behavior.
+
+For Slack, this maps a Slack channel ID to one connection and one mention
+policy.
+
+Recommended columns:
+
+```sql
+CREATE TABLE channel_route (
+    id                   VARCHAR(32) PRIMARY KEY,
+    installation_id      VARCHAR(32) NOT NULL,
+    connection_id        VARCHAR(32) NOT NULL,
+    external_channel_id  VARCHAR(256) NOT NULL,
+    external_channel_name VARCHAR(512) NULL,
+    require_mention      BOOLEAN NOT NULL DEFAULT TRUE,
+    enabled              BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at           DATETIME NOT NULL,
+    updated_at           DATETIME NOT NULL,
+    deleted_at           DATETIME NULL,
+
+    FOREIGN KEY (installation_id) REFERENCES channel_installation(id),
+    FOREIGN KEY (connection_id) REFERENCES channel_connection(id),
+
+    UNIQUE KEY uq_channel_route_channel (
+        installation_id,
+        external_channel_id
+    )
+);
+```
+
+The unique route constraint is intentional. In v1, one external channel should
+route to one active connection for a given provider installation. That avoids
+two assistants responding to the same unmentioned message.
+
+The implementation must also enforce that `channel_route.connection_id`
+belongs to the same `installation_id` as the route. That can be a composite
+foreign key, a generated constraint, or a service-layer invariant depending on
+the database and migration path.
+
+If the product later needs fan-out or multi-agent rooms, that should be a new
+explicit routing mode, not an accidental side effect of duplicate route rows.
+
+## Routing Behavior
+
+Incoming provider events should resolve in this order:
+
+1. The provider gateway computes the provider route:
+   - `provider`
+   - `principal_id`
+   - `external_installation_key`
+2. The backend resolves the matching `channel_installation`.
+3. If the event has an external channel ID, the backend looks for an enabled
+   `channel_route`.
+4. If a route exists, the event uses that route's `connection_id` and
+   `require_mention`.
+5. If no route exists, the event uses the installation's default connection
+   and requires a bot mention.
+6. If no matching route and no default connection exist, the event is ignored
+   or returned as not configured.
+
+For the no-mention Slack use case:
+
+- the Slack app is still installed in workspace mode
+- the route row points the selected Slack channel to the desired connection
+- `require_mention` is set to `false`
+- only that channel wakes the assistant without a bot mention
+
+That keeps channel-level behavior separate from Slack installation mode.
+
+## UI Model
+
+The UI should be installation-scoped first, then connection-scoped.
+
+Recommended routes:
+
+```text
+/settings/channels/installations/:installationId
+/settings/channels/installations/:installationId/connections/:connectionId
+```
+
+The installation page should show:
+
+- provider
+- external workspace, guild, team, or tenant name
+- install status
+- reconnect or disconnect actions
+- all connections under the installation
+
+The connection page should show:
+
+- display name
+- backing Spritz target summary when the connection is Spritz-backed
+- whether it is the default connection
+- explicit channel routes
+- per-channel `requireMention` policy
+
+Slack-specific labels are fine in the UI when the provider is Slack. The route
+shape should still use stable internal IDs instead of Slack team IDs or agent
+IDs.
+
+## API Shape
+
+The management API should expose internal IDs as the stable product surface.
+
+Examples:
+
+```http
+GET /channel/installations
+GET /channel/installations/ci_123
+GET /channel/installations/ci_123/connections
+POST /channel/installations/ci_123/connections
+PATCH /channel/connections/cc_456
+GET /channel/connections/cc_456/routes
+PUT /channel/connections/cc_456/routes/C0ANJGDB4Q5
+DELETE /channel/routes/cr_789
+```
+
+The route upsert body can stay generic:
+
+```json
+{
+  "externalChannelId": "C0ANJGDB4Q5",
+  "externalChannelName": "zeno-staging",
+  "requireMention": false,
+  "enabled": true
+}
+```
+
+Provider-specific validation should happen server-side. For example, Slack
+channel ID validation belongs to the Slack provider adapter or backend service,
+not to a generic UI component.
+
+## Ownership And Authorization
+
+The channel schema should not encode a product-specific ownership taxonomy.
+
+Each deployment still needs to answer:
+
+- who may see an installation
+- who may reconnect or disconnect it
+- who may create a connection under it
+- who may change channel routes and mention policy
+
+Those checks should be enforced by the deployment's normal authorization
+system and surfaced to Spritz as server-driven action availability.
+
+The generic channel tables only need stable IDs and enough route state to
+resolve provider events.
+
+## Migration From The Current Shape
+
+The existing combined installation row can migrate into the split model in
+four steps.
+
+1. Create one `channel_installation` row for each existing external route.
+   The current provider route fields map into `provider`, `principal_id`, and
+   `external_installation_key`.
+2. Create one `channel_connection` row for each existing backing concierge.
+   Existing single-connection installs should mark that row as default.
+3. Move Spritz-specific fields into `spritz_channel_connection`.
+   This includes preset inputs, binding key, instance ID, namespace, applied
+   revision, and runtime binding timestamps.
+4. Expand existing channel-policy config into `channel_route` rows.
+   Each current `channelPolicies[]` entry becomes a route row with
+   `require_mention`.
+
+During the migration window, the backend can keep serving the old session
+exchange response shape by reading from the new tables and projecting the
+legacy response.
+
+## Validation
+
+Minimum validation for this model:
+
+- a Slack workspace install creates one `channel_installation`
+- the same Slack workspace can have multiple `channel_connection` rows
+- exactly one active default connection is allowed per installation
+- a channel route points to exactly one connection
+- a channel route with `require_mention = false` relays unmentioned messages
+  for that channel
+- channels without an explicit route keep requiring a bot mention
+- reconnect updates provider auth without rewriting Spritz runtime state
+- runtime replacement updates `spritz_channel_connection` without rewriting
+  provider installation identity
+- Discord or Teams can add provider adapters without changing the core table
+  names
+
+## Pinned Decisions
+
+- Keep `provider`; for Slack the value is `slack`.
+- Use internal IDs for URLs and management APIs.
+- Model provider installation, internal connection, Spritz runtime backing,
+  and channel routes as separate concepts.
+- Do not add core `targetType`, `preset`, or `runtime` fields.
+- Do not require `scopeType` in the core uniqueness key.
+- Use one explicit channel route per external channel in v1.
+- Treat no-mention behavior as channel route policy, not as Slack install
+  mode.

--- a/docs/2026-04-24-channel-installation-data-model.md
+++ b/docs/2026-04-24-channel-installation-data-model.md
@@ -358,7 +358,7 @@ CREATE TABLE spritz_channel_connection (
     spritz_binding_key         VARCHAR(256) NULL,
     spritz_instance_id         VARCHAR(256) NULL,
     namespace                  VARCHAR(256) NULL,
-    applied_revision           BIGINT NOT NULL DEFAULT 0,
+    applied_revision           VARCHAR(255) NULL,
     runtime_binding_assigned_at DATETIME NULL,
     created_at                 DATETIME NOT NULL,
     updated_at                 DATETIME NOT NULL,
@@ -387,7 +387,7 @@ Column justifications:
 | `spritz_binding_key` | keep | Stable logical binding separate from the current live runtime. Useful when runtimes are replaced. |
 | `spritz_instance_id` | keep | Current live runtime reference. It is only a cached binding and must be validated before routing. |
 | `namespace` | optional | Keep only when runtime lookup is namespace-scoped. If runtime references become globally unique, this can go away. |
-| `applied_revision` | keep | Lets controllers know whether runtime config has caught up with saved connection/route changes. |
+| `applied_revision` | keep | Stores the runtime/controller revision string that is live for the connection, when one has been observed. |
 | `runtime_binding_assigned_at` | keep | Helps debug stale runtime bindings and recovery behavior. |
 | `created_at` | keep | Standard audit and lifecycle field. |
 | `updated_at` | keep | Standard lifecycle field for management and debugging. |
@@ -656,6 +656,32 @@ The route upsert body can stay generic:
 Provider-specific validation should happen server-side. For example, Slack
 channel ID validation belongs to the Slack provider adapter or deployment
 backend service, not to a generic UI component.
+
+The current v1 compatibility API can expose the same data through the existing
+internal channel-gateway surface while the product API settles:
+
+```text
+POST /internal/v2/spritz/channel-installations/list
+POST /internal/v2/spritz/channel-installations/routes/update
+```
+
+The list response should include `installation.id`, `connections[].id`, and
+`connections[].routes[]` while preserving the legacy `installationConfig`
+projection for older gateways. The route update request replaces the route
+set for one connection:
+
+```json
+{
+  "installationId": "ci_123",
+  "connectionId": "cc_456",
+  "channelPolicies": [
+    {
+      "externalChannelId": "C0ANJGDB4Q5",
+      "requireMention": false
+    }
+  ]
+}
+```
 
 The generic settings UI should not know:
 

--- a/docs/2026-04-24-slack-install-modes.md
+++ b/docs/2026-04-24-slack-install-modes.md
@@ -1,0 +1,187 @@
+---
+date: 2026-04-24
+author: Onur Solmaz <onur@textcortex.com>
+title: Slack Install Modes
+tags: [slack, oauth, install, channels, workspace, enterprise]
+---
+
+## Overview
+
+Slack apps are normally installed into a workspace or an Enterprise Grid
+organization.
+
+People sometimes say "channel install" when they mean one of two different
+things:
+
+- the OAuth flow included an incoming webhook channel picker
+- the app is already installed in the workspace and is then added to, invited
+  into, or configured for a specific channel
+
+Those are different from a normal workspace app install.
+
+Slack's core install model is OAuth-based. The install grants tokens and scopes
+to the app for a workspace or organization. Channel behavior is usually a later
+authorization, membership, routing, or configuration layer.
+
+Sources:
+
+- [Installing with OAuth](https://docs.slack.dev/authentication/installing-with-oauth)
+- [Developing apps for Enterprise orgs](https://docs.slack.dev/enterprise/developing-for-enterprise-orgs)
+- [Incoming webhook scope](https://docs.slack.dev/reference/scopes/incoming-webhook)
+- [Sending messages using incoming webhooks](https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks)
+- [conversations.join](https://docs.slack.dev/reference/methods/conversations.join/)
+
+## Short Version
+
+Use "workspace install" for the normal Slack app OAuth install.
+
+Use "org-wide install" for Enterprise Grid installs.
+
+Use "incoming webhook channel selection" when OAuth asks the user to choose one
+channel and returns a webhook URL for that channel.
+
+Use "channel membership" or "channel configuration" when an already-installed
+app is enabled for a channel.
+
+Avoid using "channel install" by itself unless the product defines exactly what
+it means.
+
+## Modes
+
+| Mode | What Slack Creates | Main Scope | Use It For | Important Detail |
+| --- | --- | --- | --- | --- |
+| Workspace OAuth install | Bot token, app installation, optional user token | One workspace | Most Slack apps and bots | The app is installed in the workspace, not automatically in every channel. |
+| Enterprise org-wide install | Org-level installation and enterprise identity | Enterprise Grid org, then selected workspaces | Enterprise-wide apps and admin-managed deployments | The OAuth result can be `is_enterprise_install=true`; apps still need to reason about workspace grants. |
+| Incoming webhook channel selection | Incoming webhook URL tied to one selected channel | One destination channel for webhook posting | Simple notification-style posting | This is the closest Slack-native thing to a channel install, but it is only for the webhook destination. |
+| Channel membership | App/bot joins or is invited to a channel | One Slack conversation at a time | Reading, replying, or participating in a channel | This happens after workspace install. It is not a separate OAuth install. |
+| User authorization | User token under `authed_user` | One installing or authorizing user | Acting on behalf of a user or reading user-accessible data | User scopes are separate from bot scopes. Sign in with Slack scopes must use a separate OAuth flow. |
+| Single-workspace app install | App installed only into its development workspace | One fixed workspace | Internal tools and development | This is a distribution choice, not a different runtime model. |
+| Distributed app install | OAuth install into many customer workspaces | Many workspace installs, one per customer workspace | Marketplace or customer-installed apps | Store each installation separately by workspace or enterprise identity. |
+
+## Workspace OAuth Install
+
+This is the standard Slack app install.
+
+The user approves an OAuth URL. Slack redirects back to the app. The app
+exchanges the OAuth code and receives an access response with workspace
+identity, bot token details, scopes, and optionally user token details.
+
+The workspace identity is normally the Slack `team.id`.
+
+Use this when the app needs to:
+
+- receive workspace events
+- post as the app's bot user
+- respond to mentions or messages
+- expose slash commands or app home
+- serve many workspaces through the same distributed app
+
+A workspace install does not mean the bot can act in every channel. Private
+channels still require invitation. Public channel access depends on scopes,
+membership, and Slack API behavior.
+
+## Enterprise Org-Wide Install
+
+Enterprise Grid supports org-ready apps and organization-level installation.
+
+This is different from installing the app into one workspace inside an
+Enterprise Grid organization.
+
+In an org-wide install, the app receives enterprise identity, and Slack's OAuth
+install data can indicate that this is an enterprise install. The app should
+store and fetch this installation by enterprise identity when appropriate.
+
+An org-wide install may still require the admin to add or grant the app to
+specific workspaces in the organization.
+
+Use this when the app is intended to operate across an Enterprise Grid
+organization or use Enterprise-level capabilities.
+
+## Incoming Webhook Channel Selection
+
+If an app requests the `incoming-webhook` scope, Slack shows a channel picker
+during OAuth.
+
+The OAuth access response includes an `incoming_webhook` object with:
+
+- `channel`
+- `channel_id`
+- `configuration_url`
+- `url`
+
+That webhook URL posts to the selected channel.
+
+This is channel-specific, but it is not a general channel-scoped app install.
+It only grants an incoming webhook destination.
+
+Use this for notification-style apps that only need to post to one selected
+channel.
+
+## Channel Membership Or Channel Configuration
+
+Many products say "install to a channel" when the real behavior is:
+
+1. the app is installed into the workspace
+2. the bot is invited to a channel or joins a public channel
+3. the product stores a channel preference, route, allowlist, or subscription
+
+This is not a separate Slack OAuth install.
+
+It is a product-level configuration on top of a workspace install.
+
+Use this when the app needs to operate only in selected channels.
+
+Good names for this are:
+
+- channel configuration
+- channel binding
+- channel allowlist
+- add app to channel
+- enable app in channel
+
+## User Authorization
+
+Slack OAuth can return user-level authorization under `authed_user` when the app
+requests `user_scope`.
+
+This is not the same thing as installing the app into a channel.
+
+Use user authorization when the app must act on behalf of a specific user or
+read data according to that user's access.
+
+Slack treats Sign in with Slack scopes separately from normal Slack app scopes.
+Do not mix those scopes into the same OAuth flow.
+
+## Recommended Vocabulary
+
+Use Slack-native words when talking about Slack behavior:
+
+- workspace install
+- org-wide install
+- incoming webhook channel selection
+- channel membership
+- channel configuration
+- user authorization
+
+Use product-specific words only after defining them.
+
+For example:
+
+- "Workspace mode" can mean one app install per Slack workspace.
+- "Channel mode" can mean one workspace install plus a selected channel route.
+
+But Slack itself does not treat those as symmetric install modes.
+
+## Spritz Mapping
+
+For Spritz shared Slack apps, the Slack side is a workspace OAuth install.
+
+Spritz then maps the Slack workspace identity to a deployment-owned target and a
+live concierge runtime.
+
+That means Spritz's shared-channel install flow is built on top of Slack
+workspace install, not instead of it.
+
+If Spritz later adds channel-specific settings, those should be modeled as
+installation configuration or channel routing rules, not as a second Slack app
+install.

--- a/integrations/slack-gateway/backend_client.go
+++ b/integrations/slack-gateway/backend_client.go
@@ -238,12 +238,15 @@ func isACPUnavailableError(err error) bool {
 	return strings.Contains(strings.ToLower(statusErr.body), "acp unavailable")
 }
 
-func (g *slackGateway) exchangeChannelSession(ctx context.Context, teamID string, forceRefresh bool) (channelSession, error) {
+func (g *slackGateway) exchangeChannelSession(ctx context.Context, teamID, channelID string, forceRefresh bool) (channelSession, error) {
 	body := map[string]any{
 		"principalId":       g.cfg.PrincipalID,
 		"provider":          slackProvider,
 		"externalScopeType": slackWorkspaceScope,
 		"externalTenantId":  strings.TrimSpace(teamID),
+	}
+	if strings.TrimSpace(channelID) != "" {
+		body["externalChannelId"] = strings.TrimSpace(channelID)
 	}
 	if forceRefresh {
 		body["forceRefresh"] = true

--- a/integrations/slack-gateway/backend_client.go
+++ b/integrations/slack-gateway/backend_client.go
@@ -89,8 +89,8 @@ type backendManagedInstallationRoute struct {
 type backendManagedChannelRoute struct {
 	ID                string `json:"id"`
 	ExternalChannelID string `json:"externalChannelId"`
-	RequireMention    bool   `json:"requireMention"`
-	Enabled           bool   `json:"enabled"`
+	RequireMention    *bool  `json:"requireMention"`
+	Enabled           *bool  `json:"enabled"`
 }
 
 type backendManagedConnection struct {

--- a/integrations/slack-gateway/backend_client.go
+++ b/integrations/slack-gateway/backend_client.go
@@ -33,18 +33,20 @@ func (err *httpStatusError) Error() string {
 type backendChannelSessionResponse struct {
 	Status  string `json:"status"`
 	Session struct {
-		AccessToken  string            `json:"accessToken"`
-		ExpiresAt    string            `json:"expiresAt"`
-		OwnerAuthID  string            `json:"ownerAuthId"`
-		Namespace    string            `json:"namespace"`
-		InstanceID   string            `json:"instanceId"`
-		ProviderAuth slackInstallation `json:"providerAuth"`
+		AccessToken        string             `json:"accessToken"`
+		ExpiresAt          string             `json:"expiresAt"`
+		OwnerAuthID        string             `json:"ownerAuthId"`
+		Namespace          string             `json:"namespace"`
+		InstanceID         string             `json:"instanceId"`
+		ProviderAuth       slackInstallation  `json:"providerAuth"`
+		InstallationConfig installationConfig `json:"installationConfig"`
 	} `json:"session"`
 }
 
 type backendChannelSessionUnavailableResponse struct {
-	Status       string            `json:"status"`
-	ProviderAuth slackInstallation `json:"providerAuth"`
+	Status             string             `json:"status"`
+	ProviderAuth       slackInstallation  `json:"providerAuth"`
+	InstallationConfig installationConfig `json:"installationConfig"`
 }
 
 type backendInstallationUpsertResponse struct {
@@ -84,13 +86,31 @@ type backendManagedInstallationRoute struct {
 	ExternalTenantID  string `json:"externalTenantId"`
 }
 
+type backendManagedChannelRoute struct {
+	ID                string `json:"id"`
+	ExternalChannelID string `json:"externalChannelId"`
+	RequireMention    bool   `json:"requireMention"`
+	Enabled           bool   `json:"enabled"`
+}
+
+type backendManagedConnection struct {
+	ID          string                       `json:"id"`
+	DisplayName string                       `json:"displayName,omitempty"`
+	IsDefault   bool                         `json:"isDefault"`
+	State       string                       `json:"state"`
+	Routes      []backendManagedChannelRoute `json:"routes"`
+}
+
 type backendManagedInstallation struct {
-	Route          backendManagedInstallationRoute   `json:"route"`
-	State          string                            `json:"state"`
-	CurrentTarget  *backendInstallationTargetSummary `json:"currentTarget,omitempty"`
-	AllowedActions []string                          `json:"allowedActions"`
-	ProblemCode    string                            `json:"problemCode,omitempty"`
-	DisconnectedAt string                            `json:"disconnectedAt,omitempty"`
+	ID                 string                            `json:"id"`
+	Route              backendManagedInstallationRoute   `json:"route"`
+	State              string                            `json:"state"`
+	CurrentTarget      *backendInstallationTargetSummary `json:"currentTarget,omitempty"`
+	InstallationConfig installationConfig                `json:"installationConfig"`
+	Connections        []backendManagedConnection        `json:"connections,omitempty"`
+	AllowedActions     []string                          `json:"allowedActions"`
+	ProblemCode        string                            `json:"problemCode,omitempty"`
+	DisconnectedAt     string                            `json:"disconnectedAt,omitempty"`
 }
 
 type backendManagedInstallationListResponse struct {
@@ -139,16 +159,19 @@ type spritzBootstrapResponse struct {
 }
 
 type channelSession struct {
-	AccessToken  string
-	OwnerAuthID  string
-	Namespace    string
-	InstanceID   string
-	ProviderAuth slackInstallation
+	AccessToken        string
+	OwnerAuthID        string
+	Namespace          string
+	InstanceID         string
+	ProviderAuth       slackInstallation
+	InstallationConfig installationConfig
 }
 
 type channelSessionUnavailableError struct {
-	providerAuth slackInstallation
-	cause        *httpStatusError
+	providerAuth       slackInstallation
+	installationConfig installationConfig
+	hasPolicySnapshot  bool
+	cause              *httpStatusError
 }
 
 func (err *channelSessionUnavailableError) Error() string {
@@ -177,6 +200,20 @@ func channelSessionUnavailableProviderAuth(err error) (slackInstallation, bool) 
 		return slackInstallation{}, false
 	}
 	return unavailableErr.providerAuth, true
+}
+
+func channelSessionUnavailablePolicySnapshot(err error) (installationPolicySnapshot, bool) {
+	var unavailableErr *channelSessionUnavailableError
+	if !errors.As(err, &unavailableErr) {
+		return installationPolicySnapshot{}, false
+	}
+	if !unavailableErr.hasPolicySnapshot {
+		return installationPolicySnapshot{}, false
+	}
+	return installationPolicySnapshot{
+		config:    unavailableErr.installationConfig,
+		botUserID: strings.TrimSpace(unavailableErr.providerAuth.BotUserID),
+	}, true
 }
 
 func isSpritzRuntimeMissingError(err error) bool {
@@ -218,8 +255,10 @@ func (g *slackGateway) exchangeChannelSession(ctx context.Context, teamID string
 			var unavailablePayload backendChannelSessionUnavailableResponse
 			if json.Unmarshal([]byte(statusErr.body), &unavailablePayload) == nil && strings.TrimSpace(unavailablePayload.Status) == "unavailable" {
 				return channelSession{}, &channelSessionUnavailableError{
-					providerAuth: unavailablePayload.ProviderAuth,
-					cause:        statusErr,
+					providerAuth:       unavailablePayload.ProviderAuth,
+					installationConfig: unavailablePayload.InstallationConfig,
+					hasPolicySnapshot:  true,
+					cause:              statusErr,
 				}
 			}
 			return channelSession{}, &channelSessionUnavailableError{cause: statusErr}
@@ -230,11 +269,12 @@ func (g *slackGateway) exchangeChannelSession(ctx context.Context, teamID string
 		return channelSession{}, fmt.Errorf("channel session was not resolved")
 	}
 	return channelSession{
-		AccessToken:  payload.Session.AccessToken,
-		OwnerAuthID:  payload.Session.OwnerAuthID,
-		Namespace:    payload.Session.Namespace,
-		InstanceID:   payload.Session.InstanceID,
-		ProviderAuth: payload.Session.ProviderAuth,
+		AccessToken:        payload.Session.AccessToken,
+		OwnerAuthID:        payload.Session.OwnerAuthID,
+		Namespace:          payload.Session.Namespace,
+		InstanceID:         payload.Session.InstanceID,
+		ProviderAuth:       payload.Session.ProviderAuth,
+		InstallationConfig: payload.Session.InstallationConfig,
 	}, nil
 }
 
@@ -315,6 +355,44 @@ func (g *slackGateway) updateManagedInstallationTarget(ctx context.Context, call
 	}
 	if payload.Status != "resolved" {
 		return fmt.Errorf("channel installation target was not updated")
+	}
+	return nil
+}
+
+func (g *slackGateway) updateManagedInstallationConfig(ctx context.Context, callerAuthID, teamID, requestID string, installationConfig installationConfig) error {
+	body := map[string]any{
+		"callerAuthId":       strings.TrimSpace(callerAuthID),
+		"principalId":        g.cfg.PrincipalID,
+		"provider":           slackProvider,
+		"externalScopeType":  slackWorkspaceScope,
+		"externalTenantId":   strings.TrimSpace(teamID),
+		"installationConfig": installationConfig,
+		"requestId":          strings.TrimSpace(requestID),
+	}
+	var payload backendManagedInstallationUpdateResponse
+	if err := g.postBackendFastAPIJSON(ctx, "/internal/v2/spritz/channel-installations/config/update", body, &payload); err != nil {
+		return err
+	}
+	if payload.Status != "resolved" {
+		return fmt.Errorf("channel installation config was not updated")
+	}
+	return nil
+}
+
+func (g *slackGateway) updateManagedInstallationRoutes(ctx context.Context, callerAuthID, installationID, connectionID, requestID string, channelPolicies []installationChannelPolicy) error {
+	body := map[string]any{
+		"callerAuthId":    strings.TrimSpace(callerAuthID),
+		"installationId":  strings.TrimSpace(installationID),
+		"connectionId":    strings.TrimSpace(connectionID),
+		"channelPolicies": channelPolicies,
+		"requestId":       strings.TrimSpace(requestID),
+	}
+	var payload backendManagedInstallationUpdateResponse
+	if err := g.postBackendFastAPIJSON(ctx, "/internal/v2/spritz/channel-installations/routes/update", body, &payload); err != nil {
+		return err
+	}
+	if payload.Status != "resolved" {
+		return fmt.Errorf("channel installation routes were not updated")
 	}
 	return nil
 }

--- a/integrations/slack-gateway/backend_client_test.go
+++ b/integrations/slack-gateway/backend_client_test.go
@@ -222,6 +222,28 @@ func TestUpdateManagedInstallationConfigPostsExpectedPayload(t *testing.T) {
 	}
 }
 
+func TestManagedChannelRoutesDefaultMissingBooleansSafely(t *testing.T) {
+	var connection backendManagedConnection
+	if err := json.Unmarshal(
+		[]byte(`{"id":"cc_1","routes":[{"externalChannelId":"C_default"}]}`),
+		&connection,
+	); err != nil {
+		t.Fatalf("decode connection: %v", err)
+	}
+
+	policies := channelPoliciesFromConnection(connection)
+	if len(policies) != 1 {
+		t.Fatalf("expected route with omitted enabled flag to stay enabled, got %#v", policies)
+	}
+	if policies[0].RequireMention == nil || !*policies[0].RequireMention {
+		t.Fatalf("expected omitted requireMention to default to true, got %#v", policies[0])
+	}
+	rows := channelRouteSettingsRows(connection)
+	if len(rows) != 1 || rows[0].ModeLabel != "Mentions required" {
+		t.Fatalf("expected settings row to render as mention-required, got %#v", rows)
+	}
+}
+
 func TestChannelSessionUnavailablePolicySnapshotRequiresStructuredPayload(t *testing.T) {
 	snapshot, ok := channelSessionUnavailablePolicySnapshot(&channelSessionUnavailableError{
 		cause: &httpStatusError{

--- a/integrations/slack-gateway/backend_client_test.go
+++ b/integrations/slack-gateway/backend_client_test.go
@@ -165,6 +165,94 @@ func TestUpdateManagedInstallationTargetPostsExpectedPayload(t *testing.T) {
 	}
 }
 
+func TestUpdateManagedInstallationConfigPostsExpectedPayload(t *testing.T) {
+	var updatePayload map[string]any
+	fastapi := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/internal/v2/spritz/channel-installations/config/update" {
+			t.Fatalf("unexpected fastapi path %s", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&updatePayload); err != nil {
+			t.Fatalf("decode update payload: %v", err)
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"status":            "resolved",
+			"needsProvisioning": true,
+		})
+	}))
+	defer fastapi.Close()
+
+	gateway := newSlackGateway(config{
+		BackendFastAPIBaseURL: fastapi.URL,
+		BackendInternalToken:  "backend-internal-token",
+		PrincipalID:           "shared-slack-gateway",
+		HTTPTimeout:           5 * time.Second,
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	requireMention := false
+	if err := gateway.updateManagedInstallationConfig(
+		context.Background(),
+		"user-1",
+		"T_workspace_1",
+		"req-manage-config-1",
+		installationConfig{
+			ChannelPolicies: []installationChannelPolicy{
+				{ExternalChannelID: "C_channel_1", RequireMention: &requireMention},
+			},
+		},
+	); err != nil {
+		t.Fatalf("update managed installation config: %v", err)
+	}
+	if updatePayload["callerAuthId"] != "user-1" {
+		t.Fatalf("expected caller auth id to be forwarded, got %#v", updatePayload["callerAuthId"])
+	}
+	if updatePayload["externalTenantId"] != "T_workspace_1" {
+		t.Fatalf("expected team id to be forwarded, got %#v", updatePayload["externalTenantId"])
+	}
+	configPayload, ok := updatePayload["installationConfig"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected installationConfig payload, got %#v", updatePayload["installationConfig"])
+	}
+	policies, ok := configPayload["channelPolicies"].([]any)
+	if !ok || len(policies) != 1 {
+		t.Fatalf("expected one channel policy, got %#v", configPayload["channelPolicies"])
+	}
+	policy, ok := policies[0].(map[string]any)
+	if !ok || policy["externalChannelId"] != "C_channel_1" || policy["requireMention"] != false {
+		t.Fatalf("unexpected channel policy: %#v", policies[0])
+	}
+}
+
+func TestChannelSessionUnavailablePolicySnapshotRequiresStructuredPayload(t *testing.T) {
+	snapshot, ok := channelSessionUnavailablePolicySnapshot(&channelSessionUnavailableError{
+		cause: &httpStatusError{
+			method:     http.MethodPost,
+			endpoint:   "/internal/v1/spritz/channel-sessions/exchange",
+			statusCode: http.StatusServiceUnavailable,
+			body:       "temporarily unavailable",
+		},
+	})
+	if ok {
+		t.Fatalf("expected unstructured 503 to have no policy snapshot, got %#v", snapshot)
+	}
+
+	requireMention := false
+	snapshot, ok = channelSessionUnavailablePolicySnapshot(&channelSessionUnavailableError{
+		providerAuth: slackInstallation{BotUserID: "U_bot"},
+		installationConfig: installationConfig{
+			ChannelPolicies: []installationChannelPolicy{
+				{ExternalChannelID: "C_channel_1", RequireMention: &requireMention},
+			},
+		},
+		hasPolicySnapshot: true,
+	})
+	if !ok {
+		t.Fatalf("expected structured unavailable response to have a policy snapshot")
+	}
+	if snapshot.botUserID != "U_bot" || len(snapshot.config.ChannelPolicies) != 1 {
+		t.Fatalf("unexpected policy snapshot: %#v", snapshot)
+	}
+}
+
 func TestDisconnectManagedInstallationPostsExpectedPayload(t *testing.T) {
 	var disconnectPayload map[string]any
 	fastapi := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/integrations/slack-gateway/channel_settings.go
+++ b/integrations/slack-gateway/channel_settings.go
@@ -486,6 +486,7 @@ func (g *slackGateway) renderChannelSettingsList(w http.ResponseWriter, r *http.
 	for index := range rows {
 		rows[index].SettingsHref = g.channelSettingsConnectionPath(rows[index].InstallationID, rows[index].ConnectionID)
 	}
+	w.Header().Set("Cache-Control", "no-store")
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	_ = channelSettingsListTemplate.Execute(w, channelSettingsPageData{
 		Notice: channelSettingsNoticeFromRequest(r),
@@ -498,6 +499,7 @@ func (g *slackGateway) renderChannelConnectionSettings(w http.ResponseWriter, r 
 	if installation.CurrentTarget != nil {
 		targetName = strings.TrimSpace(installation.CurrentTarget.Profile.Name)
 	}
+	w.Header().Set("Cache-Control", "no-store")
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	_ = channelConnectionSettingsTemplate.Execute(w, channelConnectionSettingsPageData{
 		Notice:         channelSettingsNoticeFromRequest(r),

--- a/integrations/slack-gateway/channel_settings.go
+++ b/integrations/slack-gateway/channel_settings.go
@@ -17,6 +17,7 @@ type channelSettingsNotice struct {
 type channelSettingsListRow struct {
 	InstallationID string
 	ConnectionID   string
+	ConnectionName string
 	TeamID         string
 	State          string
 	TargetName     string
@@ -44,6 +45,16 @@ type channelConnectionSettingsPageData struct {
 	TargetName     string
 	Rows           []channelRouteSettingsRow
 	UpdateAction   string
+	BackHref       string
+}
+
+type channelInstallationSettingsPageData struct {
+	Notice         *channelSettingsNotice
+	InstallationID string
+	TeamID         string
+	State          string
+	TargetName     string
+	Rows           []channelSettingsListRow
 	BackHref       string
 }
 
@@ -140,6 +151,7 @@ var channelSettingsListTemplate = template.Must(template.New("channel-settings-l
           <div>
             <strong>{{ .TeamID }}</strong>
             <div class="meta">{{ .TargetName }}</div>
+            {{ if .ConnectionName }}<div class="meta">{{ .ConnectionName }}</div>{{ end }}
             <div class="meta">{{ .RouteSummary }}</div>
           </div>
           <span class="state">{{ .State }}</span>
@@ -155,6 +167,128 @@ var channelSettingsListTemplate = template.Must(template.New("channel-settings-l
       {{ end }}
       {{ else }}
       <section class="panel empty">No manageable channel installations are connected for this account.</section>
+      {{ end }}
+    </main>
+  </body>
+</html>`))
+
+var channelInstallationSettingsTemplate = template.Must(template.New("channel-installation-settings").Parse(`<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Channel settings</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f7f8fa;
+        --surface: #ffffff;
+        --border: #d7dce3;
+        --text: #17202a;
+        --muted: #627083;
+        --primary: #1f6feb;
+        --primary-text: #ffffff;
+        --secondary: #eef2f7;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        padding: 24px;
+      }
+      main {
+        width: min(960px, 100%);
+        margin: 0 auto;
+        display: grid;
+        gap: 16px;
+      }
+      header, .panel, .notice {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 20px;
+      }
+      h1, h2, p { margin: 0; }
+      h1 { font-size: 26px; line-height: 1.15; }
+      p, .meta { color: var(--muted); }
+      .topline, .row {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 16px;
+      }
+      .panel {
+        display: grid;
+        gap: 14px;
+      }
+      .state {
+        display: inline-flex;
+        align-items: center;
+        border-radius: 6px;
+        padding: 5px 8px;
+        background: var(--secondary);
+        color: var(--muted);
+        font-size: 13px;
+      }
+      a.button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 6px;
+        padding: 9px 12px;
+        background: var(--primary);
+        color: var(--primary-text);
+        text-decoration: none;
+        font-weight: 650;
+      }
+      a.secondary {
+        background: var(--secondary);
+        color: var(--text);
+      }
+      .empty { color: var(--muted); }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <div class="topline">
+          <div>
+            <h1>{{ .TeamID }}</h1>
+            <p>{{ .TargetName }}</p>
+          </div>
+          <a class="button secondary" href="{{ .BackHref }}">Back</a>
+        </div>
+      </header>
+      {{ if .Notice }}
+      <section class="notice">
+        <h2>{{ .Notice.Title }}</h2>
+        <p>{{ .Notice.Message }}</p>
+      </section>
+      {{ end }}
+      {{ if .Rows }}
+      {{ range .Rows }}
+      <section class="panel">
+        <div class="row">
+          <div>
+            <strong>{{ if .ConnectionName }}{{ .ConnectionName }}{{ else }}{{ .ConnectionID }}{{ end }}</strong>
+            <div class="meta">{{ .RouteSummary }}</div>
+          </div>
+          <span class="state">{{ .State }}</span>
+        </div>
+        <div>
+          {{ if .SettingsHref }}
+          <a class="button" href="{{ .SettingsHref }}">Open settings</a>
+          {{ else }}
+          <span class="state">Settings unavailable</span>
+          {{ end }}
+        </div>
+      </section>
+      {{ end }}
+      {{ else }}
+      <section class="panel empty">No manageable connections are connected for this installation.</section>
       {{ end }}
     </main>
   </body>
@@ -396,6 +530,32 @@ func managedConnectionByID(installation backendManagedInstallation, connectionID
 	return backendManagedConnection{}, false
 }
 
+func installationTargetName(installation backendManagedInstallation) string {
+	if installation.CurrentTarget != nil {
+		if name := strings.TrimSpace(installation.CurrentTarget.Profile.Name); name != "" {
+			return name
+		}
+	}
+	return "No target selected"
+}
+
+func managedConnectionName(connection backendManagedConnection) string {
+	if name := strings.TrimSpace(connection.DisplayName); name != "" {
+		return name
+	}
+	if id := strings.TrimSpace(connection.ID); id != "" {
+		return id
+	}
+	return "Connection"
+}
+
+func managedConnectionState(installation backendManagedInstallation, connection backendManagedConnection) string {
+	if state := strings.TrimSpace(connection.State); state != "" {
+		return state
+	}
+	return strings.TrimSpace(installation.State)
+}
+
 func routesFromInstallationConfig(config installationConfig) []backendManagedChannelRoute {
 	routes := make([]backendManagedChannelRoute, 0, len(config.ChannelPolicies))
 	for _, policy := range config.ChannelPolicies {
@@ -470,19 +630,20 @@ func routeSummary(connection backendManagedConnection) string {
 	}
 }
 
-func channelSettingsRows(installations []backendManagedInstallation) []channelSettingsListRow {
-	rows := make([]channelSettingsListRow, 0, len(installations))
-	for _, installation := range installations {
-		connection := primaryManagedConnection(installation)
-		targetName := "No target selected"
-		if installation.CurrentTarget != nil {
-			targetName = strings.TrimSpace(installation.CurrentTarget.Profile.Name)
-		}
+func channelSettingsRowsForInstallation(installation backendManagedInstallation) []channelSettingsListRow {
+	connections := installation.Connections
+	if len(connections) == 0 {
+		connections = []backendManagedConnection{primaryManagedConnection(installation)}
+	}
+	targetName := installationTargetName(installation)
+	rows := make([]channelSettingsListRow, 0, len(connections))
+	for _, connection := range connections {
 		rows = append(rows, channelSettingsListRow{
-			InstallationID: installation.ID,
-			ConnectionID:   connection.ID,
+			InstallationID: strings.TrimSpace(installation.ID),
+			ConnectionID:   strings.TrimSpace(connection.ID),
+			ConnectionName: managedConnectionName(connection),
 			TeamID:         strings.TrimSpace(installation.Route.ExternalTenantID),
-			State:          strings.TrimSpace(installation.State),
+			State:          managedConnectionState(installation, connection),
 			TargetName:     targetName,
 			RouteSummary:   routeSummary(connection),
 			SettingsHref:   "",
@@ -491,14 +652,26 @@ func channelSettingsRows(installations []backendManagedInstallation) []channelSe
 	return rows
 }
 
-func (g *slackGateway) renderChannelSettingsList(w http.ResponseWriter, r *http.Request, installations []backendManagedInstallation) {
-	rows := channelSettingsRows(installations)
+func channelSettingsRows(installations []backendManagedInstallation) []channelSettingsListRow {
+	rows := []channelSettingsListRow{}
+	for _, installation := range installations {
+		rows = append(rows, channelSettingsRowsForInstallation(installation)...)
+	}
+	return rows
+}
+
+func (g *slackGateway) applyChannelSettingsRowLinks(rows []channelSettingsListRow) {
 	for index := range rows {
 		if strings.TrimSpace(rows[index].InstallationID) == "" || strings.TrimSpace(rows[index].ConnectionID) == "" {
 			continue
 		}
 		rows[index].SettingsHref = g.channelSettingsConnectionPath(rows[index].InstallationID, rows[index].ConnectionID)
 	}
+}
+
+func (g *slackGateway) renderChannelSettingsList(w http.ResponseWriter, r *http.Request, installations []backendManagedInstallation) {
+	rows := channelSettingsRows(installations)
+	g.applyChannelSettingsRowLinks(rows)
 	w.Header().Set("Cache-Control", "no-store")
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	_ = channelSettingsListTemplate.Execute(w, channelSettingsPageData{
@@ -507,11 +680,23 @@ func (g *slackGateway) renderChannelSettingsList(w http.ResponseWriter, r *http.
 	})
 }
 
+func (g *slackGateway) renderChannelInstallationSettings(w http.ResponseWriter, r *http.Request, installation backendManagedInstallation) {
+	rows := channelSettingsRowsForInstallation(installation)
+	g.applyChannelSettingsRowLinks(rows)
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_ = channelInstallationSettingsTemplate.Execute(w, channelInstallationSettingsPageData{
+		Notice:         channelSettingsNoticeFromRequest(r),
+		InstallationID: strings.TrimSpace(installation.ID),
+		TeamID:         strings.TrimSpace(installation.Route.ExternalTenantID),
+		State:          strings.TrimSpace(installation.State),
+		TargetName:     installationTargetName(installation),
+		Rows:           rows,
+		BackHref:       g.channelSettingsPath(),
+	})
+}
+
 func (g *slackGateway) renderChannelConnectionSettings(w http.ResponseWriter, r *http.Request, installation backendManagedInstallation, connection backendManagedConnection) {
-	targetName := "No target selected"
-	if installation.CurrentTarget != nil {
-		targetName = strings.TrimSpace(installation.CurrentTarget.Profile.Name)
-	}
 	w.Header().Set("Cache-Control", "no-store")
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	_ = channelConnectionSettingsTemplate.Execute(w, channelConnectionSettingsPageData{
@@ -520,9 +705,9 @@ func (g *slackGateway) renderChannelConnectionSettings(w http.ResponseWriter, r 
 		ConnectionID:   connection.ID,
 		TeamID:         strings.TrimSpace(installation.Route.ExternalTenantID),
 		State:          strings.TrimSpace(installation.State),
-		TargetName:     targetName,
+		TargetName:     installationTargetName(installation),
 		Rows:           channelRouteSettingsRows(connection),
 		UpdateAction:   g.channelSettingsConnectionPath(installation.ID, connection.ID),
-		BackHref:       g.channelSettingsPath(),
+		BackHref:       g.channelSettingsInstallationPath(installation.ID),
 	})
 }

--- a/integrations/slack-gateway/channel_settings.go
+++ b/integrations/slack-gateway/channel_settings.go
@@ -145,7 +145,11 @@ var channelSettingsListTemplate = template.Must(template.New("channel-settings-l
           <span class="state">{{ .State }}</span>
         </div>
         <div>
+          {{ if .SettingsHref }}
           <a class="button" href="{{ .SettingsHref }}">Open settings</a>
+          {{ else }}
+          <span class="state">Settings unavailable</span>
+          {{ end }}
         </div>
       </section>
       {{ end }}
@@ -374,12 +378,8 @@ func primaryManagedConnection(installation backendManagedInstallation) backendMa
 	if len(installation.Connections) > 0 {
 		return installation.Connections[0]
 	}
-	connectionID := ""
-	if strings.HasPrefix(strings.TrimSpace(installation.ID), "ci_") {
-		connectionID = "cc_" + strings.TrimPrefix(strings.TrimSpace(installation.ID), "ci_")
-	}
 	return backendManagedConnection{
-		ID:        connectionID,
+		ID:        "",
 		IsDefault: true,
 		State:     installation.State,
 		Routes:    routesFromInstallationConfig(installation.InstallationConfig),
@@ -389,12 +389,6 @@ func primaryManagedConnection(installation backendManagedInstallation) backendMa
 func managedConnectionByID(installation backendManagedInstallation, connectionID string) (backendManagedConnection, bool) {
 	connectionID = strings.TrimSpace(connectionID)
 	for _, connection := range installation.Connections {
-		if strings.TrimSpace(connection.ID) == connectionID {
-			return connection, true
-		}
-	}
-	if len(installation.Connections) == 0 {
-		connection := primaryManagedConnection(installation)
 		if strings.TrimSpace(connection.ID) == connectionID {
 			return connection, true
 		}
@@ -500,6 +494,9 @@ func channelSettingsRows(installations []backendManagedInstallation) []channelSe
 func (g *slackGateway) renderChannelSettingsList(w http.ResponseWriter, r *http.Request, installations []backendManagedInstallation) {
 	rows := channelSettingsRows(installations)
 	for index := range rows {
+		if strings.TrimSpace(rows[index].InstallationID) == "" || strings.TrimSpace(rows[index].ConnectionID) == "" {
+			continue
+		}
 		rows[index].SettingsHref = g.channelSettingsConnectionPath(rows[index].InstallationID, rows[index].ConnectionID)
 	}
 	w.Header().Set("Cache-Control", "no-store")

--- a/integrations/slack-gateway/channel_settings.go
+++ b/integrations/slack-gateway/channel_settings.go
@@ -563,10 +563,11 @@ func routesFromInstallationConfig(config installationConfig) []backendManagedCha
 		if policy.RequireMention != nil {
 			requireMention = *policy.RequireMention
 		}
+		enabled := true
 		routes = append(routes, backendManagedChannelRoute{
 			ExternalChannelID: strings.TrimSpace(policy.ExternalChannelID),
-			RequireMention:    requireMention,
-			Enabled:           true,
+			RequireMention:    &requireMention,
+			Enabled:           &enabled,
 		})
 	}
 	sort.Slice(routes, func(i, j int) bool {
@@ -575,17 +576,25 @@ func routesFromInstallationConfig(config installationConfig) []backendManagedCha
 	return routes
 }
 
+func managedRouteEnabled(route backendManagedChannelRoute) bool {
+	return route.Enabled == nil || *route.Enabled
+}
+
+func managedRouteRequireMention(route backendManagedChannelRoute) bool {
+	return route.RequireMention == nil || *route.RequireMention
+}
+
 func channelPoliciesFromConnection(connection backendManagedConnection) []installationChannelPolicy {
 	policies := make([]installationChannelPolicy, 0, len(connection.Routes))
 	for _, route := range connection.Routes {
-		if !route.Enabled {
+		if !managedRouteEnabled(route) {
 			continue
 		}
 		channelID := strings.TrimSpace(route.ExternalChannelID)
 		if channelID == "" {
 			continue
 		}
-		requireMention := route.RequireMention
+		requireMention := managedRouteRequireMention(route)
 		policies = append(policies, installationChannelPolicy{
 			ExternalChannelID: channelID,
 			RequireMention:    &requireMention,

--- a/integrations/slack-gateway/channel_settings.go
+++ b/integrations/slack-gateway/channel_settings.go
@@ -1,0 +1,513 @@
+package main
+
+import (
+	"fmt"
+	"html/template"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+type channelSettingsNotice struct {
+	Title   string
+	Message string
+}
+
+type channelSettingsListRow struct {
+	InstallationID string
+	ConnectionID   string
+	TeamID         string
+	State          string
+	TargetName     string
+	RouteSummary   string
+	SettingsHref   string
+}
+
+type channelSettingsPageData struct {
+	Notice *channelSettingsNotice
+	Rows   []channelSettingsListRow
+}
+
+type channelRouteSettingsRow struct {
+	ExternalChannelID string
+	RequireMention    bool
+	ModeLabel         string
+}
+
+type channelConnectionSettingsPageData struct {
+	Notice         *channelSettingsNotice
+	InstallationID string
+	ConnectionID   string
+	TeamID         string
+	State          string
+	TargetName     string
+	Rows           []channelRouteSettingsRow
+	UpdateAction   string
+	BackHref       string
+}
+
+var channelSettingsListTemplate = template.Must(template.New("channel-settings-list").Parse(`<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Channel settings</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f7f8fa;
+        --surface: #ffffff;
+        --border: #d7dce3;
+        --text: #17202a;
+        --muted: #627083;
+        --primary: #1f6feb;
+        --primary-text: #ffffff;
+        --secondary: #eef2f7;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        padding: 24px;
+      }
+      main {
+        width: min(960px, 100%);
+        margin: 0 auto;
+        display: grid;
+        gap: 16px;
+      }
+      header, .panel, .notice {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+      }
+      header, .notice, .panel { padding: 20px; }
+      h1, h2, p { margin: 0; }
+      h1 { font-size: 26px; line-height: 1.15; }
+      p, .meta { color: var(--muted); }
+      .panel {
+        display: grid;
+        gap: 14px;
+      }
+      .row {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 16px;
+      }
+      .state {
+        display: inline-flex;
+        align-items: center;
+        border-radius: 6px;
+        padding: 5px 8px;
+        background: var(--secondary);
+        color: var(--muted);
+        font-size: 13px;
+      }
+      a.button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 6px;
+        padding: 9px 12px;
+        background: var(--primary);
+        color: var(--primary-text);
+        text-decoration: none;
+        font-weight: 650;
+      }
+      .empty { color: var(--muted); }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>Channel settings</h1>
+      </header>
+      {{ if .Notice }}
+      <section class="notice">
+        <h2>{{ .Notice.Title }}</h2>
+        <p>{{ .Notice.Message }}</p>
+      </section>
+      {{ end }}
+      {{ if .Rows }}
+      {{ range .Rows }}
+      <section class="panel">
+        <div class="row">
+          <div>
+            <strong>{{ .TeamID }}</strong>
+            <div class="meta">{{ .TargetName }}</div>
+            <div class="meta">{{ .RouteSummary }}</div>
+          </div>
+          <span class="state">{{ .State }}</span>
+        </div>
+        <div>
+          <a class="button" href="{{ .SettingsHref }}">Open settings</a>
+        </div>
+      </section>
+      {{ end }}
+      {{ else }}
+      <section class="panel empty">No manageable channel installations are connected for this account.</section>
+      {{ end }}
+    </main>
+  </body>
+</html>`))
+
+var channelConnectionSettingsTemplate = template.Must(template.New("channel-connection-settings").Parse(`<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Channel settings</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f7f8fa;
+        --surface: #ffffff;
+        --border: #d7dce3;
+        --text: #17202a;
+        --muted: #627083;
+        --primary: #1f6feb;
+        --primary-text: #ffffff;
+        --secondary: #eef2f7;
+        --danger: #b42318;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        padding: 24px;
+      }
+      main {
+        width: min(980px, 100%);
+        margin: 0 auto;
+        display: grid;
+        gap: 16px;
+      }
+      header, .panel, .notice {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 20px;
+      }
+      h1, h2, p { margin: 0; }
+      h1 { font-size: 26px; line-height: 1.15; }
+      p, .meta, label { color: var(--muted); }
+      .topline, .route-row, .form-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 16px;
+      }
+      .route-list {
+        display: grid;
+        gap: 10px;
+      }
+      .route-row {
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 12px;
+      }
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        border-radius: 6px;
+        padding: 5px 8px;
+        background: var(--secondary);
+        color: var(--muted);
+        font-size: 13px;
+      }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+      button, a.button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 36px;
+        border-radius: 6px;
+        padding: 8px 12px;
+        border: 0;
+        text-decoration: none;
+        cursor: pointer;
+        font-weight: 650;
+      }
+      .primary { background: var(--primary); color: var(--primary-text); }
+      .secondary { background: var(--secondary); color: var(--text); }
+      .danger { color: var(--danger); }
+      input[type="text"] {
+        width: min(320px, 100%);
+        min-height: 36px;
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 8px 10px;
+        font: inherit;
+      }
+      input[type="checkbox"] {
+        width: 18px;
+        height: 18px;
+      }
+      form { margin: 0; }
+      .form-row { flex-wrap: wrap; justify-content: flex-start; }
+      .empty { color: var(--muted); }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <div class="topline">
+          <div>
+            <h1>{{ .TeamID }}</h1>
+            <p>{{ .TargetName }}</p>
+          </div>
+          <a class="button secondary" href="{{ .BackHref }}">Back</a>
+        </div>
+      </header>
+      {{ if .Notice }}
+      <section class="notice">
+        <h2>{{ .Notice.Title }}</h2>
+        <p>{{ .Notice.Message }}</p>
+      </section>
+      {{ end }}
+      <section class="panel">
+        <form method="post" action="{{ .UpdateAction }}">
+          <input type="hidden" name="action" value="upsert">
+          <div class="form-row">
+            <input type="text" name="externalChannelId" placeholder="C12345678" required>
+            <label><input type="checkbox" name="requireMention" checked> Require mention</label>
+            <button class="primary" type="submit">Save channel</button>
+          </div>
+        </form>
+      </section>
+      <section class="panel">
+        {{ if .Rows }}
+        <div class="route-list">
+          {{ range .Rows }}
+          <div class="route-row">
+            <div>
+              <strong>{{ .ExternalChannelID }}</strong>
+              <div class="meta">{{ .ModeLabel }}</div>
+            </div>
+            <div class="actions">
+              <form method="post" action="{{ $.UpdateAction }}">
+                <input type="hidden" name="action" value="toggle">
+                <input type="hidden" name="externalChannelId" value="{{ .ExternalChannelID }}">
+                {{ if .RequireMention }}
+                <input type="hidden" name="requireMention" value="false">
+                <button class="secondary" type="submit">Allow without mention</button>
+                {{ else }}
+                <input type="hidden" name="requireMention" value="true">
+                <button class="secondary" type="submit">Require mention</button>
+                {{ end }}
+              </form>
+              <form method="post" action="{{ $.UpdateAction }}">
+                <input type="hidden" name="action" value="delete">
+                <input type="hidden" name="externalChannelId" value="{{ .ExternalChannelID }}">
+                <button class="secondary danger" type="submit">Remove</button>
+              </form>
+            </div>
+          </div>
+          {{ end }}
+        </div>
+        {{ else }}
+        <div class="empty">No channel overrides are configured.</div>
+        {{ end }}
+      </section>
+    </main>
+  </body>
+</html>`))
+
+func (g *slackGateway) channelSettingsPath() string {
+	return g.publicPathPrefix() + "/settings/channels"
+}
+
+func (g *slackGateway) channelSettingsInstallationPath(installationID string) string {
+	return g.publicPathPrefix() + "/settings/channels/installations/" + url.PathEscape(strings.TrimSpace(installationID))
+}
+
+func (g *slackGateway) channelSettingsConnectionPath(installationID, connectionID string) string {
+	return g.channelSettingsInstallationPath(installationID) + "/connections/" + url.PathEscape(strings.TrimSpace(connectionID))
+}
+
+func (g *slackGateway) relativeGatewayPath(requestPath string) string {
+	requestPath = strings.TrimSpace(requestPath)
+	prefix := g.publicPathPrefix()
+	if prefix != "" {
+		if requestPath == prefix {
+			return "/"
+		}
+		if strings.HasPrefix(requestPath, prefix+"/") {
+			return strings.TrimPrefix(requestPath, prefix)
+		}
+	}
+	return requestPath
+}
+
+func channelSettingsNoticeFromRequest(r *http.Request) *channelSettingsNotice {
+	if r == nil {
+		return nil
+	}
+	switch strings.TrimSpace(r.URL.Query().Get("notice")) {
+	case "routes-updated":
+		return &channelSettingsNotice{Title: "Channel settings updated", Message: "The channel routing settings were saved."}
+	case "routes-update-failed":
+		return &channelSettingsNotice{Title: "Channel settings update failed", Message: "The channel routing settings could not be saved right now."}
+	default:
+		return nil
+	}
+}
+
+func primaryManagedConnection(installation backendManagedInstallation) backendManagedConnection {
+	for _, connection := range installation.Connections {
+		if connection.IsDefault {
+			return connection
+		}
+	}
+	if len(installation.Connections) > 0 {
+		return installation.Connections[0]
+	}
+	connectionID := ""
+	if strings.HasPrefix(strings.TrimSpace(installation.ID), "ci_") {
+		connectionID = "cc_" + strings.TrimPrefix(strings.TrimSpace(installation.ID), "ci_")
+	}
+	return backendManagedConnection{
+		ID:        connectionID,
+		IsDefault: true,
+		State:     installation.State,
+		Routes:    routesFromInstallationConfig(installation.InstallationConfig),
+	}
+}
+
+func routesFromInstallationConfig(config installationConfig) []backendManagedChannelRoute {
+	routes := make([]backendManagedChannelRoute, 0, len(config.ChannelPolicies))
+	for _, policy := range config.ChannelPolicies {
+		requireMention := true
+		if policy.RequireMention != nil {
+			requireMention = *policy.RequireMention
+		}
+		routes = append(routes, backendManagedChannelRoute{
+			ExternalChannelID: strings.TrimSpace(policy.ExternalChannelID),
+			RequireMention:    requireMention,
+			Enabled:           true,
+		})
+	}
+	sort.Slice(routes, func(i, j int) bool {
+		return routes[i].ExternalChannelID < routes[j].ExternalChannelID
+	})
+	return routes
+}
+
+func channelPoliciesFromConnection(connection backendManagedConnection) []installationChannelPolicy {
+	policies := make([]installationChannelPolicy, 0, len(connection.Routes))
+	for _, route := range connection.Routes {
+		if !route.Enabled {
+			continue
+		}
+		channelID := strings.TrimSpace(route.ExternalChannelID)
+		if channelID == "" {
+			continue
+		}
+		requireMention := route.RequireMention
+		policies = append(policies, installationChannelPolicy{
+			ExternalChannelID: channelID,
+			RequireMention:    &requireMention,
+		})
+	}
+	sort.Slice(policies, func(i, j int) bool {
+		return policies[i].ExternalChannelID < policies[j].ExternalChannelID
+	})
+	return policies
+}
+
+func channelRouteSettingsRows(connection backendManagedConnection) []channelRouteSettingsRow {
+	policies := channelPoliciesFromConnection(connection)
+	rows := make([]channelRouteSettingsRow, 0, len(policies))
+	for _, policy := range policies {
+		requireMention := true
+		if policy.RequireMention != nil {
+			requireMention = *policy.RequireMention
+		}
+		modeLabel := "Mentions required"
+		if !requireMention {
+			modeLabel = "Relays without mention"
+		}
+		rows = append(rows, channelRouteSettingsRow{
+			ExternalChannelID: policy.ExternalChannelID,
+			RequireMention:    requireMention,
+			ModeLabel:         modeLabel,
+		})
+	}
+	return rows
+}
+
+func routeSummary(connection backendManagedConnection) string {
+	count := len(channelPoliciesFromConnection(connection))
+	switch count {
+	case 0:
+		return "No channel overrides"
+	case 1:
+		return "1 channel override"
+	default:
+		return fmt.Sprintf("%d channel overrides", count)
+	}
+}
+
+func channelSettingsRows(installations []backendManagedInstallation) []channelSettingsListRow {
+	rows := make([]channelSettingsListRow, 0, len(installations))
+	for _, installation := range installations {
+		connection := primaryManagedConnection(installation)
+		targetName := "No target selected"
+		if installation.CurrentTarget != nil {
+			targetName = strings.TrimSpace(installation.CurrentTarget.Profile.Name)
+		}
+		rows = append(rows, channelSettingsListRow{
+			InstallationID: installation.ID,
+			ConnectionID:   connection.ID,
+			TeamID:         strings.TrimSpace(installation.Route.ExternalTenantID),
+			State:          strings.TrimSpace(installation.State),
+			TargetName:     targetName,
+			RouteSummary:   routeSummary(connection),
+			SettingsHref:   "",
+		})
+	}
+	return rows
+}
+
+func (g *slackGateway) renderChannelSettingsList(w http.ResponseWriter, r *http.Request, installations []backendManagedInstallation) {
+	rows := channelSettingsRows(installations)
+	for index := range rows {
+		rows[index].SettingsHref = g.channelSettingsConnectionPath(rows[index].InstallationID, rows[index].ConnectionID)
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_ = channelSettingsListTemplate.Execute(w, channelSettingsPageData{
+		Notice: channelSettingsNoticeFromRequest(r),
+		Rows:   rows,
+	})
+}
+
+func (g *slackGateway) renderChannelConnectionSettings(w http.ResponseWriter, r *http.Request, installation backendManagedInstallation, connection backendManagedConnection) {
+	targetName := "No target selected"
+	if installation.CurrentTarget != nil {
+		targetName = strings.TrimSpace(installation.CurrentTarget.Profile.Name)
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_ = channelConnectionSettingsTemplate.Execute(w, channelConnectionSettingsPageData{
+		Notice:         channelSettingsNoticeFromRequest(r),
+		InstallationID: installation.ID,
+		ConnectionID:   connection.ID,
+		TeamID:         strings.TrimSpace(installation.Route.ExternalTenantID),
+		State:          strings.TrimSpace(installation.State),
+		TargetName:     targetName,
+		Rows:           channelRouteSettingsRows(connection),
+		UpdateAction:   g.channelSettingsConnectionPath(installation.ID, connection.ID),
+		BackHref:       g.channelSettingsPath(),
+	})
+}

--- a/integrations/slack-gateway/channel_settings.go
+++ b/integrations/slack-gateway/channel_settings.go
@@ -386,6 +386,22 @@ func primaryManagedConnection(installation backendManagedInstallation) backendMa
 	}
 }
 
+func managedConnectionByID(installation backendManagedInstallation, connectionID string) (backendManagedConnection, bool) {
+	connectionID = strings.TrimSpace(connectionID)
+	for _, connection := range installation.Connections {
+		if strings.TrimSpace(connection.ID) == connectionID {
+			return connection, true
+		}
+	}
+	if len(installation.Connections) == 0 {
+		connection := primaryManagedConnection(installation)
+		if strings.TrimSpace(connection.ID) == connectionID {
+			return connection, true
+		}
+	}
+	return backendManagedConnection{}, false
+}
+
 func routesFromInstallationConfig(config installationConfig) []backendManagedChannelRoute {
 	routes := make([]backendManagedChannelRoute, 0, len(config.ChannelPolicies))
 	for _, policy := range config.ChannelPolicies {

--- a/integrations/slack-gateway/channel_settings_handlers.go
+++ b/integrations/slack-gateway/channel_settings_handlers.go
@@ -86,8 +86,8 @@ func (g *slackGateway) matchChannelSettingsConnectionPath(
 		if strings.TrimSpace(installation.ID) != installationID {
 			continue
 		}
-		connection := primaryManagedConnection(installation)
-		if strings.TrimSpace(connection.ID) != connectionID {
+		connection, found := managedConnectionByID(installation, connectionID)
+		if !found {
 			http.NotFound(w, r)
 			return backendManagedInstallation{}, backendManagedConnection{}, false
 		}

--- a/integrations/slack-gateway/channel_settings_handlers.go
+++ b/integrations/slack-gateway/channel_settings_handlers.go
@@ -178,6 +178,7 @@ func (g *slackGateway) handleChannelSettingsUpdate(
 		)
 		return
 	}
+	g.policies.forget(installation.Route.ExternalTenantID)
 	http.Redirect(
 		w,
 		r,

--- a/integrations/slack-gateway/channel_settings_handlers.go
+++ b/integrations/slack-gateway/channel_settings_handlers.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+)
+
+func (g *slackGateway) handleChannelSettings(w http.ResponseWriter, r *http.Request) {
+	principal, ok := requireBrowserPrincipal(g.cfg, w, r)
+	if !ok {
+		return
+	}
+	installations, err := g.listManagedInstallations(r.Context(), principal.ID)
+	if err != nil {
+		g.logger.ErrorContext(
+			r.Context(),
+			"channel settings list failed",
+			"err",
+			err,
+			"caller_auth_id",
+			principal.ID,
+		)
+		http.Error(w, "channel settings unavailable", http.StatusBadGateway)
+		return
+	}
+
+	relativePath := strings.TrimRight(g.relativeGatewayPath(r.URL.Path), "/")
+	if relativePath == "/settings/channels" {
+		g.renderChannelSettingsList(w, r, installations)
+		return
+	}
+
+	installation, connection, ok := g.matchChannelSettingsConnectionPath(
+		w,
+		r,
+		installations,
+		relativePath,
+	)
+	if !ok {
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		g.renderChannelConnectionSettings(w, r, installation, connection)
+	case http.MethodPost:
+		g.handleChannelSettingsUpdate(w, r, principal.ID, installation, connection)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (g *slackGateway) matchChannelSettingsConnectionPath(
+	w http.ResponseWriter,
+	r *http.Request,
+	installations []backendManagedInstallation,
+	relativePath string,
+) (backendManagedInstallation, backendManagedConnection, bool) {
+	trimmed := strings.Trim(strings.TrimPrefix(relativePath, "/settings/channels/"), "/")
+	parts := strings.Split(trimmed, "/")
+	if len(parts) == 2 && parts[0] == "installations" {
+		installationID := strings.TrimSpace(parts[1])
+		for _, installation := range installations {
+			if strings.TrimSpace(installation.ID) != installationID {
+				continue
+			}
+			connection := primaryManagedConnection(installation)
+			http.Redirect(
+				w,
+				r,
+				g.channelSettingsConnectionPath(installation.ID, connection.ID),
+				http.StatusSeeOther,
+			)
+			return backendManagedInstallation{}, backendManagedConnection{}, false
+		}
+		http.NotFound(w, r)
+		return backendManagedInstallation{}, backendManagedConnection{}, false
+	}
+	if len(parts) != 4 || parts[0] != "installations" || parts[2] != "connections" {
+		http.NotFound(w, r)
+		return backendManagedInstallation{}, backendManagedConnection{}, false
+	}
+	installationID := strings.TrimSpace(parts[1])
+	connectionID := strings.TrimSpace(parts[3])
+	for _, installation := range installations {
+		if strings.TrimSpace(installation.ID) != installationID {
+			continue
+		}
+		connection := primaryManagedConnection(installation)
+		if strings.TrimSpace(connection.ID) != connectionID {
+			http.NotFound(w, r)
+			return backendManagedInstallation{}, backendManagedConnection{}, false
+		}
+		return installation, connection, true
+	}
+	http.NotFound(w, r)
+	return backendManagedInstallation{}, backendManagedConnection{}, false
+}
+
+func (g *slackGateway) handleChannelSettingsUpdate(
+	w http.ResponseWriter,
+	r *http.Request,
+	callerAuthID string,
+	installation backendManagedInstallation,
+	connection backendManagedConnection,
+) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "invalid form payload", http.StatusBadRequest)
+		return
+	}
+	channelID := strings.TrimSpace(r.FormValue("externalChannelId"))
+	if channelID == "" {
+		http.Error(w, "externalChannelId is required", http.StatusBadRequest)
+		return
+	}
+
+	policiesByChannel := map[string]installationChannelPolicy{}
+	for _, policy := range channelPoliciesFromConnection(connection) {
+		policiesByChannel[policy.ExternalChannelID] = policy
+	}
+
+	switch strings.TrimSpace(r.FormValue("action")) {
+	case "delete":
+		delete(policiesByChannel, channelID)
+	case "toggle":
+		requireMention := strings.EqualFold(strings.TrimSpace(r.FormValue("requireMention")), "true")
+		policiesByChannel[channelID] = installationChannelPolicy{
+			ExternalChannelID: channelID,
+			RequireMention:    &requireMention,
+		}
+	default:
+		requireMention := r.FormValue("requireMention") == "on"
+		policiesByChannel[channelID] = installationChannelPolicy{
+			ExternalChannelID: channelID,
+			RequireMention:    &requireMention,
+		}
+	}
+
+	policies := make([]installationChannelPolicy, 0, len(policiesByChannel))
+	for _, policy := range policiesByChannel {
+		policies = append(policies, policy)
+	}
+	sort.Slice(policies, func(i, j int) bool {
+		return policies[i].ExternalChannelID < policies[j].ExternalChannelID
+	})
+	requestID := newInstallRequestID()
+	if err := g.updateManagedInstallationRoutes(
+		r.Context(),
+		callerAuthID,
+		installation.ID,
+		connection.ID,
+		requestID,
+		policies,
+	); err != nil {
+		g.logger.ErrorContext(
+			r.Context(),
+			"channel settings update failed",
+			"err",
+			err,
+			"caller_auth_id",
+			callerAuthID,
+			"installation_id",
+			installation.ID,
+			"connection_id",
+			connection.ID,
+			"request_id",
+			requestID,
+		)
+		http.Redirect(
+			w,
+			r,
+			g.channelSettingsConnectionNoticeURL(
+				installation.ID,
+				connection.ID,
+				"routes-update-failed",
+			),
+			http.StatusSeeOther,
+		)
+		return
+	}
+	http.Redirect(
+		w,
+		r,
+		g.channelSettingsConnectionNoticeURL(
+			installation.ID,
+			connection.ID,
+			"routes-updated",
+		),
+		http.StatusSeeOther,
+	)
+}
+
+func (g *slackGateway) channelSettingsConnectionNoticeURL(installationID, connectionID, notice string) string {
+	target := g.channelSettingsConnectionPath(installationID, connectionID)
+	if strings.TrimSpace(notice) == "" {
+		return target
+	}
+	separator := "?"
+	if strings.Contains(target, "?") {
+		separator = "&"
+	}
+	return target + separator + "notice=" + strings.TrimSpace(notice)
+}

--- a/integrations/slack-gateway/channel_settings_handlers.go
+++ b/integrations/slack-gateway/channel_settings_handlers.go
@@ -31,6 +31,21 @@ func (g *slackGateway) handleChannelSettings(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	if installationID, ok := channelSettingsInstallationPathID(relativePath); ok {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		for _, installation := range installations {
+			if strings.TrimSpace(installation.ID) == installationID {
+				g.renderChannelInstallationSettings(w, r, installation)
+				return
+			}
+		}
+		http.NotFound(w, r)
+		return
+	}
+
 	installation, connection, ok := g.matchChannelSettingsConnectionPath(
 		w,
 		r,
@@ -50,6 +65,15 @@ func (g *slackGateway) handleChannelSettings(w http.ResponseWriter, r *http.Requ
 	}
 }
 
+func channelSettingsInstallationPathID(relativePath string) (string, bool) {
+	trimmed := strings.Trim(strings.TrimPrefix(relativePath, "/settings/channels/"), "/")
+	parts := strings.Split(trimmed, "/")
+	if len(parts) != 2 || parts[0] != "installations" {
+		return "", false
+	}
+	return strings.TrimSpace(parts[1]), true
+}
+
 func (g *slackGateway) matchChannelSettingsConnectionPath(
 	w http.ResponseWriter,
 	r *http.Request,
@@ -58,24 +82,6 @@ func (g *slackGateway) matchChannelSettingsConnectionPath(
 ) (backendManagedInstallation, backendManagedConnection, bool) {
 	trimmed := strings.Trim(strings.TrimPrefix(relativePath, "/settings/channels/"), "/")
 	parts := strings.Split(trimmed, "/")
-	if len(parts) == 2 && parts[0] == "installations" {
-		installationID := strings.TrimSpace(parts[1])
-		for _, installation := range installations {
-			if strings.TrimSpace(installation.ID) != installationID {
-				continue
-			}
-			connection := primaryManagedConnection(installation)
-			http.Redirect(
-				w,
-				r,
-				g.channelSettingsConnectionPath(installation.ID, connection.ID),
-				http.StatusSeeOther,
-			)
-			return backendManagedInstallation{}, backendManagedConnection{}, false
-		}
-		http.NotFound(w, r)
-		return backendManagedInstallation{}, backendManagedConnection{}, false
-	}
 	if len(parts) != 4 || parts[0] != "installations" || parts[2] != "connections" {
 		http.NotFound(w, r)
 		return backendManagedInstallation{}, backendManagedConnection{}, false

--- a/integrations/slack-gateway/config.go
+++ b/integrations/slack-gateway/config.go
@@ -9,62 +9,64 @@ import (
 )
 
 type config struct {
-	Addr                   string
-	PublicURL              string
-	BrowserAuthHeaderID    string
-	BrowserAuthHeaderEmail string
-	SlackClientID          string
-	SlackClientSecret      string
-	SlackSigningSecret     string
-	OAuthStateSecret       string
-	SlackAPIBaseURL        string
-	SlackBotScopes         []string
-	PresetID               string
-	BackendBaseURL         string
-	BackendFastAPIBaseURL  string
-	BackendInternalToken   string
-	SpritzBaseURL          string
-	SpritzServiceToken     string
-	PrincipalID            string
-	HTTPTimeout            time.Duration
-	DedupeTTL              time.Duration
-	ProcessingTimeout      time.Duration
-	SessionRetryInterval   time.Duration
-	StatusMessageDelay     time.Duration
-	RecoveryTimeout        time.Duration
-	PromptRetryInitial     time.Duration
-	PromptRetryMax         time.Duration
-	PromptRetryTimeout     time.Duration
+	Addr                       string
+	PublicURL                  string
+	BrowserAuthHeaderID        string
+	BrowserAuthHeaderEmail     string
+	SlackClientID              string
+	SlackClientSecret          string
+	SlackSigningSecret         string
+	OAuthStateSecret           string
+	SlackAPIBaseURL            string
+	SlackBotScopes             []string
+	PresetID                   string
+	BackendBaseURL             string
+	BackendFastAPIBaseURL      string
+	BackendInternalToken       string
+	SpritzBaseURL              string
+	SpritzServiceToken         string
+	PrincipalID                string
+	HTTPTimeout                time.Duration
+	DedupeTTL                  time.Duration
+	ProcessingTimeout          time.Duration
+	SessionRetryInterval       time.Duration
+	StatusMessageDelay         time.Duration
+	RecoveryTimeout            time.Duration
+	PromptRetryInitial         time.Duration
+	PromptRetryMax             time.Duration
+	PromptRetryTimeout         time.Duration
+	InstallationPolicyCacheTTL time.Duration
 }
 
 func loadConfig() (config, error) {
 	cfg := config{
-		Addr:                   envOrDefault("SPRITZ_SLACK_GATEWAY_ADDR", ":8080"),
-		PublicURL:              strings.TrimRight(strings.TrimSpace(os.Getenv("SPRITZ_SLACK_GATEWAY_PUBLIC_URL")), "/"),
-		BrowserAuthHeaderID:    envOrDefault("SPRITZ_AUTH_HEADER_ID", "X-Spritz-User-Id"),
-		BrowserAuthHeaderEmail: envOrDefault("SPRITZ_AUTH_HEADER_EMAIL", "X-Spritz-User-Email"),
-		SlackClientID:          strings.TrimSpace(os.Getenv("SPRITZ_SLACK_CLIENT_ID")),
-		SlackClientSecret:      strings.TrimSpace(os.Getenv("SPRITZ_SLACK_CLIENT_SECRET")),
-		SlackSigningSecret:     strings.TrimSpace(os.Getenv("SPRITZ_SLACK_SIGNING_SECRET")),
-		OAuthStateSecret:       strings.TrimSpace(os.Getenv("SPRITZ_SLACK_OAUTH_STATE_SECRET")),
-		SlackAPIBaseURL:        strings.TrimRight(envOrDefault("SPRITZ_SLACK_API_BASE_URL", "https://slack.com/api"), "/"),
-		SlackBotScopes:         splitCSV(envOrDefault("SPRITZ_SLACK_BOT_SCOPES", "app_mentions:read,channels:history,chat:write,im:history,mpim:history")),
-		PresetID:               strings.TrimSpace(envOrDefault("SPRITZ_SLACK_PRESET_ID", defaultSlackPresetID)),
-		BackendBaseURL:         strings.TrimRight(strings.TrimSpace(os.Getenv("SPRITZ_SLACK_BACKEND_BASE_URL")), "/"),
-		BackendFastAPIBaseURL:  strings.TrimRight(strings.TrimSpace(os.Getenv("SPRITZ_SLACK_BACKEND_FASTAPI_BASE_URL")), "/"),
-		BackendInternalToken:   strings.TrimSpace(os.Getenv("SPRITZ_SLACK_BACKEND_INTERNAL_TOKEN")),
-		SpritzBaseURL:          strings.TrimRight(strings.TrimSpace(os.Getenv("SPRITZ_SLACK_SPRITZ_BASE_URL")), "/"),
-		SpritzServiceToken:     strings.TrimSpace(os.Getenv("SPRITZ_SLACK_SPRITZ_SERVICE_TOKEN")),
-		PrincipalID:            strings.TrimSpace(os.Getenv("SPRITZ_SLACK_PRINCIPAL_ID")),
-		HTTPTimeout:            parseDurationEnv("SPRITZ_SLACK_HTTP_TIMEOUT", 15*time.Second),
-		DedupeTTL:              parseDurationEnv("SPRITZ_SLACK_DEDUPE_TTL", 10*time.Minute),
-		ProcessingTimeout:      parseDurationEnv("SPRITZ_SLACK_PROCESSING_TIMEOUT", 120*time.Second),
-		SessionRetryInterval:   parseDurationEnv("SPRITZ_SLACK_SESSION_RETRY_INTERVAL", time.Second),
-		StatusMessageDelay:     parseDurationEnv("SPRITZ_SLACK_STATUS_MESSAGE_DELAY", 5*time.Second),
-		RecoveryTimeout:        parseDurationEnv("SPRITZ_SLACK_RECOVERY_TIMEOUT", 120*time.Second),
-		PromptRetryInitial:     parseDurationEnv("SPRITZ_SLACK_PROMPT_RETRY_INITIAL", 250*time.Millisecond),
-		PromptRetryMax:         parseDurationEnv("SPRITZ_SLACK_PROMPT_RETRY_MAX", 2*time.Second),
-		PromptRetryTimeout:     parseDurationEnv("SPRITZ_SLACK_PROMPT_RETRY_TIMEOUT", 8*time.Second),
+		Addr:                       envOrDefault("SPRITZ_SLACK_GATEWAY_ADDR", ":8080"),
+		PublicURL:                  strings.TrimRight(strings.TrimSpace(os.Getenv("SPRITZ_SLACK_GATEWAY_PUBLIC_URL")), "/"),
+		BrowserAuthHeaderID:        envOrDefault("SPRITZ_AUTH_HEADER_ID", "X-Spritz-User-Id"),
+		BrowserAuthHeaderEmail:     envOrDefault("SPRITZ_AUTH_HEADER_EMAIL", "X-Spritz-User-Email"),
+		SlackClientID:              strings.TrimSpace(os.Getenv("SPRITZ_SLACK_CLIENT_ID")),
+		SlackClientSecret:          strings.TrimSpace(os.Getenv("SPRITZ_SLACK_CLIENT_SECRET")),
+		SlackSigningSecret:         strings.TrimSpace(os.Getenv("SPRITZ_SLACK_SIGNING_SECRET")),
+		OAuthStateSecret:           strings.TrimSpace(os.Getenv("SPRITZ_SLACK_OAUTH_STATE_SECRET")),
+		SlackAPIBaseURL:            strings.TrimRight(envOrDefault("SPRITZ_SLACK_API_BASE_URL", "https://slack.com/api"), "/"),
+		SlackBotScopes:             splitCSV(envOrDefault("SPRITZ_SLACK_BOT_SCOPES", "app_mentions:read,channels:history,chat:write,im:history,mpim:history")),
+		PresetID:                   strings.TrimSpace(envOrDefault("SPRITZ_SLACK_PRESET_ID", defaultSlackPresetID)),
+		BackendBaseURL:             strings.TrimRight(strings.TrimSpace(os.Getenv("SPRITZ_SLACK_BACKEND_BASE_URL")), "/"),
+		BackendFastAPIBaseURL:      strings.TrimRight(strings.TrimSpace(os.Getenv("SPRITZ_SLACK_BACKEND_FASTAPI_BASE_URL")), "/"),
+		BackendInternalToken:       strings.TrimSpace(os.Getenv("SPRITZ_SLACK_BACKEND_INTERNAL_TOKEN")),
+		SpritzBaseURL:              strings.TrimRight(strings.TrimSpace(os.Getenv("SPRITZ_SLACK_SPRITZ_BASE_URL")), "/"),
+		SpritzServiceToken:         strings.TrimSpace(os.Getenv("SPRITZ_SLACK_SPRITZ_SERVICE_TOKEN")),
+		PrincipalID:                strings.TrimSpace(os.Getenv("SPRITZ_SLACK_PRINCIPAL_ID")),
+		HTTPTimeout:                parseDurationEnv("SPRITZ_SLACK_HTTP_TIMEOUT", 15*time.Second),
+		DedupeTTL:                  parseDurationEnv("SPRITZ_SLACK_DEDUPE_TTL", 10*time.Minute),
+		ProcessingTimeout:          parseDurationEnv("SPRITZ_SLACK_PROCESSING_TIMEOUT", 120*time.Second),
+		SessionRetryInterval:       parseDurationEnv("SPRITZ_SLACK_SESSION_RETRY_INTERVAL", time.Second),
+		StatusMessageDelay:         parseDurationEnv("SPRITZ_SLACK_STATUS_MESSAGE_DELAY", 5*time.Second),
+		RecoveryTimeout:            parseDurationEnv("SPRITZ_SLACK_RECOVERY_TIMEOUT", 120*time.Second),
+		PromptRetryInitial:         parseDurationEnv("SPRITZ_SLACK_PROMPT_RETRY_INITIAL", 250*time.Millisecond),
+		PromptRetryMax:             parseDurationEnv("SPRITZ_SLACK_PROMPT_RETRY_MAX", 2*time.Second),
+		PromptRetryTimeout:         parseDurationEnv("SPRITZ_SLACK_PROMPT_RETRY_TIMEOUT", 8*time.Second),
+		InstallationPolicyCacheTTL: parseDurationEnv("SPRITZ_SLACK_INSTALLATION_POLICY_CACHE_TTL", 10*time.Second),
 	}
 
 	if cfg.PublicURL == "" {

--- a/integrations/slack-gateway/gateway.go
+++ b/integrations/slack-gateway/gateway.go
@@ -23,6 +23,7 @@ type slackGateway struct {
 	httpClient *http.Client
 	state      *oauthStateManager
 	dedupe     *dedupeStore
+	policies   *installationPolicyCache
 	logger     *slog.Logger
 	workers    sync.WaitGroup
 }
@@ -66,11 +67,15 @@ func newSlackGateway(cfg config, logger *slog.Logger) *slackGateway {
 	if cfg.PromptRetryTimeout <= 0 {
 		cfg.PromptRetryTimeout = 8 * time.Second
 	}
+	if cfg.InstallationPolicyCacheTTL <= 0 {
+		cfg.InstallationPolicyCacheTTL = 10 * time.Second
+	}
 	return &slackGateway{
 		cfg:        cfg,
 		httpClient: &http.Client{},
 		state:      newOAuthStateManager(cfg.OAuthStateSecret, 15*time.Minute),
 		dedupe:     newDedupeStore(cfg.DedupeTTL),
+		policies:   newInstallationPolicyCache(cfg.InstallationPolicyCacheTTL),
 		logger:     logger,
 	}
 }
@@ -85,6 +90,8 @@ func (g *slackGateway) routes() http.Handler {
 	g.registerRoute(mux, "/slack/workspaces/target", g.handleWorkspaceTarget)
 	g.registerRoute(mux, "/slack/workspaces/test", g.handleWorkspaceTest)
 	g.registerRoute(mux, "/slack/workspaces/disconnect", g.handleWorkspaceDisconnect)
+	g.registerRoute(mux, "/settings/channels", g.handleChannelSettings)
+	g.registerRoute(mux, "/settings/channels/", g.handleChannelSettings)
 	g.registerRoute(mux, "/slack/oauth/callback", g.handleOAuthCallback)
 	g.registerRoute(mux, "/slack/events", g.handleSlackEvents)
 	return mux

--- a/integrations/slack-gateway/gateway_test.go
+++ b/integrations/slack-gateway/gateway_test.go
@@ -1893,10 +1893,14 @@ func TestSlackEventRoutesToConversationAndReplies(t *testing.T) {
 
 func TestSlackEventIgnoresTopLevelChannelMessagesWithoutMention(t *testing.T) {
 	var backendCalls int
+	var exchangePayload map[string]any
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		backendCalls++
 		if r.URL.Path != "/internal/v1/spritz/channel-sessions/exchange" {
 			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&exchangePayload); err != nil {
+			t.Fatalf("decode session exchange body: %v", err)
 		}
 		writeJSON(w, http.StatusOK, map[string]any{
 			"status": "resolved",
@@ -1952,6 +1956,9 @@ func TestSlackEventIgnoresTopLevelChannelMessagesWithoutMention(t *testing.T) {
 	}
 	if backendCalls != 1 {
 		t.Fatalf("expected one backend policy lookup, got %d backend calls", backendCalls)
+	}
+	if exchangePayload["externalChannelId"] != "C_1" {
+		t.Fatalf("expected session exchange to include message channel id, got %#v", exchangePayload)
 	}
 }
 

--- a/integrations/slack-gateway/gateway_test.go
+++ b/integrations/slack-gateway/gateway_test.go
@@ -369,6 +369,170 @@ func TestWorkspaceManagementRendersManagedInstallations(t *testing.T) {
 	}
 }
 
+func TestChannelSettingsRendersManagedConnections(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/internal/v2/spritz/channel-installations/list" {
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"status": "resolved",
+			"installations": []map[string]any{
+				{
+					"id": "ci_1",
+					"route": map[string]any{
+						"principalId":       "shared-slack-gateway",
+						"provider":          "slack",
+						"externalScopeType": "workspace",
+						"externalTenantId":  "T_workspace_1",
+					},
+					"state": "ready",
+					"currentTarget": map[string]any{
+						"id": "ag_workspace",
+						"profile": map[string]any{
+							"name": "Workspace Helper",
+						},
+					},
+					"connections": []map[string]any{
+						{
+							"id":        "cc_1",
+							"isDefault": true,
+							"state":     "ready",
+							"routes": []map[string]any{
+								{
+									"id":                "cr_1",
+									"externalChannelId": "C_channel_1",
+									"requireMention":    false,
+									"enabled":           true,
+								},
+							},
+						},
+					},
+					"allowedActions": []string{"changeTarget", "disconnect"},
+				},
+			},
+		})
+	}))
+	defer backend.Close()
+
+	gateway := newSlackGateway(config{
+		BackendFastAPIBaseURL: backend.URL,
+		BackendInternalToken:  "backend-internal-token",
+		PrincipalID:           "shared-slack-gateway",
+		HTTPTimeout:           5 * time.Second,
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	req := httptest.NewRequest(http.MethodGet, "/settings/channels/installations/ci_1/connections/cc_1", nil)
+	req.Header.Set("X-Spritz-User-Id", "user-1")
+	rec := httptest.NewRecorder()
+	gateway.routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "T_workspace_1") || !strings.Contains(body, "Workspace Helper") {
+		t.Fatalf("expected channel settings context on page, got %q", body)
+	}
+	if !strings.Contains(body, "C_channel_1") || !strings.Contains(body, "Relays without mention") {
+		t.Fatalf("expected configured channel route on page, got %q", body)
+	}
+}
+
+func TestChannelSettingsUpdatePostsRoutePolicies(t *testing.T) {
+	var updatePayload map[string]any
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/internal/v2/spritz/channel-installations/list":
+			writeJSON(w, http.StatusOK, map[string]any{
+				"status": "resolved",
+				"installations": []map[string]any{
+					{
+						"id": "ci_1",
+						"route": map[string]any{
+							"principalId":       "shared-slack-gateway",
+							"provider":          "slack",
+							"externalScopeType": "workspace",
+							"externalTenantId":  "T_workspace_1",
+						},
+						"state": "ready",
+						"connections": []map[string]any{
+							{
+								"id":        "cc_1",
+								"isDefault": true,
+								"state":     "ready",
+								"routes": []map[string]any{
+									{
+										"id":                "cr_1",
+										"externalChannelId": "C_existing",
+										"requireMention":    true,
+										"enabled":           true,
+									},
+								},
+							},
+						},
+						"allowedActions": []string{"changeTarget", "disconnect"},
+					},
+				},
+			})
+		case "/internal/v2/spritz/channel-installations/routes/update":
+			if err := json.NewDecoder(r.Body).Decode(&updatePayload); err != nil {
+				t.Fatalf("decode update payload: %v", err)
+			}
+			writeJSON(w, http.StatusOK, map[string]any{
+				"status":            "resolved",
+				"needsProvisioning": false,
+			})
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer backend.Close()
+
+	gateway := newSlackGateway(config{
+		BackendFastAPIBaseURL: backend.URL,
+		BackendInternalToken:  "backend-internal-token",
+		PrincipalID:           "shared-slack-gateway",
+		HTTPTimeout:           5 * time.Second,
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/settings/channels/installations/ci_1/connections/cc_1",
+		strings.NewReader("action=upsert&externalChannelId=C_new"),
+	)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("X-Spritz-User-Id", "user-1")
+	rec := httptest.NewRecorder()
+	gateway.routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if updatePayload["callerAuthId"] != "user-1" {
+		t.Fatalf("expected caller auth id, got %#v", updatePayload["callerAuthId"])
+	}
+	if updatePayload["installationId"] != "ci_1" || updatePayload["connectionId"] != "cc_1" {
+		t.Fatalf("expected installation and connection ids, got %#v", updatePayload)
+	}
+	policies, ok := updatePayload["channelPolicies"].([]any)
+	if !ok || len(policies) != 2 {
+		t.Fatalf("expected two channel policies, got %#v", updatePayload["channelPolicies"])
+	}
+	var newPolicy map[string]any
+	for _, rawPolicy := range policies {
+		policy, ok := rawPolicy.(map[string]any)
+		if !ok {
+			t.Fatalf("expected policy object, got %#v", rawPolicy)
+		}
+		if policy["externalChannelId"] == "C_new" {
+			newPolicy = policy
+		}
+	}
+	if newPolicy == nil || newPolicy["requireMention"] != false {
+		t.Fatalf("expected no-mention policy for C_new, got %#v", policies)
+	}
+}
+
 func TestWorkspaceManagementAcceptsConfiguredBrowserAuthHeaders(t *testing.T) {
 	t.Setenv("SPRITZ_AUTH_HEADER_ID", "X-Forwarded-User")
 	t.Setenv("SPRITZ_AUTH_HEADER_EMAIL", "X-Forwarded-Email")
@@ -1632,7 +1796,22 @@ func TestSlackEventIgnoresTopLevelChannelMessagesWithoutMention(t *testing.T) {
 	var backendCalls int
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		backendCalls++
-		t.Fatalf("unexpected backend path %s", r.URL.Path)
+		if r.URL.Path != "/internal/v1/spritz/channel-sessions/exchange" {
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"status": "resolved",
+			"session": map[string]any{
+				"accessToken":  "owner-token",
+				"ownerAuthId":  "owner-123",
+				"namespace":    "spritz-staging",
+				"instanceId":   "zeno-acme",
+				"providerAuth": map[string]any{"botUserId": "U_bot"},
+				"installationConfig": map[string]any{
+					"channelPolicies": []map[string]any{},
+				},
+			},
+		})
 	}))
 	defer backend.Close()
 
@@ -1672,8 +1851,8 @@ func TestSlackEventIgnoresTopLevelChannelMessagesWithoutMention(t *testing.T) {
 	if err := gateway.waitForWorkers(drainCtx); err != nil {
 		t.Fatalf("worker drain failed: %v", err)
 	}
-	if backendCalls != 0 {
-		t.Fatalf("expected plain channel chatter to be ignored, got %d backend calls", backendCalls)
+	if backendCalls != 1 {
+		t.Fatalf("expected one backend policy lookup, got %d backend calls", backendCalls)
 	}
 }
 
@@ -2458,8 +2637,8 @@ func TestShouldIgnoreSlackMessageEventRejectsSystemSubtypes(t *testing.T) {
 	}
 }
 
-func TestShouldProcessSlackMessageEventRequiresMentionOutsideDMs(t *testing.T) {
-	if shouldProcessSlackMessageEvent(
+func TestShouldProcessSlackMessageEventQueuesChannelMessagesForPolicyCheck(t *testing.T) {
+	if !shouldProcessSlackMessageEvent(
 		slackEventInner{
 			Type:        "message",
 			Channel:     "C_1",
@@ -2467,7 +2646,7 @@ func TestShouldProcessSlackMessageEventRequiresMentionOutsideDMs(t *testing.T) {
 			TS:          "1711387375.000100",
 		},
 	) {
-		t.Fatalf("expected top-level channel messages to be ignored")
+		t.Fatalf("expected top-level channel messages to be queued for policy check")
 	}
 	if !shouldProcessSlackMessageEvent(
 		slackEventInner{
@@ -2479,7 +2658,7 @@ func TestShouldProcessSlackMessageEventRequiresMentionOutsideDMs(t *testing.T) {
 	) {
 		t.Fatalf("expected channel app_mention events to be processed")
 	}
-	if shouldProcessSlackMessageEvent(
+	if !shouldProcessSlackMessageEvent(
 		slackEventInner{
 			Type:        "message",
 			Channel:     "C_1",
@@ -2488,7 +2667,7 @@ func TestShouldProcessSlackMessageEventRequiresMentionOutsideDMs(t *testing.T) {
 			TS:          "1711387376.000100",
 		},
 	) {
-		t.Fatalf("expected unmentioned channel thread replies to be ignored")
+		t.Fatalf("expected channel thread replies to be queued for policy check")
 	}
 	if !shouldProcessSlackMessageEvent(
 		slackEventInner{
@@ -2499,6 +2678,37 @@ func TestShouldProcessSlackMessageEventRequiresMentionOutsideDMs(t *testing.T) {
 		},
 	) {
 		t.Fatalf("expected DM messages to be processed")
+	}
+}
+
+func TestShouldRelaySlackMessageEventUsesInstallationPolicy(t *testing.T) {
+	requireMention := true
+	withoutMention := false
+	config := installationConfig{
+		ChannelPolicies: []installationChannelPolicy{
+			{ExternalChannelID: "C_requires", RequireMention: &requireMention},
+			{ExternalChannelID: "C_open", RequireMention: &withoutMention},
+		},
+	}
+	snapshot := installationPolicySnapshot{config: config, botUserID: "U_bot"}
+
+	if shouldRelaySlackMessageEvent(
+		slackEventInner{Type: "message", Channel: "C_requires", Text: "hello"},
+		snapshot,
+	) {
+		t.Fatalf("expected configured requireMention channel to require the bot mention")
+	}
+	if !shouldRelaySlackMessageEvent(
+		slackEventInner{Type: "message", Channel: "C_open", Text: "hello"},
+		snapshot,
+	) {
+		t.Fatalf("expected requireMention=false channel to relay without mention")
+	}
+	if !shouldRelaySlackMessageEvent(
+		slackEventInner{Type: "message", Channel: "C_requires", Text: "<@U_bot> hello"},
+		snapshot,
+	) {
+		t.Fatalf("expected explicit bot mention to relay even when requireMention is true")
 	}
 }
 

--- a/integrations/slack-gateway/gateway_test.go
+++ b/integrations/slack-gateway/gateway_test.go
@@ -450,6 +450,60 @@ func TestChannelSettingsRendersManagedConnections(t *testing.T) {
 	}
 }
 
+func TestChannelSettingsListDoesNotInventLegacyConnectionIDs(t *testing.T) {
+	requireMention := false
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/internal/v2/spritz/channel-installations/list" {
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"status": "resolved",
+			"installations": []map[string]any{
+				{
+					"id": "ci_1",
+					"route": map[string]any{
+						"principalId":       "shared-slack-gateway",
+						"provider":          "slack",
+						"externalScopeType": "workspace",
+						"externalTenantId":  "T_workspace_1",
+					},
+					"state": "ready",
+					"installationConfig": installationConfig{
+						ChannelPolicies: []installationChannelPolicy{
+							{ExternalChannelID: "C_channel_1", RequireMention: &requireMention},
+						},
+					},
+					"allowedActions": []string{"changeTarget", "disconnect"},
+				},
+			},
+		})
+	}))
+	defer backend.Close()
+
+	gateway := newSlackGateway(config{
+		BackendFastAPIBaseURL: backend.URL,
+		BackendInternalToken:  "backend-internal-token",
+		PrincipalID:           "shared-slack-gateway",
+		HTTPTimeout:           5 * time.Second,
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	req := httptest.NewRequest(http.MethodGet, "/settings/channels", nil)
+	req.Header.Set("X-Spritz-User-Id", "user-1")
+	rec := httptest.NewRecorder()
+	gateway.routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "/connections/cc_1") || strings.Contains(body, "Open settings") {
+		t.Fatalf("expected legacy response without connection id to be read-only, got %q", body)
+	}
+	if !strings.Contains(body, "Settings unavailable") {
+		t.Fatalf("expected unavailable settings marker, got %q", body)
+	}
+}
+
 func TestChannelSettingsUpdatePostsRoutePolicies(t *testing.T) {
 	var updatePayload map[string]any
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -518,6 +572,10 @@ func TestChannelSettingsUpdatePostsRoutePolicies(t *testing.T) {
 		PrincipalID:           "shared-slack-gateway",
 		HTTPTimeout:           5 * time.Second,
 	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	gateway.policies.remember("T_workspace_1", installationPolicySnapshot{
+		config:    installationConfig{},
+		botUserID: "U_bot",
+	})
 
 	req := httptest.NewRequest(
 		http.MethodPost,
@@ -554,6 +612,9 @@ func TestChannelSettingsUpdatePostsRoutePolicies(t *testing.T) {
 	}
 	if newPolicy == nil || newPolicy["requireMention"] != false {
 		t.Fatalf("expected no-mention policy for C_new, got %#v", policies)
+	}
+	if _, ok := gateway.policies.lookup("T_workspace_1"); ok {
+		t.Fatalf("expected channel settings update to evict cached policy")
 	}
 }
 

--- a/integrations/slack-gateway/gateway_test.go
+++ b/integrations/slack-gateway/gateway_test.go
@@ -406,6 +406,18 @@ func TestChannelSettingsRendersManagedConnections(t *testing.T) {
 								},
 							},
 						},
+						{
+							"id":    "cc_2",
+							"state": "ready",
+							"routes": []map[string]any{
+								{
+									"id":                "cr_2",
+									"externalChannelId": "C_channel_2",
+									"requireMention":    true,
+									"enabled":           true,
+								},
+							},
+						},
 					},
 					"allowedActions": []string{"changeTarget", "disconnect"},
 				},
@@ -421,7 +433,7 @@ func TestChannelSettingsRendersManagedConnections(t *testing.T) {
 		HTTPTimeout:           5 * time.Second,
 	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
 
-	req := httptest.NewRequest(http.MethodGet, "/settings/channels/installations/ci_1/connections/cc_1", nil)
+	req := httptest.NewRequest(http.MethodGet, "/settings/channels/installations/ci_1/connections/cc_2", nil)
 	req.Header.Set("X-Spritz-User-Id", "user-1")
 	rec := httptest.NewRecorder()
 	gateway.routes().ServeHTTP(rec, req)
@@ -433,7 +445,7 @@ func TestChannelSettingsRendersManagedConnections(t *testing.T) {
 	if !strings.Contains(body, "T_workspace_1") || !strings.Contains(body, "Workspace Helper") {
 		t.Fatalf("expected channel settings context on page, got %q", body)
 	}
-	if !strings.Contains(body, "C_channel_1") || !strings.Contains(body, "Relays without mention") {
+	if !strings.Contains(body, "C_channel_2") || !strings.Contains(body, "Mentions required") {
 		t.Fatalf("expected configured channel route on page, got %q", body)
 	}
 }
@@ -464,6 +476,18 @@ func TestChannelSettingsUpdatePostsRoutePolicies(t *testing.T) {
 									{
 										"id":                "cr_1",
 										"externalChannelId": "C_existing",
+										"requireMention":    true,
+										"enabled":           true,
+									},
+								},
+							},
+							{
+								"id":    "cc_2",
+								"state": "ready",
+								"routes": []map[string]any{
+									{
+										"id":                "cr_2",
+										"externalChannelId": "C_channel_2",
 										"requireMention":    true,
 										"enabled":           true,
 									},

--- a/integrations/slack-gateway/gateway_test.go
+++ b/integrations/slack-gateway/gateway_test.go
@@ -433,6 +433,20 @@ func TestChannelSettingsRendersManagedConnections(t *testing.T) {
 		HTTPTimeout:           5 * time.Second,
 	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
 
+	installationReq := httptest.NewRequest(http.MethodGet, "/settings/channels/installations/ci_1", nil)
+	installationReq.Header.Set("X-Spritz-User-Id", "user-1")
+	installationRec := httptest.NewRecorder()
+	gateway.routes().ServeHTTP(installationRec, installationReq)
+
+	if installationRec.Code != http.StatusOK {
+		t.Fatalf("expected installation page 200, got %d: %s", installationRec.Code, installationRec.Body.String())
+	}
+	installationBody := installationRec.Body.String()
+	if !strings.Contains(installationBody, "/settings/channels/installations/ci_1/connections/cc_1") ||
+		!strings.Contains(installationBody, "/settings/channels/installations/ci_1/connections/cc_2") {
+		t.Fatalf("expected installation page to link every connection, got %q", installationBody)
+	}
+
 	req := httptest.NewRequest(http.MethodGet, "/settings/channels/installations/ci_1/connections/cc_2", nil)
 	req.Header.Set("X-Spritz-User-Id", "user-1")
 	rec := httptest.NewRecorder()

--- a/integrations/slack-gateway/installation_policy.go
+++ b/integrations/slack-gateway/installation_policy.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"strings"
+	"sync"
+	"time"
+)
+
+type installationConfig struct {
+	ChannelPolicies []installationChannelPolicy `json:"channelPolicies,omitempty"`
+}
+
+type installationChannelPolicy struct {
+	ExternalChannelID   string `json:"externalChannelId"`
+	ExternalChannelType string `json:"externalChannelType,omitempty"`
+	RequireMention      *bool  `json:"requireMention"`
+}
+
+type installationPolicySnapshot struct {
+	config    installationConfig
+	botUserID string
+}
+
+type installationPolicyCacheEntry struct {
+	snapshot  installationPolicySnapshot
+	expiresAt time.Time
+}
+
+type installationPolicyCache struct {
+	mu      sync.Mutex
+	ttl     time.Duration
+	now     func() time.Time
+	entries map[string]installationPolicyCacheEntry
+}
+
+func newInstallationPolicyCache(ttl time.Duration) *installationPolicyCache {
+	if ttl <= 0 {
+		ttl = 10 * time.Second
+	}
+	return &installationPolicyCache{
+		ttl:     ttl,
+		now:     time.Now,
+		entries: map[string]installationPolicyCacheEntry{},
+	}
+}
+
+func (cache *installationPolicyCache) remember(teamID string, snapshot installationPolicySnapshot) {
+	if cache == nil {
+		return
+	}
+	teamID = strings.TrimSpace(teamID)
+	if teamID == "" {
+		return
+	}
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	cache.entries[teamID] = installationPolicyCacheEntry{
+		snapshot:  snapshot,
+		expiresAt: cache.now().Add(cache.ttl),
+	}
+}
+
+func (cache *installationPolicyCache) lookup(teamID string) (installationPolicySnapshot, bool) {
+	if cache == nil {
+		return installationPolicySnapshot{}, false
+	}
+	teamID = strings.TrimSpace(teamID)
+	if teamID == "" {
+		return installationPolicySnapshot{}, false
+	}
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	entry, ok := cache.entries[teamID]
+	if !ok {
+		return installationPolicySnapshot{}, false
+	}
+	if !entry.expiresAt.After(cache.now()) {
+		delete(cache.entries, teamID)
+		return installationPolicySnapshot{}, false
+	}
+	return entry.snapshot, true
+}
+
+func (session channelSession) policySnapshot() installationPolicySnapshot {
+	return installationPolicySnapshot{
+		config:    session.InstallationConfig,
+		botUserID: strings.TrimSpace(session.ProviderAuth.BotUserID),
+	}
+}
+
+func shouldRelaySlackMessageEvent(event slackEventInner, snapshot installationPolicySnapshot) bool {
+	eventType := strings.TrimSpace(event.Type)
+	if isSlackDirectMessageEvent(event) {
+		return eventType == "message"
+	}
+	if eventType == "app_mention" {
+		return true
+	}
+	if eventType != "message" {
+		return false
+	}
+	if slackTextMentionsBot(event.Text, snapshot.botUserID) {
+		return true
+	}
+	return installationConfigAllowsChannelWithoutMention(
+		snapshot.config,
+		strings.TrimSpace(event.Channel),
+	)
+}
+
+func slackTextMentionsBot(text, botUserID string) bool {
+	botUserID = strings.TrimSpace(botUserID)
+	if botUserID == "" {
+		return false
+	}
+	return strings.Contains(strings.TrimSpace(text), "<@"+botUserID+">")
+}
+
+func installationConfigAllowsChannelWithoutMention(config installationConfig, channelID string) bool {
+	channelID = strings.TrimSpace(channelID)
+	if channelID == "" {
+		return false
+	}
+	for _, policy := range config.ChannelPolicies {
+		if strings.TrimSpace(policy.ExternalChannelID) != channelID {
+			continue
+		}
+		return policy.RequireMention != nil && !*policy.RequireMention
+	}
+	return false
+}

--- a/integrations/slack-gateway/installation_policy.go
+++ b/integrations/slack-gateway/installation_policy.go
@@ -81,6 +81,19 @@ func (cache *installationPolicyCache) lookup(teamID string) (installationPolicyS
 	return entry.snapshot, true
 }
 
+func (cache *installationPolicyCache) forget(teamID string) {
+	if cache == nil {
+		return
+	}
+	teamID = strings.TrimSpace(teamID)
+	if teamID == "" {
+		return
+	}
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	delete(cache.entries, teamID)
+}
+
 func (session channelSession) policySnapshot() installationPolicySnapshot {
 	return installationPolicySnapshot{
 		config:    session.InstallationConfig,

--- a/integrations/slack-gateway/slack_events.go
+++ b/integrations/slack-gateway/slack_events.go
@@ -859,6 +859,7 @@ func (g *slackGateway) awaitChannelSession(
 		session, err := g.exchangeChannelSession(
 			exchangeCtx,
 			envelope.TeamID,
+			event.Channel,
 			exchangeForceRefresh,
 		)
 		cancelExchange()

--- a/integrations/slack-gateway/slack_events.go
+++ b/integrations/slack-gateway/slack_events.go
@@ -574,7 +574,11 @@ func (g *slackGateway) processMessageEventWithDeliveryOptions(
 	}
 
 	recoveryState := newChannelSessionRecoveryState()
-	session, terminalHandled, err := g.awaitChannelSession(
+	if snapshot, ok := g.policies.lookup(envelope.TeamID); ok && !shouldRelaySlackMessageEvent(event, snapshot) {
+		success = true
+		return messageEventProcessResult{Outcome: messageEventOutcomeIgnored}, nil
+	}
+	session, ignoredByPolicy, terminalHandled, err := g.awaitChannelSession(
 		ctx,
 		envelope,
 		event,
@@ -583,6 +587,10 @@ func (g *slackGateway) processMessageEventWithDeliveryOptions(
 	)
 	if err != nil {
 		return messageEventProcessResult{}, err
+	}
+	if ignoredByPolicy {
+		success = true
+		return messageEventProcessResult{Outcome: messageEventOutcomeIgnored}, nil
 	}
 	if terminalHandled {
 		success = true
@@ -652,7 +660,7 @@ func (g *slackGateway) processMessageEventWithDeliveryOptions(
 			}
 		} else {
 			recoveryState.resetPromptRetry()
-			recoveredSession, recoveredTerminalHandled, recoveryErr := g.awaitChannelSession(
+			recoveredSession, recoveredIgnoredByPolicy, recoveredTerminalHandled, recoveryErr := g.awaitChannelSession(
 				ctx,
 				envelope,
 				event,
@@ -661,6 +669,10 @@ func (g *slackGateway) processMessageEventWithDeliveryOptions(
 			)
 			if recoveryErr != nil {
 				return messageEventProcessResult{}, recoveryErr
+			}
+			if recoveredIgnoredByPolicy {
+				success = true
+				return messageEventProcessResult{Outcome: messageEventOutcomeIgnored}, nil
 			}
 			if recoveredTerminalHandled {
 				success = true
@@ -807,7 +819,7 @@ func (g *slackGateway) awaitChannelSession(
 	event slackEventInner,
 	recoveryState *channelSessionRecoveryState,
 	forceRefresh bool,
-) (channelSession, bool, error) {
+) (channelSession, bool, bool, error) {
 	if recoveryState == nil {
 		recoveryState = newChannelSessionRecoveryState()
 	}
@@ -831,11 +843,11 @@ func (g *slackGateway) awaitChannelSession(
 					"channel_id", strings.TrimSpace(event.Channel),
 					"message_ts", strings.TrimSpace(event.TS),
 				)
-				return channelSession{}, false, postErr
+				return channelSession{}, false, false, postErr
 			} else if terminalHandled {
-				return channelSession{}, true, nil
+				return channelSession{}, false, true, nil
 			}
-			return channelSession{}, false, context.DeadlineExceeded
+			return channelSession{}, false, false, context.DeadlineExceeded
 		}
 
 		exchangeCtx := ctx
@@ -852,7 +864,17 @@ func (g *slackGateway) awaitChannelSession(
 		cancelExchange()
 		if err == nil {
 			recoveryState.rememberProviderAuth(session.ProviderAuth)
-			return session, false, nil
+			g.policies.remember(envelope.TeamID, session.policySnapshot())
+			if !shouldRelaySlackMessageEvent(event, session.policySnapshot()) {
+				return channelSession{}, true, false, nil
+			}
+			return session, false, false, nil
+		}
+		if snapshot, ok := channelSessionUnavailablePolicySnapshot(err); ok {
+			g.policies.remember(envelope.TeamID, snapshot)
+			if !shouldRelaySlackMessageEvent(event, snapshot) {
+				return channelSession{}, true, false, nil
+			}
 		}
 
 		providerAuth, recoverable := channelSessionUnavailableProviderAuth(err)
@@ -874,11 +896,11 @@ func (g *slackGateway) awaitChannelSession(
 						"channel_id", strings.TrimSpace(event.Channel),
 						"message_ts", strings.TrimSpace(event.TS),
 					)
-					return channelSession{}, false, postErr
+					return channelSession{}, false, false, postErr
 				} else if terminalHandled {
-					return channelSession{}, true, nil
+					return channelSession{}, false, true, nil
 				}
-				return channelSession{}, false, err
+				return channelSession{}, false, false, err
 			}
 		} else {
 			recoveryState.rememberProviderAuth(providerAuth)
@@ -912,11 +934,11 @@ func (g *slackGateway) awaitChannelSession(
 					"channel_id", strings.TrimSpace(event.Channel),
 					"message_ts", strings.TrimSpace(event.TS),
 				)
-				return channelSession{}, false, postErr
+				return channelSession{}, false, false, postErr
 			} else if terminalHandled {
-				return channelSession{}, true, nil
+				return channelSession{}, false, true, nil
 			}
-			return channelSession{}, false, err
+			return channelSession{}, false, false, err
 		}
 	}
 }
@@ -931,7 +953,7 @@ func shouldProcessSlackMessageEvent(event slackEventInner) bool {
 	if isSlackDirectMessageEvent(event) {
 		return eventType == "message"
 	}
-	return eventType == "app_mention"
+	return eventType == "app_mention" || eventType == "message"
 }
 
 func isSlackDirectMessageEvent(event slackEventInner) bool {
@@ -944,18 +966,16 @@ func isSlackDirectMessageEvent(event slackEventInner) bool {
 
 func normalizeSlackPromptText(eventType, text, botUserID string) string {
 	normalized := strings.TrimSpace(text)
-	if strings.TrimSpace(eventType) == "app_mention" {
-		botUserID = strings.TrimSpace(botUserID)
-		if botUserID != "" {
-			mentionToken := "<@" + botUserID + ">"
-			if index := strings.Index(normalized, mentionToken); index >= 0 {
-				normalized = strings.TrimSpace(
-					normalized[:index] + normalized[index+len(mentionToken):],
-				)
-			}
-		} else {
-			normalized = slackMentionTokenPattern.ReplaceAllString(normalized, " ")
+	botUserID = strings.TrimSpace(botUserID)
+	if botUserID != "" {
+		mentionToken := "<@" + botUserID + ">"
+		if index := strings.Index(normalized, mentionToken); index >= 0 {
+			normalized = strings.TrimSpace(
+				normalized[:index] + normalized[index+len(mentionToken):],
+			)
 		}
+	} else if strings.TrimSpace(eventType) == "app_mention" {
+		normalized = slackMentionTokenPattern.ReplaceAllString(normalized, " ")
 	}
 	return strings.TrimSpace(normalized)
 }

--- a/integrations/slack-gateway/workspace_management.go
+++ b/integrations/slack-gateway/workspace_management.go
@@ -13,17 +13,18 @@ type workspaceManagementNotice struct {
 }
 
 type workspaceManagementRow struct {
-	TeamID             string
-	State              string
-	CurrentTargetName  string
-	CurrentTargetOwner string
-	TargetStatus       string
-	ChangeTargetHref   string
-	TestHref           string
-	ReconnectHref      string
-	ShowReconnect      bool
-	ShowDisconnect     bool
-	ShowTest           bool
+	TeamID              string
+	State               string
+	CurrentTargetName   string
+	CurrentTargetOwner  string
+	TargetStatus        string
+	ChangeTargetHref    string
+	ChannelSettingsHref string
+	TestHref            string
+	ReconnectHref       string
+	ShowReconnect       bool
+	ShowDisconnect      bool
+	ShowTest            bool
 }
 
 type workspaceManagementPageData struct {
@@ -165,6 +166,9 @@ var workspaceManagementTemplate = template.Must(template.New("workspace-manageme
         </div>
         <div class="actions">
           <a class="primary" href="{{ .ChangeTargetHref }}">Change target</a>
+          {{ if .ChannelSettingsHref }}
+          <a class="secondary" href="{{ .ChannelSettingsHref }}">Channel settings</a>
+          {{ end }}
           {{ if .ShowTest }}
           <a class="secondary" href="{{ .TestHref }}">Send test</a>
           {{ end }}
@@ -287,18 +291,24 @@ func (g *slackGateway) renderWorkspaceManagementPage(w http.ResponseWriter, r *h
 			currentTargetName = strings.TrimSpace(installation.CurrentTarget.Profile.Name)
 			currentTargetOwner = strings.TrimSpace(installation.CurrentTarget.OwnerLabel)
 		}
+		settingsHref := ""
+		connection := primaryManagedConnection(installation)
+		if strings.TrimSpace(installation.ID) != "" && strings.TrimSpace(connection.ID) != "" {
+			settingsHref = g.channelSettingsConnectionPath(installation.ID, connection.ID)
+		}
 		rows = append(rows, workspaceManagementRow{
-			TeamID:             strings.TrimSpace(installation.Route.ExternalTenantID),
-			State:              strings.TrimSpace(installation.State),
-			CurrentTargetName:  currentTargetName,
-			CurrentTargetOwner: currentTargetOwner,
-			TargetStatus:       workspaceTargetStatus(installation),
-			ChangeTargetHref:   g.buildWorkspaceTargetHref(installation.Route.ExternalTenantID),
-			TestHref:           g.buildWorkspaceTestHref(installation.Route.ExternalTenantID),
-			ReconnectHref:      g.installRedirectPath(),
-			ShowReconnect:      hasAllowedAction(installation, "reconnect"),
-			ShowDisconnect:     hasAllowedAction(installation, "disconnect"),
-			ShowTest:           !strings.EqualFold(strings.TrimSpace(installation.State), "disconnected"),
+			TeamID:              strings.TrimSpace(installation.Route.ExternalTenantID),
+			State:               strings.TrimSpace(installation.State),
+			CurrentTargetName:   currentTargetName,
+			CurrentTargetOwner:  currentTargetOwner,
+			TargetStatus:        workspaceTargetStatus(installation),
+			ChangeTargetHref:    g.buildWorkspaceTargetHref(installation.Route.ExternalTenantID),
+			ChannelSettingsHref: settingsHref,
+			TestHref:            g.buildWorkspaceTestHref(installation.Route.ExternalTenantID),
+			ReconnectHref:       g.installRedirectPath(),
+			ShowReconnect:       hasAllowedAction(installation, "reconnect"),
+			ShowDisconnect:      hasAllowedAction(installation, "disconnect"),
+			ShowTest:            !strings.EqualFold(strings.TrimSpace(installation.State), "disconnected"),
 		})
 	}
 


### PR DESCRIPTION
## Summary

Shared channel installs need a cleaner long-term model before Slack workspace installs grow more special cases.
This documents a provider-agnostic schema that separates the external provider install, internal connection, Spritz runtime backing, and per-channel route policy.
It also pins the naming decisions we discussed: `provider = slack` is valid in this domain, while core `targetType`, `preset`, `runtime`, and `scopeType` fields should not be part of the generic installation key.

## What Changed

This adds one Spritz architecture doc for the channel installation data model.
The doc defines the recommended tables, routing behavior, UI/API shape, and migration path from the current combined installation row.

- Added `channel_installation` for the provider app installation.
- Added `channel_connection` for one or more internal connections under that install.
- Added `spritz_channel_connection` for Spritz-specific preset and runtime binding state.
- Added `channel_route` for per-channel routing and `requireMention` policy.
- Documented how Slack no-mention channels still work under workspace install mode.

## Testing

This is a docs-only change.
I checked the staged markdown diff for whitespace errors.

- `git diff --cached --check`

## Risks

Runtime behavior does not change in this PR.
The main risk is naming churn during implementation review, but the doc calls out the terms that should stay out of the generic schema.