### PR TITLE
fix: project Slack channel policies into OpenClaw channels

### DIFF
--- a/api/channel_installation_config.go
+++ b/api/channel_installation_config.go
@@ -66,16 +66,16 @@ func applyChannelInstallationConfigProjection(spec *spritzv1.SpritzSpec, attribu
 	if err != nil {
 		return err
 	}
-	providers := ensureObjectField(config, "providers")
-	providerConfig := ensureObjectField(providers, provider)
-	channels := map[string]any{}
+	channelsConfig := ensureObjectField(config, "channels")
+	providerConfig := ensureObjectField(channelsConfig, provider)
+	providerChannels := map[string]any{}
 	for _, policy := range channelPolicies {
-		channels[policy.ExternalChannelID] = map[string]any{
+		providerChannels[policy.ExternalChannelID] = map[string]any{
 			"allow":          true,
 			"requireMention": *policy.RequireMention,
 		}
 	}
-	providerConfig["channels"] = channels
+	providerConfig["channels"] = providerChannels
 
 	encoded, err := json.Marshal(config)
 	if err != nil {

--- a/api/internal_bindings_test.go
+++ b/api/internal_bindings_test.go
@@ -191,7 +191,7 @@ func TestInternalUpsertBindingProjectsInstallationConfigIntoOpenClawEnv(t *testi
 	s := newInternalSpritzesTestServer(t)
 	s.presets.byID[0].Env = []corev1.EnvVar{{
 		Name:  "OPENCLAW_CONFIG_JSON",
-		Value: `{"providers":{"slack":{"channels":{"C_OLD":{"allow":true,"requireMention":false}}}}}`,
+		Value: `{"channels":{"slack":{"groupPolicy":"allowlist","channels":{"C_OLD":{"allow":true,"requireMention":false}}}}}`,
 	}}
 	e := echo.New()
 	s.registerRoutes(e)
@@ -250,12 +250,15 @@ func TestInternalUpsertBindingProjectsInstallationConfigIntoOpenClawEnv(t *testi
 	if err := json.Unmarshal([]byte(openClawConfig), &projected); err != nil {
 		t.Fatalf("expected valid OpenClaw config JSON, got %s: %v", openClawConfig, err)
 	}
-	providers, _ := projected["providers"].(map[string]any)
-	slackConfig, _ := providers["slack"].(map[string]any)
+	channelsConfig, _ := projected["channels"].(map[string]any)
+	slackConfig, _ := channelsConfig["slack"].(map[string]any)
 	channels, _ := slackConfig["channels"].(map[string]any)
 	channelConfig, _ := channels["C0ANJGDB4Q5"].(map[string]any)
 	if channelConfig["allow"] != true || channelConfig["requireMention"] != false {
 		t.Fatalf("expected OpenClaw channel policy in env, got %s", openClawConfig)
+	}
+	if slackConfig["groupPolicy"] != "allowlist" {
+		t.Fatalf("expected existing Slack OpenClaw config to be preserved, got %s", openClawConfig)
 	}
 	if _, exists := channels["C_OLD"]; exists {
 		t.Fatalf("expected stale OpenClaw channel policy to be removed, got %s", openClawConfig)
@@ -266,7 +269,7 @@ func TestInternalUpsertBindingProjectsNullInstallationConfigAsEmptyPolicy(t *tes
 	spec := spritzv1.SpritzSpec{
 		Env: []corev1.EnvVar{{
 			Name:  "OPENCLAW_CONFIG_JSON",
-			Value: `{"providers":{"slack":{"channels":{"C_OLD":{"allow":true,"requireMention":false}}}}}`,
+			Value: `{"channels":{"slack":{"channels":{"C_OLD":{"allow":true,"requireMention":false}}}}}`,
 		}},
 	}
 
@@ -293,8 +296,8 @@ func TestInternalUpsertBindingProjectsNullInstallationConfigAsEmptyPolicy(t *tes
 	if err := json.Unmarshal([]byte(openClawConfig), &projected); err != nil {
 		t.Fatalf("expected valid OpenClaw config JSON, got %s: %v", openClawConfig, err)
 	}
-	providers, _ := projected["providers"].(map[string]any)
-	slackConfig, _ := providers["slack"].(map[string]any)
+	channelsConfig, _ := projected["channels"].(map[string]any)
+	slackConfig, _ := channelsConfig["slack"].(map[string]any)
 	channels, _ := slackConfig["channels"].(map[string]any)
 	if len(channels) != 0 {
 		t.Fatalf("expected null installationConfig to remove stale channels, got %s", openClawConfig)
@@ -331,8 +334,8 @@ func TestInternalUpsertBindingProjectsInstallationConfigWithoutDroppingOpenClawD
 	if browser["enabled"] != true || browser["executablePath"] != "/usr/bin/chromium" {
 		t.Fatalf("expected OpenClaw browser defaults to be preserved, got %s", openClawConfig)
 	}
-	providers, _ := projected["providers"].(map[string]any)
-	slackConfig, _ := providers["slack"].(map[string]any)
+	channelsConfig, _ := projected["channels"].(map[string]any)
+	slackConfig, _ := channelsConfig["slack"].(map[string]any)
 	channels, _ := slackConfig["channels"].(map[string]any)
 	channelConfig, _ := channels["C0ANJGDB4Q5"].(map[string]any)
 	if channelConfig["allow"] != true || channelConfig["requireMention"] != false {

--- a/docs/2026-04-24-channel-install-message-policy-config.md
+++ b/docs/2026-04-24-channel-install-message-policy-config.md
@@ -249,7 +249,7 @@ Example projection:
 
 ```json
 {
-  "providers": {
+  "channels": {
     "slack": {
       "channels": {
         "C1234567890": {


### PR DESCRIPTION
## Summary
- project managed Slack channel policies into `channels.slack.channels`, which matches the OpenClaw config schema
- preserve existing Slack channel config fields while replacing the generated per-channel policy map
- update docs and regression tests for the valid OpenClaw shape

## Testing
- `GOCACHE=/tmp/go-build-cache go test ./...` in `api`
- `GOCACHE=/tmp/go-build-cache go test ./...` in `integrations/slack-gateway`
- `git diff --check`
