### PR TITLE
fix: keep Slack React redirects public

### DIFF
--- a/integrations/slack-gateway/.env.example
+++ b/integrations/slack-gateway/.env.example
@@ -21,6 +21,9 @@ SPRITZ_SLACK_BACKEND_FASTAPI_BASE_URL=https://backend-fastapi.example.com
 SPRITZ_SLACK_BACKEND_INTERNAL_TOKEN=fill-me
 
 SPRITZ_SLACK_SPRITZ_BASE_URL=https://spritz.example.com
+# Optional public React UI base URL for browser redirects. Keep SpritzBaseURL
+# private/internal when the gateway should call the Spritz API inside a cluster.
+SPRITZ_SLACK_REACT_BASE_URL=https://spritz.example.com
 SPRITZ_SLACK_SPRITZ_SERVICE_TOKEN=fill-me
 SPRITZ_SLACK_PRINCIPAL_ID=slack-shared-app
 

--- a/integrations/slack-gateway/config.go
+++ b/integrations/slack-gateway/config.go
@@ -24,6 +24,7 @@ type config struct {
 	BackendFastAPIBaseURL      string
 	BackendInternalToken       string
 	SpritzBaseURL              string
+	ReactBaseURL               string
 	SpritzServiceToken         string
 	PrincipalID                string
 	HTTPTimeout                time.Duration
@@ -55,6 +56,7 @@ func loadConfig() (config, error) {
 		BackendFastAPIBaseURL:      strings.TrimRight(strings.TrimSpace(os.Getenv("SPRITZ_SLACK_BACKEND_FASTAPI_BASE_URL")), "/"),
 		BackendInternalToken:       strings.TrimSpace(os.Getenv("SPRITZ_SLACK_BACKEND_INTERNAL_TOKEN")),
 		SpritzBaseURL:              strings.TrimRight(strings.TrimSpace(os.Getenv("SPRITZ_SLACK_SPRITZ_BASE_URL")), "/"),
+		ReactBaseURL:               strings.TrimRight(strings.TrimSpace(os.Getenv("SPRITZ_SLACK_REACT_BASE_URL")), "/"),
 		SpritzServiceToken:         strings.TrimSpace(os.Getenv("SPRITZ_SLACK_SPRITZ_SERVICE_TOKEN")),
 		PrincipalID:                strings.TrimSpace(os.Getenv("SPRITZ_SLACK_PRINCIPAL_ID")),
 		HTTPTimeout:                parseDurationEnv("SPRITZ_SLACK_HTTP_TIMEOUT", 15*time.Second),
@@ -103,6 +105,16 @@ func loadConfig() (config, error) {
 	if cfg.SpritzBaseURL == "" {
 		return config{}, fmt.Errorf("SPRITZ_SLACK_SPRITZ_BASE_URL is required")
 	}
+	if cfg.ReactBaseURL == "" {
+		cfg.ReactBaseURL = defaultReactBaseURL(cfg.PublicURL, cfg.SpritzBaseURL)
+	}
+	reactURL, err := url.Parse(cfg.ReactBaseURL)
+	if err != nil {
+		return config{}, fmt.Errorf("SPRITZ_SLACK_REACT_BASE_URL is invalid: %w", err)
+	}
+	if strings.TrimSpace(reactURL.Scheme) == "" || strings.TrimSpace(reactURL.Host) == "" {
+		return config{}, fmt.Errorf("SPRITZ_SLACK_REACT_BASE_URL must be an absolute URL")
+	}
 	if cfg.SpritzServiceToken == "" {
 		return config{}, fmt.Errorf("SPRITZ_SLACK_SPRITZ_SERVICE_TOKEN is required")
 	}
@@ -110,6 +122,46 @@ func loadConfig() (config, error) {
 		return config{}, fmt.Errorf("SPRITZ_SLACK_PRINCIPAL_ID is required")
 	}
 	return cfg, nil
+}
+
+func defaultReactBaseURL(publicURL string, spritzBaseURL string) string {
+	spritzBaseURL = strings.TrimRight(strings.TrimSpace(spritzBaseURL), "/")
+	if !isPrivateServiceBaseURL(spritzBaseURL) {
+		return spritzBaseURL
+	}
+	if publicReactURL := reactBaseURLFromGatewayPublicURL(publicURL); publicReactURL != "" {
+		return publicReactURL
+	}
+	return spritzBaseURL
+}
+
+func reactBaseURLFromGatewayPublicURL(raw string) string {
+	parsed, err := url.Parse(strings.TrimRight(strings.TrimSpace(raw), "/"))
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return ""
+	}
+	path := strings.TrimRight(parsed.Path, "/")
+	if strings.HasSuffix(path, "/slack-gateway") {
+		path = strings.TrimSuffix(path, "/slack-gateway")
+	} else {
+		path = ""
+	}
+	parsed.RawPath = ""
+	parsed.Path = path
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return strings.TrimRight(parsed.String(), "/")
+}
+
+func isPrivateServiceBaseURL(raw string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(strings.TrimSpace(parsed.Hostname()))
+	return strings.HasSuffix(host, ".svc") ||
+		strings.Contains(host, ".svc.") ||
+		strings.HasSuffix(host, ".cluster.local")
 }
 
 func envOrDefault(key, fallback string) string {

--- a/integrations/slack-gateway/gateway_test.go
+++ b/integrations/slack-gateway/gateway_test.go
@@ -7990,6 +7990,52 @@ func TestLoadConfigDefaultsBackendFastAPIBaseURLToBackendBaseURL(t *testing.T) {
 	}
 }
 
+func TestLoadConfigDefaultsReactBaseURLToPublicOriginWhenSpritzBaseURLIsClusterInternal(t *testing.T) {
+	t.Setenv("SPRITZ_SLACK_GATEWAY_PUBLIC_URL", "https://staging.spritz.textcortex.com/slack-gateway")
+	t.Setenv("SPRITZ_SLACK_CLIENT_ID", "client-id")
+	t.Setenv("SPRITZ_SLACK_CLIENT_SECRET", "client-secret")
+	t.Setenv("SPRITZ_SLACK_SIGNING_SECRET", "signing-secret")
+	t.Setenv("SPRITZ_SLACK_OAUTH_STATE_SECRET", "oauth-state-secret")
+	t.Setenv("SPRITZ_SLACK_BACKEND_BASE_URL", "https://backend.example.test")
+	t.Setenv("SPRITZ_SLACK_BACKEND_INTERNAL_TOKEN", "backend-internal-token")
+	t.Setenv("SPRITZ_SLACK_SPRITZ_BASE_URL", "http://spritz-api.spritz-system-staging.svc.cluster.local:8080")
+	t.Setenv("SPRITZ_SLACK_SPRITZ_SERVICE_TOKEN", "spritz-service-token")
+	t.Setenv("SPRITZ_SLACK_PRINCIPAL_ID", "shared-slack-gateway")
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig failed: %v", err)
+	}
+	if cfg.ReactBaseURL != "https://staging.spritz.textcortex.com" {
+		t.Fatalf("expected public React base URL, got %q", cfg.ReactBaseURL)
+	}
+	if cfg.SpritzBaseURL != "http://spritz-api.spritz-system-staging.svc.cluster.local:8080" {
+		t.Fatalf("expected internal Spritz base URL to stay unchanged, got %q", cfg.SpritzBaseURL)
+	}
+}
+
+func TestLoadConfigUsesExplicitReactBaseURL(t *testing.T) {
+	t.Setenv("SPRITZ_SLACK_GATEWAY_PUBLIC_URL", "https://gateway.example.test/slack-gateway")
+	t.Setenv("SPRITZ_SLACK_CLIENT_ID", "client-id")
+	t.Setenv("SPRITZ_SLACK_CLIENT_SECRET", "client-secret")
+	t.Setenv("SPRITZ_SLACK_SIGNING_SECRET", "signing-secret")
+	t.Setenv("SPRITZ_SLACK_OAUTH_STATE_SECRET", "oauth-state-secret")
+	t.Setenv("SPRITZ_SLACK_BACKEND_BASE_URL", "https://backend.example.test")
+	t.Setenv("SPRITZ_SLACK_BACKEND_INTERNAL_TOKEN", "backend-internal-token")
+	t.Setenv("SPRITZ_SLACK_SPRITZ_BASE_URL", "http://spritz-api.spritz-system-staging.svc.cluster.local:8080")
+	t.Setenv("SPRITZ_SLACK_REACT_BASE_URL", "https://spritz.example.test/app")
+	t.Setenv("SPRITZ_SLACK_SPRITZ_SERVICE_TOKEN", "spritz-service-token")
+	t.Setenv("SPRITZ_SLACK_PRINCIPAL_ID", "shared-slack-gateway")
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig failed: %v", err)
+	}
+	if cfg.ReactBaseURL != "https://spritz.example.test/app" {
+		t.Fatalf("expected explicit React base URL, got %q", cfg.ReactBaseURL)
+	}
+}
+
 func TestSpritzWebSocketURLPreservesBasePath(t *testing.T) {
 	gateway := newSlackGateway(
 		config{SpritzBaseURL: "https://spritz.example.test/prefix"},
@@ -8034,6 +8080,21 @@ func TestReactRouteURLUsesSpritzBaseURL(t *testing.T) {
 	}
 	if parsed.Query().Get("teamId") != "T_workspace_1" {
 		t.Fatalf("expected query to be preserved, got %q", parsed.RawQuery)
+	}
+}
+
+func TestReactRouteURLUsesReactBaseURL(t *testing.T) {
+	gateway := newSlackGateway(
+		config{
+			SpritzBaseURL: "http://spritz-api.spritz-system-staging.svc.cluster.local:8080",
+			ReactBaseURL:  "https://staging.spritz.textcortex.com",
+		},
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+
+	target := gateway.reactRouteURL("/settings/slack/workspaces")
+	if target != "https://staging.spritz.textcortex.com/settings/slack/workspaces" {
+		t.Fatalf("expected public React redirect URL, got %q", target)
 	}
 }
 

--- a/integrations/slack-gateway/react_routes.go
+++ b/integrations/slack-gateway/react_routes.go
@@ -54,7 +54,7 @@ func (g *slackGateway) reactRouteURL(target string) string {
 		return route.String()
 	}
 
-	base, err := url.Parse(strings.TrimRight(strings.TrimSpace(g.cfg.SpritzBaseURL), "/"))
+	base, err := url.Parse(strings.TrimRight(strings.TrimSpace(g.reactBaseURL()), "/"))
 	if err != nil || base.Scheme == "" || base.Host == "" {
 		return route.String()
 	}
@@ -67,12 +67,19 @@ func (g *slackGateway) reactRouteURL(target string) string {
 	return base.String()
 }
 
+func (g *slackGateway) reactBaseURL() string {
+	if baseURL := strings.TrimSpace(g.cfg.ReactBaseURL); baseURL != "" {
+		return baseURL
+	}
+	return g.cfg.SpritzBaseURL
+}
+
 func (g *slackGateway) reactRoutesShareGatewayOrigin() bool {
 	gatewayURL, err := url.Parse(strings.TrimSpace(g.cfg.PublicURL))
 	if err != nil || gatewayURL.Scheme == "" || gatewayURL.Host == "" {
 		return false
 	}
-	reactURL, err := url.Parse(strings.TrimSpace(g.cfg.SpritzBaseURL))
+	reactURL, err := url.Parse(strings.TrimSpace(g.reactBaseURL()))
 	if err != nil || reactURL.Scheme == "" || reactURL.Host == "" {
 		return false
 	}


### PR DESCRIPTION
## Summary

Slack settings redirects could send users to a Kubernetes service URL when the gateway used an internal Spritz API base URL.
This change separates browser redirects from service-to-service API calls.
The gateway can keep using the internal Spritz API URL, while React settings redirects use a public UI base URL.

## What Changed

The Slack gateway now has a public React base URL for browser redirects.
It still uses the existing Spritz base URL for internal API and websocket calls.

- Added optional `SPRITZ_SLACK_REACT_BASE_URL`.
- Updated React route redirects and same-origin checks to use the React base URL.
- Added a fallback that derives the public UI origin from the gateway public URL when the Spritz base URL is a Kubernetes service host.
- Documented the new env var in `.env.example`.

## Testing

The gateway tests cover the new config default and explicit React base behavior.

- `go test ./...` from `integrations/slack-gateway`
- `git diff --check`

## Risks

Risk is low.
The API base URL still points at the same internal service, and only browser-facing React redirects move to the public base URL.
Cross-origin deployments can still set `SPRITZ_SLACK_REACT_BASE_URL` explicitly.