### PR TITLE
fix: expose rendered binding template internally

### DIFF
--- a/api/internal_bindings.go
+++ b/api/internal_bindings.go
@@ -43,10 +43,14 @@ type internalBindingMetadata struct {
 }
 
 type internalBindingTemplateSummary struct {
-	PresetID  string `json:"presetId,omitempty"`
-	Source    string `json:"source,omitempty"`
-	RequestID string `json:"requestId,omitempty"`
-	OwnerID   string `json:"ownerId,omitempty"`
+	PresetID    string              `json:"presetId,omitempty"`
+	NamePrefix  string              `json:"namePrefix,omitempty"`
+	Source      string              `json:"source,omitempty"`
+	RequestID   string              `json:"requestId,omitempty"`
+	OwnerID     string              `json:"ownerId,omitempty"`
+	Spec        spritzv1.SpritzSpec `json:"spec"`
+	Labels      map[string]string   `json:"labels,omitempty"`
+	Annotations map[string]string   `json:"annotations,omitempty"`
 }
 
 type internalBindingSpecSummary struct {
@@ -78,6 +82,8 @@ func bindingResourceNameForKey(bindingKey string) string {
 }
 
 func summarizeInternalBinding(binding *spritzv1.SpritzBinding) internalBindingSummary {
+	templateSpec := spritzv1.SpritzSpec{}
+	binding.Spec.Template.Spec.DeepCopyInto(&templateSpec)
 	return internalBindingSummary{
 		Metadata: internalBindingMetadata{
 			Name:              binding.Name,
@@ -90,10 +96,14 @@ func summarizeInternalBinding(binding *spritzv1.SpritzBinding) internalBindingSu
 			Disconnected:    binding.Spec.Disconnected,
 			Attributes:      cloneStringMap(binding.Spec.Attributes),
 			Template: internalBindingTemplateSummary{
-				PresetID:  strings.TrimSpace(binding.Spec.Template.PresetID),
-				Source:    strings.TrimSpace(binding.Spec.Template.Source),
-				RequestID: strings.TrimSpace(binding.Spec.Template.RequestID),
-				OwnerID:   strings.TrimSpace(binding.Spec.Template.Spec.Owner.ID),
+				PresetID:    strings.TrimSpace(binding.Spec.Template.PresetID),
+				NamePrefix:  strings.TrimSpace(binding.Spec.Template.NamePrefix),
+				Source:      strings.TrimSpace(binding.Spec.Template.Source),
+				RequestID:   strings.TrimSpace(binding.Spec.Template.RequestID),
+				OwnerID:     strings.TrimSpace(binding.Spec.Template.Spec.Owner.ID),
+				Spec:        templateSpec,
+				Labels:      cloneStringMap(binding.Spec.Template.Labels),
+				Annotations: cloneStringMap(binding.Spec.Template.Annotations),
 			},
 		},
 		Status: binding.Status,

--- a/api/internal_bindings_test.go
+++ b/api/internal_bindings_test.go
@@ -109,6 +109,19 @@ func TestInternalUpsertBindingCreatesAndFetchesBinding(t *testing.T) {
 	if !strings.Contains(getRec.Body.String(), `"presetId":"zeno"`) {
 		t.Fatalf("expected fetched preset id in response, got %s", getRec.Body.String())
 	}
+	var getPayload map[string]any
+	if err := json.Unmarshal(getRec.Body.Bytes(), &getPayload); err != nil {
+		t.Fatalf("failed to decode fetched binding response: %v", err)
+	}
+	template := requireJSONPathObject(t, getPayload, "data", "spec", "template")
+	renderedSpec := requireJSONPathObject(t, template, "spec")
+	if renderedSpec["serviceAccountName"] != "zeno-agent-user-123" {
+		t.Fatalf("expected rendered service account in fetched binding response, got %#v", renderedSpec)
+	}
+	agentRef := requireJSONPathObject(t, renderedSpec, "agentRef")
+	if agentRef["id"] != "ag-123" {
+		t.Fatalf("expected rendered agent ref in fetched binding response, got %#v", agentRef)
+	}
 
 	var stored spritzv1.SpritzBinding
 	if err := s.client.Get(
@@ -130,6 +143,19 @@ func TestInternalUpsertBindingCreatesAndFetchesBinding(t *testing.T) {
 	if resolverHits != 1 {
 		t.Fatalf("expected resolver to be called once, got %d", resolverHits)
 	}
+}
+
+func requireJSONPathObject(t *testing.T, root map[string]any, path ...string) map[string]any {
+	t.Helper()
+	current := root
+	for _, key := range path {
+		next, ok := current[key].(map[string]any)
+		if !ok {
+			t.Fatalf("expected object at JSON path %s, got %#v", strings.Join(path, "."), current[key])
+		}
+		current = next
+	}
+	return current
 }
 
 func TestInternalUpsertBindingPreservesNormalizedCreateAnnotations(t *testing.T) {

--- a/docs/2026-04-25-binding-target-reconciliation.md
+++ b/docs/2026-04-25-binding-target-reconciliation.md
@@ -1,0 +1,255 @@
+---
+date: 2026-04-25
+author: Spritz Team
+title: Binding Target Reconciliation
+tags: [spritz, binding, reconciliation, channel-gateway, architecture]
+---
+
+## Overview
+
+Spritz needs one clear readiness rule for long-lived channel bindings:
+
+> The desired target saved by the deployment must match the target rendered into
+> the live `SpritzBinding`.
+
+If those two targets differ, the binding is not ready.
+It should be repaired automatically and reported as provisioning until the live
+runtime catches up.
+
+This document describes the generic Spritz-side contract.
+It does not depend on any specific deployment, provider, model, or agent system.
+
+Related docs:
+
+- [Spritz Binding Lifecycle Architecture](2026-04-03-spritz-binding-lifecycle-architecture.md)
+- [Channel Install Target Selection Architecture](2026-04-17-channel-install-target-selection-architecture.md)
+- [Channel Installation Data Model](2026-04-24-channel-installation-data-model.md)
+
+## Problem
+
+A shared channel installation has two layers of state:
+
+- desired business state, usually stored by the deployment
+- live runtime state, stored in Spritz and Kubernetes
+
+For target-selected installs, the desired business state includes an opaque
+target selector such as `presetInputs`.
+
+The live runtime state includes the rendered `SpritzBinding` template and the
+currently active `Spritz` instance.
+
+If these layers disagree, Spritz can route traffic to the wrong runtime while a
+management API or UI shows the desired target.
+
+That is a correctness bug.
+
+## Required Invariant
+
+For any binding backed by a saved target selection:
+
+```text
+saved target selector == rendered binding target
+```
+
+In v1, the target selector is deployment-owned and opaque to Spritz.
+
+Spritz should not interpret the selector as an agent, organization, workspace,
+or provider-specific object.
+
+Spritz only needs a deployment-provided way to compare:
+
+```text
+expected target identity from saved desired state
+actual target identity from rendered SpritzBinding
+```
+
+If they differ, the binding must not be treated as ready.
+
+## Source of Truth
+
+The deployment-owned installation record remains the source of truth for:
+
+- provider installation identity
+- target selection payload
+- owner or tenant business metadata
+- provider auth metadata
+
+The `SpritzBinding` is derived control-plane state.
+
+Spritz should not invent a new target from Kubernetes state.
+Kubernetes state can prove what is running, but it should not decide what should
+be running.
+
+## Simple Production Fix
+
+No schema change is required for the first production fix.
+
+The route or status resolver should check target consistency before returning
+ready.
+
+For each active installation:
+
+1. Load the saved target selection from the deployment installation record.
+2. Load the live `SpritzBinding` by binding key.
+3. Extract the rendered target identity from the binding template.
+4. Compare the saved target identity with the rendered target identity.
+5. If they differ, trigger the existing binding upsert/reconcile path.
+6. Return provisioning until the corrected binding becomes ready.
+
+This turns stale runtime state into self-healing state.
+
+## Where the Check Belongs
+
+The check should live in the shared path that decides whether a channel binding
+is usable.
+
+It should not be only a management UI check.
+
+It should run for:
+
+- channel route resolution
+- channel session exchange
+- workspace or installation status APIs
+- any force-refresh or repair path
+
+That makes the next real lookup repair drift automatically.
+
+## Repair Behavior
+
+When a mismatch is found:
+
+```text
+saved desired target = A
+live binding target = B
+```
+
+the resolver should:
+
+1. log a target mismatch event with the binding key and both target identities
+2. emit a metric for alerting
+3. call the normal binding upsert path using the saved desired state
+4. return provisioning
+
+It should not patch the live Kubernetes object directly.
+
+Direct Kubernetes patching is only an emergency operator action.
+Normal repair must use the same desired-state path as initial provisioning.
+
+## Readiness Rule
+
+A binding can be reported ready only when all of these are true:
+
+```text
+saved target == rendered binding target
+SpritzBinding phase == ready
+active runtime phase == Ready
+```
+
+If the target check fails, readiness is false even if the active runtime is
+healthy.
+
+A healthy wrong runtime is still wrong.
+
+## API Need
+
+The binding status/read API should expose enough information for a deployment to
+check the rendered target.
+
+At minimum, the response should include one of:
+
+- the rendered `spec.template`
+- a normalized rendered target identity
+- a deployment extension response that includes the resolved target identity
+
+The safest generic option is to expose the rendered binding template in the
+internal binding read response.
+
+Deployments can then compare their saved selector with the part of the rendered
+template they own.
+
+## Pseudocode
+
+```python
+def resolve_channel_binding(installation):
+    expected = deployment.extract_expected_target(installation.saved_target)
+    binding = spritz.get_binding(installation.binding_key)
+    actual = deployment.extract_rendered_target(binding.template)
+
+    if expected != actual:
+        log_target_mismatch(
+            binding_key=installation.binding_key,
+            expected=expected,
+            actual=actual,
+        )
+        binding = spritz.upsert_binding(
+            binding_key=installation.binding_key,
+            desired_state=installation.to_binding_desired_state(),
+        )
+        return provisioning(binding)
+
+    if binding.ready and binding.active_runtime_ready:
+        return ready(binding)
+
+    return provisioning(binding)
+```
+
+The deployment owns `extract_expected_target` and `extract_rendered_target`.
+Spritz owns the idempotent binding reconcile.
+
+## Versioning
+
+Do not add desired and observed generation fields for the first fix.
+
+The mismatch check is enough to prevent the known failure mode:
+
+```text
+saved target changed
+live binding did not change
+system still reported ready
+```
+
+Generation fields can be added later if Spritz needs stronger ordering,
+high-frequency target changes, or detailed audit history.
+
+The first production fix should stay small:
+
+```text
+compare
+repair
+return provisioning until ready
+```
+
+## Tests
+
+Add tests for:
+
+1. saved target and rendered target match, binding ready: returns ready
+2. saved target and rendered target differ: calls binding upsert and returns provisioning
+3. saved target and rendered target differ, upsert fails: returns unavailable or failed with a typed error
+4. rendered target is missing: treats as mismatch and repairs
+5. active runtime is healthy but target differs: does not return ready
+6. management status path shows provisioning while repair is in progress
+7. route/session path triggers the same repair as the status path
+
+## Non-Goals
+
+This document does not require:
+
+- moving deployment business records into Spritz
+- teaching Spritz deployment-specific target semantics
+- adding new SQL columns
+- adding a full audit log
+- making Kubernetes the source of truth for desired target selection
+
+## Final Rule
+
+The simple long-term rule is:
+
+```text
+desired target comes from the deployment record
+live target comes from SpritzBinding
+ready requires both to match
+```
+
+That rule keeps Spritz generic and prevents stale runtimes from silently serving
+traffic after a target change.


### PR DESCRIPTION
## Summary

- documents the generic binding target reconciliation contract
- exposes rendered binding template details in the internal binding response so deployments can compare saved target state with live SpritzBinding state
- adds a regression test covering resolved service account and agent ref visibility from the internal binding read response

## Tests

- go test ./... (api)
- go test ./... (operator)
- codex review --base main

## Staging

Pending merge and staging deployment verification.